### PR TITLE
Allow connecting to rbn.telegraphy.de

### DIFF
--- a/not1mm/bandmap.py
+++ b/not1mm/bandmap.py
@@ -737,7 +737,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.send_command("set dx extension Name CTY State Section")
             self.send_command("set dx mode " + PREF.get("cluster_mode", "OPEN"))
             return
-        if "call:" in data:
+        if "call:" in data or "callsign:" in data:
             self.send_command(self.callsignField.text())
             self.send_command(PREF.get("cluster_filter", ""))
             self.send_command("set dx extension Name CTY State Section")


### PR DESCRIPTION
The prompt for the callsign when connecting to rbn.telegraphy.de 7000 does not match "call".  It prompts for "callsign:" instead.

This change allows that option alongside the previous matches.