### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ pip install -U not1mm
 ```bash
 sudo apt update
 sudo apt upgrade
-sudo apt install -y libportaudio2 pipx
+sudo apt install -y libportaudio2 pipx libxcb-cursor0
 pipx install not1mm
 pipx ensurepath
 ```


### PR DESCRIPTION
missing prereq?

```qt.qpa.plugin: From 6.5.0, xcb-cursor0 or libxcb-cursor0 is needed to load the Qt xcb platform plugin.
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: wayland-egl, minimal, offscreen, linuxfb, wayland, xcb, eglfs, vnc, minimalegl, vkkhrdisplay.
```