### PR TITLE
Fix crash opening windows on systems with zombie processes

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -101,9 +101,14 @@ def check_process(name: str) -> bool:
     Bool
     """
     for proc in psutil.process_iter():
-        if len(proc.cmdline()) == 2:
-            if name in proc.cmdline()[1]:
-                return True
+        try:
+            if len(proc.cmdline()) == 2:
+                if name in proc.cmdline()[1]:
+                    return True
+        except psutil.NoSuchProcess:
+            continue
+        except psutil.ZombieProcess:
+            continue
     return False
 
 


### PR DESCRIPTION
When opening new windows (band map, log, etc), we currently iterate over all running processes on the system to ensure that window is not currently open. However, if there are any zombie processes (unrelated to us), `proc.cmdline()` will throw an exception.

This commit simply catches and continues when that exception is thrown. It will also catch NoSuchProcess in the event that a process closed between grabbing the list and that process in the iteration.