### PR TITLE
fix crash on MacOS related to psutil accessdenied

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -105,7 +105,7 @@ def check_process(name: str) -> bool:
             if len(proc.cmdline()) == 2:
                 if name in proc.cmdline()[1] and "python" in proc.cmdline()[0]:
                     return True
-        except (psutil.NoSuchProcess, psutil.ZombieProcess):
+        except (psutil.NoSuchProcess, psutil.ZombieProcess, psutil.AccessDenied):
             continue
     return False
 


### PR DESCRIPTION
Trying to load the log window or anything that calls 'check_process' causes not1mm to crash. This looks like a MacOS + psutil issue. See: https://github.com/giampaolo/psutil/issues/883

This adds 'psutil.AccessDenied' to the list of exceptions check_process will ignore.