### PR TITLE
MST Removed leading zeros on serial numbers

### DIFF
--- a/not1mm/plugins/icwc_mst.py
+++ b/not1mm/plugins/icwc_mst.py
@@ -138,9 +138,9 @@ def predupe(self):  # pylint: disable=unused-argument
 def prefill(self):
     """Fill SentNR"""
     result = self.database.get_serial()
-    serial_nr = str(result.get("serial_nr", "1")).zfill(3)
+    serial_nr = str(result.get("serial_nr", "1"))
     if serial_nr == "None":
-        serial_nr = "001"
+        serial_nr = "1"
     field = self.sent
     if len(field.text()) == 0:
         field.setText(serial_nr)


### PR DESCRIPTION
I used not1mm for MST today and saw that it makes all serial numbers start with zeros. Made this simple change to speed up the exchange.

73