### PR TITLE
fix bug in get_logged_band.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ I wish to thank those who've contributed to the project.
 
 ## Recent Changes
 
+- [24-1-21] Fixed crash in get_logged_band when out of band.
 - [24-1-16.1] Fix possible crash when cabrillo generated without a station call.
 - [24-1-16] Added Stew Perry Topband.
 - [24-1-15] Added the Phone Weekly Test.

--- a/not1mm/lib/ham_utility.py
+++ b/not1mm/lib/ham_utility.py
@@ -153,7 +153,7 @@ def get_logged_band(freq: str) -> str:
             return "902"
         if 1300000000 > frequency > 1240000000:
             return "1296"
-        if 10500000000 > freq > 2300000000:
+        if 10500000000 > frequency > 2300000000:
             return "2300+"
     return "0"
 

--- a/not1mm/lib/version.py
+++ b/not1mm/lib/version.py
@@ -1,2 +1,2 @@
 """It's the version"""
-__version__ = "24.1.16.1"
+__version__ = "24.1.21"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "not1mm" 
-version = "24.1.16.1"
+version = "24.1.21"
 description = "NOT1MM Logger"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Crash when OOB.

```
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.9/site-packages/not1mm/__main__.py", line 2208, in poll_radio
    self.contact["Band"] = get_logged_band(str(vfo))
  File "/home/user/.local/lib/python3.9/site-packages/not1mm/lib/ham_utility.py", line 156, in get_logged_band
    if 10500000000 > freq > 2300000000:
TypeError: '>' not supported between instances of 'int' and 'str'
Aborted
```
