### PR TITLE
101 nonsense from rigctrld causes a glitch in the matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ I wish to thank those who've contributed to the project.
 
 ## Recent Changes
 
+- [24-5-10] Add sanity check for VFO freq.
 - [24-5-9] Add ICWC MST.
 - [24-5-1] Moved the voice keying into it's own thread.
 

--- a/not1mm/lib/version.py
+++ b/not1mm/lib/version.py
@@ -1,3 +1,3 @@
 """It's the version"""
 
-__version__ = "24.5.9"
+__version__ = "24.5.10"

--- a/not1mm/radio.py
+++ b/not1mm/radio.py
@@ -55,6 +55,9 @@ class Radio(QObject):
                 vfoa = self.cat.get_vfo()
                 self.online = False
                 if vfoa:
+                    if not vfoa.isnumeric():
+                        logger.debug(f"Bad VFOA data {vfoa=}")
+                        continue
                     self.vfoa = vfoa
                     self.online = True
                 mode = self.cat.get_mode()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "not1mm" 
-version = "24.5.9"
+version = "24.5.10"
 description = "NOT1MM Logger"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Correct issue with getting bad CAT info from rigctld.
Tests vfoa value to make sure it's just numbers before emitting a poll signal.
  