### PR TITLE
Improved fuzzy matching

### DIFF
--- a/not1mm/lib/super_check_partial.py
+++ b/not1mm/lib/super_check_partial.py
@@ -4,8 +4,8 @@ import logging
 
 import requests
 
-from thefuzz import fuzz
-from thefuzz import process
+from rapidfuzz import fuzz
+from rapidfuzz import process
 
 MASTER_SCP_URL = "https://www.supercheckpartial.com/MASTER.SCP"
 
@@ -14,6 +14,11 @@ if __name__ == "__main__":
 
 logger = logging.getLogger("__main__")
 
+def prefer_prefix_score(query: str, candidate: str, **kwargs) -> int:
+    score = 0.5 * fuzz.ratio(query, candidate) + 0.5 * fuzz.partial_ratio(query, candidate)
+    if not candidate.startswith(query):
+        score = 0.8 * score
+    return int(round(score))
 
 class SCP:
     """Super check partial"""
@@ -59,7 +64,7 @@ class SCP:
                 [
                     x[0]
                     for x in process.extract(
-                        acall, self.scp, scorer=fuzz.partial_ratio, limit=25
+                        acall, self.scp, scorer=prefer_prefix_score, limit=25
                     )
                 ]
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "soundfile",
     "numpy",
     "notctyparser >= 23.6.21",
-    "thefuzz",
+    "rapidfuzz",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
* Switch from thefuzz to rapidfuzz. Thefuzz is mostly just a compatibility wrapper around rapidfuzz (to make it like FuzzyWuzzy), and rapidfuzz is, well, faster.

* Use a blend of 'ratio' and 'partial_ratio'. partial_ratio is good when you only have a piece of the callsign, but it's a little *too* indiscriminate. Mixing 50/50 with 'ratio' gives the closer matches a boost.

* Give an added boost to callsigns that have what you typed as a prefix.

This is what I used during ARRLDX, seems like a pretty good improvement over what I submitted before :)