### PR TITLE
Added Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:latest
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+RUN apt-get -y upgrade
+RUN apt-get -y install \
+	libgl1 \
+	libportaudio2 \
+	libxcb-icccm4 \
+	libxcb-image0 \
+	libxcb-keysyms1 \
+	libxcb-render-util0 \
+	libxcb-shape0 \
+	libxcb-xinerama0 \
+	libxcb-xkb-dev \
+	libxkbcommon-x11-0 \
+	libdbus-1-3 \
+	xdg-utils
+
+RUN useradd -ms /bin/bash docker
+USER docker
+
+RUN pip install not1mm
+RUN mkdir -p ~/.config/not1mm ~/.local/share/not1mm /tmp/xdg
+
+ENV QT_DEBUG_PLUGINS=0
+ENV QT_X11_NO_MITSHM=1
+ENV _X11_NO_MITSHM=1
+ENV _MITSHM=0
+ENV XDG_RUNTIME_DIR=/tmp/xdg
+
+ENTRYPOINT ["/home/docker/.local/bin/not1mm"]
+CMD ["--help"]

--- a/Dockerfile.md
+++ b/Dockerfile.md
@@ -1,0 +1,19 @@
+# Docker Installation
+
+To use this with `docker`, you'll need to build the container using the supplied `Dockerfile`. The extra installed libraries are based on launching Not1MM and fixing any missing requirements.
+
+It's entirely possible that there are more requirements that will become visible once you actually start using the software. Patches welcome.
+
+
+# Launch and Configure
+
+Not1MM has two internal variables to track where your data is stored. You can set these variables using Docker environment variables:
+
+`docker run -e XDG_DATA_HOME="$(pwd)/data/" -e XDG_CONFIG_HOME="$(pwd)/config/" imagename:latest`
+
+This should create two directories in your current directory that store the data used inside Not1MM.
+
+
+# Warning
+
+Note that there is a bug in `xdg-desktop-menu` (not part of Not1MM) which causes issues if your path has a space in it. There's a closed bug report associated with this, but the issue doesn't appear to have been actually fixed. I'm working on how to report this again and hopefully get that fixed. In the mean time, don't use a path with a space in it.


### PR DESCRIPTION
The Dockerfile uses the Python image and adds the required libraries to successfully launch Not1MM.