### PR TITLE
Reduce duplication of multicast functions by using multicast lib

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -2252,25 +2252,9 @@ class MainWindow(QtWidgets.QMainWindow):
         None
         """
 
-        while self.multicast_interface.server_udp.hasPendingDatagrams():
-            bundle = self.multicast_interface.server_udp.readDatagram(
-                self.multicast_interface.server_udp.pendingDatagramSize()
-            )
-            datagram, _, _ = bundle
-            # logger.debug(datagram.decode())
-            if datagram:
-                try:
-                    # debug_info = f"{datagram.decode()}"
-                    # logger.debug(debug_info)
-                    json_data = loads(datagram.decode())
-                except UnicodeDecodeError as err:
-                    the_error = f"Not Unicode: {err}\n{datagram}"
-                    logger.warning(the_error)
-                    continue
-                except JSONDecodeError as err:
-                    the_error = f"Not JSON: {err}\n{datagram}"
-                    logger.warning(the_error)
-                    continue
+        while self.multicast_interface.has_pending_datagrams():
+            json_data = self.multicast_interface.read_datagram_as_json()
+            if json_data:
                 if (
                     json_data.get("cmd", "") == "GETCOLUMNS"
                     and json_data.get("station", "") == platform.node()

--- a/not1mm/checkwindow.py
+++ b/not1mm/checkwindow.py
@@ -74,14 +74,10 @@ class MainWindow(QMainWindow):
         self.mscp = SCP(WORKING_PATH)
         self._udpwatch = None
         self.udp_fifo = queue.Queue()
-        self.udpsocket = QtNetwork.QUdpSocket(self)
-        self.udpsocket.bind(
-            QtNetwork.QHostAddress.AnyIPv4,
-            MULTICAST_PORT,
-            QtNetwork.QUdpSocket.ShareAddress,
+        self.udpsocket = Multicast(
+            self.multicast_group, self.multicast_port, self.interface_ip
         )
-        self.udpsocket.joinMulticastGroup(QtNetwork.QHostAddress(MULTICAST_GROUP))
-        self.udpsocket.readyRead.connect(self.watch_udp)
+        self.udpsocket.ready_read_connect(self.watch_udp)
 
     def quit_app(self):
         """
@@ -122,6 +118,10 @@ class MainWindow(QMainWindow):
         except IOError as exception:
             logger.critical("Error: %s", exception)
 
+        self.multicast_port = int(self.pref.get("multicast_port", MULTICAST_PORT))
+        self.multicast_group = self.pref.get("multicast_group", MULTICAST_GROUP)
+        self.interface_ip = self.pref.get("interface_ip", "0.0.0.0")
+
     def watch_udp(self):
         """
         Puts UDP datagrams in a FIFO queue.
@@ -134,23 +134,9 @@ class MainWindow(QMainWindow):
         -------
         None
         """
-        while self.udpsocket.hasPendingDatagrams():
-            datagram, _, _ = self.udpsocket.readDatagram(
-                self.udpsocket.pendingDatagramSize()
-            )
+        while self.udpsocket.has_pending_datagrams():
+            json_data = self.udpsocket.read_datagram_as_json()
 
-            try:
-                debug_info = f"{datagram.decode()}"
-                logger.debug(debug_info)
-                json_data = loads(datagram.decode())
-            except UnicodeDecodeError as err:
-                the_error = f"Not Unicode: {err}\n{datagram}"
-                logger.debug(the_error)
-                continue
-            except JSONDecodeError as err:
-                the_error = f"Not JSON: {err}\n{datagram}"
-                logger.debug(the_error)
-                continue
             if json_data.get("station", "") != platform.node():
                 continue
             if json_data.get("cmd", "") == "UPDATELOG":

--- a/not1mm/lib/multicast.py
+++ b/not1mm/lib/multicast.py
@@ -32,11 +32,38 @@ class Multicast:
         )
         self.server_udp.joinMulticastGroup(QtNetwork.QHostAddress(self.multicast_group))
 
-    def ready_read_connect(self, watcher):
+    def has_pending_datagrams(self) -> bool:
+        return self.server_udp.hasPendingDatagrams()
+
+    def read_datagram(self) -> bytes:
+        datagram, _, _ = self.server_udp.readDatagram(
+                self.server_udp.pendingDatagramSize()
+        )
+        logger.debug("datagram {0}".format(datagram))
+        return datagram
+
+    def read_datagram_as_json(self) -> dict:
+        datagram = self.read_datagram()
+
+        json_dict = {}
+
+        if datagram:
+            try:
+                json_dict = loads(datagram.decode())
+            except UnicodeDecodeError as err:
+                the_error = f"Not Unicode: {err}\n{datagram}"
+                logger.debug(the_error)
+            except JSONDecodeError as err:
+                the_error = f"Not JSON: {err}\n{datagram}"
+                logger.debug(the_error)
+
+        return json_dict
+
+    def ready_read_connect(self, watcher) -> None:
         """pass in function to watch traffic"""
         self.server_udp.readyRead.connect(watcher)
 
-    def send_as_json(self, dict_object: dict):
+    def send_as_json(self, dict_object: dict) -> None:
         """Send dict as json encoded packet"""
         packet = bytes(dumps(dict_object), encoding="ascii")
         logger.debug("%s", f"{dict_object}")
@@ -44,7 +71,7 @@ class Multicast:
             packet, QtNetwork.QHostAddress(self.multicast_group), self.multicast_port
         )
 
-    def send_as_xml(self, dict_object: dict, package_name: str):
+    def send_as_xml(self, dict_object: dict, package_name: str) -> None:
         """Send dict as XML encoded packet"""
         packet = dicttoxml(dict_object, custom_root=package_name, attr_type=False)
         self.server_udp.writeDatagram(


### PR DESCRIPTION
This PR switches all the windows/other tools to use the multicast library. In addition it reads multicast settings from the common app config file.