### PR TITLE
Use thefuzz fuzzy matcher for SCP results

### DIFF
--- a/not1mm/lib/super_check_partial.py
+++ b/not1mm/lib/super_check_partial.py
@@ -4,6 +4,9 @@ import logging
 
 import requests
 
+from thefuzz import fuzz
+from thefuzz import process
+
 MASTER_SCP_URL = "https://www.supercheckpartial.com/MASTER.SCP"
 
 if __name__ == "__main__":
@@ -51,6 +54,6 @@ class SCP:
         """
         Performs a supercheck partial on the callsign entered in the field.
         """
-        if len(acall) > 2:
-            return list(filter(lambda x: x.startswith(acall), self.scp))
+        if len(acall) > 1:
+            return list([ x[0] for x in process.extract(acall, self.scp, scorer=fuzz.partial_ratio, limit=25)])
         return []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "soundfile",
     "numpy",
     "notctyparser >= 23.6.21",
+    "thefuzz",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
this is nicer than prefix match:

* It works if you enter a suffix.
* It works if you enter a call that's missing something in the middle (just skip the part that you don't know).
* Even with a full call it will show you likely off-by-ones.