### PR TITLE
Allow entering some of the mode and frequency commands

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -910,6 +910,7 @@ class MainWindow(QtWidgets.QMainWindow):
             "[SPACE]\tWhen in the callsign field, will move the input to the\n"
             "\tfirst field needed for the exchange.\n"
             "[Enter]\tSubmits the fields to the log.\n"
+            "\tUnless the callsign field contains a command.\n"
             "[F1-F12]\tSend (CW or Voice) macros.\n"
             "[CTRL-G]\tTune to a spot matching partial text in the callsign\n"
             "\tentry field (CAT Required).\n"


### PR DESCRIPTION
N1MM has the option to enter the frequency or the mode in the callsign field and press return. That will make the rig jump to that mode or frequency. A similar, but most likely simpler - I did not experiement on the nitty gritty details of N1MM, is added by this change.


PS. I just found not1mm today and I must say that this is a very interesting project for me. I think am on just the right level of contesting, python, open source and Linux to appreciate this. Just by looking at the code, I am learning a lot about how to build and application with Qt that I previously knew nothing about. When participating in contests at the club, we use N1MM but should I get antennas up at home, for some QRP contesting, I will probably now use Not1mm, I have failed to install N1MM in wine.