### PR TITLE
ESM (Enter send message)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Not1MM
 <!-- markdownlint-disable MD001 MD033 -->
 
+### Branch ESM
+
  ![logo](https://github.com/mbridak/not1mm/raw/master/not1mm/data/k6gte.not1mm.svg)
 
  The worlds #1 unfinished contest logger <sup>*According to my daughter Corinna.<sup>

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -245,7 +245,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.radioButton_sp.clicked.connect(self.run_sp_buttons_clicked)
         self.score.setText("0")
         self.callsign.textEdited.connect(self.callsign_changed)
-        self.callsign.returnPressed.connect(self.save_contact)
+        # Disconnecting the save_contact by pressing return /SM0HPL
+        self.callsign.returnPressed.disconnect(self.save_contact)
+        # Add "send F2 + F3" method (~line 643 ) instead, and move to receive field /SM0HPL
+        self.callsign.returnPressed.connect(self.callsign_enter_pressed)
         self.sent.returnPressed.connect(self.save_contact)
         self.receive.returnPressed.connect(self.save_contact)
         self.other_1.returnPressed.connect(self.save_contact)
@@ -303,152 +306,58 @@ class MainWindow(QtWidgets.QMainWindow):
         self.F12.customContextMenuRequested.connect(lambda x: self.edit_macro(self.F12))
         self.F12.clicked.connect(lambda x: self.process_function_key(self.F12))
 
-        self.cw_band_160.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            160, "CW"
-        )
-        self.cw_band_80.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            80, "CW"
-        )
-        self.cw_band_60.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            60, "CW"
-        )
-        self.cw_band_40.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            40, "CW"
-        )
-        self.cw_band_30.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            30, "CW"
-        )
-        self.cw_band_20.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            20, "CW"
-        )
-        self.cw_band_17.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            17, "CW"
-        )
-        self.cw_band_15.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            15, "CW"
-        )
-        self.cw_band_12.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            12, "CW"
-        )
-        self.cw_band_10.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            10, "CW"
-        )
+        self.cw_band_160.mousePressEvent = lambda x: self.change_to_band_and_mode(160, "CW")
+        self.cw_band_80.mousePressEvent = lambda x: self.change_to_band_and_mode(80, "CW")
+        self.cw_band_60.mousePressEvent = lambda x: self.change_to_band_and_mode(60, "CW")
+        self.cw_band_40.mousePressEvent = lambda x: self.change_to_band_and_mode(40, "CW")
+        self.cw_band_30.mousePressEvent = lambda x: self.change_to_band_and_mode(30, "CW")
+        self.cw_band_20.mousePressEvent = lambda x: self.change_to_band_and_mode(20, "CW")
+        self.cw_band_17.mousePressEvent = lambda x: self.change_to_band_and_mode(17, "CW")
+        self.cw_band_15.mousePressEvent = lambda x: self.change_to_band_and_mode(15, "CW")
+        self.cw_band_12.mousePressEvent = lambda x: self.change_to_band_and_mode(12, "CW")
+        self.cw_band_10.mousePressEvent = lambda x: self.change_to_band_and_mode(10, "CW")
         self.cw_band_6.mousePressEvent = lambda x: self.change_to_band_and_mode(6, "CW")
         self.cw_band_4.mousePressEvent = lambda x: self.change_to_band_and_mode(4, "CW")
         self.cw_band_2.mousePressEvent = lambda x: self.change_to_band_and_mode(2, "CW")
-        self.cw_band_125.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            222, "CW"
-        )
-        self.cw_band_70cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            432, "CW"
-        )
-        self.cw_band_33cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            902, "CW"
-        )
-        self.cw_band_23cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            1240, "CW"
-        )
+        self.cw_band_125.mousePressEvent = lambda x: self.change_to_band_and_mode(222, "CW")
+        self.cw_band_70cm.mousePressEvent = lambda x: self.change_to_band_and_mode(432, "CW")
+        self.cw_band_33cm.mousePressEvent = lambda x: self.change_to_band_and_mode(902, "CW")
+        self.cw_band_23cm.mousePressEvent = lambda x: self.change_to_band_and_mode(1240, "CW")
 
-        self.ssb_band_160.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            160, "SSB"
-        )
-        self.ssb_band_80.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            80, "SSB"
-        )
-        self.ssb_band_60.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            60, "SSB"
-        )
-        self.ssb_band_40.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            40, "SSB"
-        )
-        self.ssb_band_20.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            20, "SSB"
-        )
-        self.ssb_band_17.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            17, "SSB"
-        )
-        self.ssb_band_15.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            15, "SSB"
-        )
-        self.ssb_band_12.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            12, "SSB"
-        )
-        self.ssb_band_10.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            10, "SSB"
-        )
-        self.ssb_band_6.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            6, "SSB"
-        )
-        self.ssb_band_4.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            4, "SSB"
-        )
-        self.ssb_band_2.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            2, "SSB"
-        )
-        self.ssb_band_125.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            222, "SSB"
-        )
-        self.ssb_band_70cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            432, "SSB"
-        )
-        self.ssb_band_33cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            902, "SSB"
-        )
-        self.ssb_band_23cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            1240, "SSB"
-        )
+        self.ssb_band_160.mousePressEvent = lambda x: self.change_to_band_and_mode(160, "SSB")
+        self.ssb_band_80.mousePressEvent = lambda x: self.change_to_band_and_mode(80, "SSB")
+        self.ssb_band_60.mousePressEvent = lambda x: self.change_to_band_and_mode(60, "SSB")
+        self.ssb_band_40.mousePressEvent = lambda x: self.change_to_band_and_mode(40, "SSB")
+        self.ssb_band_20.mousePressEvent = lambda x: self.change_to_band_and_mode(20, "SSB")
+        self.ssb_band_17.mousePressEvent = lambda x: self.change_to_band_and_mode(17, "SSB")
+        self.ssb_band_15.mousePressEvent = lambda x: self.change_to_band_and_mode(15, "SSB")
+        self.ssb_band_12.mousePressEvent = lambda x: self.change_to_band_and_mode(12, "SSB")
+        self.ssb_band_10.mousePressEvent = lambda x: self.change_to_band_and_mode(10, "SSB")
+        self.ssb_band_6.mousePressEvent = lambda x: self.change_to_band_and_mode(6, "SSB")
+        self.ssb_band_4.mousePressEvent = lambda x: self.change_to_band_and_mode(4, "SSB")
+        self.ssb_band_2.mousePressEvent = lambda x: self.change_to_band_and_mode(2, "SSB")
+        self.ssb_band_125.mousePressEvent = lambda x: self.change_to_band_and_mode(222, "SSB")
+        self.ssb_band_70cm.mousePressEvent = lambda x: self.change_to_band_and_mode(432, "SSB")
+        self.ssb_band_33cm.mousePressEvent = lambda x: self.change_to_band_and_mode(902, "SSB")
+        self.ssb_band_23cm.mousePressEvent = lambda x: self.change_to_band_and_mode(1240, "SSB")
 
-        self.rtty_band_160.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            160, "RTTY"
-        )
-        self.rtty_band_80.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            80, "RTTY"
-        )
-        self.rtty_band_60.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            60, "RTTY"
-        )
-        self.rtty_band_40.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            40, "RTTY"
-        )
-        self.rtty_band_30.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            30, "RTTY"
-        )
-        self.rtty_band_20.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            20, "RTTY"
-        )
-        self.rtty_band_17.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            17, "RTTY"
-        )
-        self.rtty_band_15.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            15, "RTTY"
-        )
-        self.rtty_band_12.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            12, "RTTY"
-        )
-        self.rtty_band_10.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            10, "RTTY"
-        )
-        self.rtty_band_6.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            6, "RTTY"
-        )
-        self.rtty_band_4.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            4, "RTTY"
-        )
-        self.rtty_band_2.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            2, "RTTY"
-        )
-        self.rtty_band_125.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            222, "RTTY"
-        )
-        self.rtty_band_70cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            432, "RTTY"
-        )
-        self.rtty_band_33cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            902, "RTTY"
-        )
-        self.rtty_band_23cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            1240, "RTTY"
-        )
+        self.rtty_band_160.mousePressEvent = lambda x: self.change_to_band_and_mode(160, "RTTY")
+        self.rtty_band_80.mousePressEvent = lambda x: self.change_to_band_and_mode(80, "RTTY")
+        self.rtty_band_60.mousePressEvent = lambda x: self.change_to_band_and_mode(60, "RTTY")
+        self.rtty_band_40.mousePressEvent = lambda x: self.change_to_band_and_mode(40, "RTTY")
+        self.rtty_band_30.mousePressEvent = lambda x: self.change_to_band_and_mode(30, "RTTY")
+        self.rtty_band_20.mousePressEvent = lambda x: self.change_to_band_and_mode(20, "RTTY")
+        self.rtty_band_17.mousePressEvent = lambda x: self.change_to_band_and_mode(17, "RTTY")
+        self.rtty_band_15.mousePressEvent = lambda x: self.change_to_band_and_mode(15, "RTTY")
+        self.rtty_band_12.mousePressEvent = lambda x: self.change_to_band_and_mode(12, "RTTY")
+        self.rtty_band_10.mousePressEvent = lambda x: self.change_to_band_and_mode(10, "RTTY")
+        self.rtty_band_6.mousePressEvent = lambda x: self.change_to_band_and_mode(6, "RTTY")
+        self.rtty_band_4.mousePressEvent = lambda x: self.change_to_band_and_mode(4, "RTTY")
+        self.rtty_band_2.mousePressEvent = lambda x: self.change_to_band_and_mode(2, "RTTY")
+        self.rtty_band_125.mousePressEvent = lambda x: self.change_to_band_and_mode(222, "RTTY")
+        self.rtty_band_70cm.mousePressEvent = lambda x: self.change_to_band_and_mode(432, "RTTY")
+        self.rtty_band_33cm.mousePressEvent = lambda x: self.change_to_band_and_mode(902, "RTTY")
+        self.rtty_band_23cm.mousePressEvent = lambda x: self.change_to_band_and_mode(1240, "RTTY")
 
         self.band_indicators_cw = {
             "160": self.cw_band_160,
@@ -635,6 +544,19 @@ class MainWindow(QtWidgets.QMainWindow):
                     "You can udate to the current version by using:\npip install -U not1mm"
                 )
 
+
+
+    def callsign_enter_pressed(self):
+        self.process_function_key(self.F2)
+        self.process_function_key(self.F3)
+        self.receive.setFocus()    
+    
+        """
+        Pressing enter in the callsign field replaced from 
+        being save_contact to F2 + F3 /SM0HPL
+
+        """
+    
     def fldigi_qso(self, result: str):
         """
         gets called when there is a new fldigi qso logged.

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -2322,8 +2322,8 @@ class MainWindow(QtWidgets.QMainWindow):
             app.processEvents()
             self.rig_control.ptt_off()
 
-###### This modification allows the method to handle both QPushButton objects (when clicked directly) 
-###### and string inputs (when triggered programmatically, like in callsign_enter_pressed). /SM0HPL
+        # This modification allows the method to handle both QPushButton objects (when clicked directly) 
+        # and string inputs (when triggered programmatically, like in callsign_enter_pressed). /SM0HPL
 
     def process_function_key(self, function_key) -> None:
         """
@@ -2332,21 +2332,21 @@ class MainWindow(QtWidgets.QMainWindow):
         Parameters
         ----------
         function_key : QPushButton or str
-            Function key to process.
+        Function key to process.
 
         Returns
         -------
         None
         """
-    if isinstance(function_key, str):
-        # If it's a string, find the corresponding function key
-        function_key_name = function_key.upper()
-        function_key = getattr(self, function_key_name, None)
-        if function_key is None:
-            logger.warning(f"Function key {function_key_name} not found")
-            return
+        if isinstance(function_key, str):
+            # If it's a string, find the corresponding function key
+            function_key_name = function_key.upper()
+            function_key = getattr(self, function_key_name, None)
+            if function_key is None:
+                logger.warning(f"Function key {function_key_name} not found")
+                return
 
-    logger.debug("Function Key: %s", function_key.text())
+        logger.debug("Function Key: %s", function_key.text())
         if self.n1mm:
             self.n1mm.radio_info["FunctionKeyCaption"] = function_key.text()
         if self.radio_state.get("mode") in ["LSB", "USB", "SSB"]:

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -246,20 +246,18 @@ class MainWindow(QtWidgets.QMainWindow):
         self.score.setText("0")
         self.callsign.textEdited.connect(self.callsign_changed)
           
-        # Try disconnecting the save_contact by pressing return /SM0HPL
-        try:
-            self.callsign.returnPressed.disconnect(self.save_contact)
-        except TypeError:
-            pass
-        # Add "send F2 + F3" method (~line 550 ) instead, and move focus to other_2 field
-        # where saving the contact can happen /SM0HPL
+###### Remove old returnPressed function /SM0HPL
+#        self.callsign.returnPressed.connect(self.save_contact)
+        # Add send F2 method (~line 550 ) instead, and move focus to other_2 field where saving the contact can happen /SM0HPL
         self.callsign.returnPressed.connect(self.callsign_enter_pressed)
+        # Add send F4 method and also save contact, return focus to callsign field
+        self.other_2.returnPressed.connect(self.on_other_2_return_pressed)
         #### /SM0HPL
         self.sent.returnPressed.connect(self.save_contact)
         self.receive.returnPressed.connect(self.save_contact)
         self.other_1.returnPressed.connect(self.save_contact)
         self.other_1.textEdited.connect(self.other_1_changed)
-        self.other_2.returnPressed.connect(self.save_contact)
+#        self.other_2.returnPressed.connect(self.save_contact)
         self.other_2.textEdited.connect(self.other_2_changed)
 
         self.sent.setText("59")
@@ -550,15 +548,40 @@ class MainWindow(QtWidgets.QMainWindow):
                     "You can udate to the current version by using:\npip install -U not1mm"
                 )
 
-        # New method to send F2 and F3 instead of saving to log  /SM0HPL
+###### New method to send F3 instead of saving to log  /SM0HPL
+
+#    def callsign_enter_pressed(self):
+#        self.process_function_key(self.F2)
+#        self.process_function_key(self.F3)
+#        self.other_2.setFocus()
 
     def callsign_enter_pressed(self):
-        self.process_function_key(self.F2)
-        self.process_function_key(self.F3)
-        self.other_2.setFocus()
+        # Stripping whitespace
+        callsign = self.callsign.text().strip()
+        if not callsign:
+            # Callsign is empty, execute F1
+            self.process_function_key('F1')
+            # Keep focus in callsign field until it's filled
+            self.callsign.setFocus()
+        else:
+            # Callsign is not empty, execute F3
+            self.process_function_key('F3')
+            # Move focus to other_2 field
+            self.other_2.setFocus()
 
-        #### /SM0HPL
+###### /SM0HPL
     
+###### New method for sending F4 after logging  /SM0HPL    
+    def on_other_2_return_pressed(self):
+        # Log the contact
+            self.save_contact()
+    
+        # Execute F4 macros and put focus in the callsign field
+            self.process_function_key('F4')
+            self.callsign.setFocus()
+
+###### /SM0HPL
+
     def fldigi_qso(self, result: str):
         """
         gets called when there is a new fldigi qso logged.

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -570,12 +570,12 @@ class MainWindow(QtWidgets.QMainWindow):
             self.other_2.setFocus()
 
 ###### /SM0HPL
-    
+
 ###### New method for sending F4 after logging  /SM0HPL    
     def on_other_2_return_pressed(self):
         # Log the contact
             self.save_contact()
-    
+
         # Execute F4 macros and put focus in the callsign field
             self.process_function_key('F4')
             self.callsign.setFocus()
@@ -2322,21 +2322,31 @@ class MainWindow(QtWidgets.QMainWindow):
             app.processEvents()
             self.rig_control.ptt_off()
 
+###### This modification allows the method to handle both QPushButton objects (when clicked directly) 
+###### and string inputs (when triggered programmatically, like in callsign_enter_pressed). /SM0HPL
+
     def process_function_key(self, function_key) -> None:
         """
-        Called when a function key is clicked.
+        Called when a function key is clicked or triggered programmatically.
 
-        Parameters
-        ----------
-        function_key : QPushButton
+    Parameters
+    ----------
+    function_key : QPushButton or str
         Function key to process.
 
-        Returns
-        -------
-        None
-        """
+    Returns
+    -------
+    None
+    """
+    if isinstance(function_key, str):
+        # If it's a string, find the corresponding function key
+        function_key_name = function_key.upper()
+        function_key = getattr(self, function_key_name, None)
+        if function_key is None:
+            logger.warning(f"Function key {function_key_name} not found")
+            return
 
-        logger.debug("Function Key: %s", function_key.text())
+    logger.debug("Function Key: %s", function_key.text())
         if self.n1mm:
             self.n1mm.radio_info["FunctionKeyCaption"] = function_key.text()
         if self.radio_state.get("mode") in ["LSB", "USB", "SSB"]:

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -582,6 +582,20 @@ class MainWindow(QtWidgets.QMainWindow):
 
 ###### /SM0HPL
 
+    def show_splash_msg(self, msg: str) -> None:
+        """Show text message in the splash window."""
+        self.splash.showMessage(
+            msg,
+            alignment=Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignCenter,
+            color=QColor(255, 255, 0),
+        )
+        QCoreApplication.processEvents()
+
+    def cluster_expire_updated(self, number):
+        """signal from bandmap"""
+        self.pref["cluster_expire"] = int(number)
+        self.write_preference()
+
     def fldigi_qso(self, result: str):
         """
         gets called when there is a new fldigi qso logged.

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -245,10 +245,16 @@ class MainWindow(QtWidgets.QMainWindow):
         self.radioButton_sp.clicked.connect(self.run_sp_buttons_clicked)
         self.score.setText("0")
         self.callsign.textEdited.connect(self.callsign_changed)
-        # Disconnecting the save_contact by pressing return /SM0HPL
-        self.callsign.returnPressed.disconnect(self.save_contact)
-        # Add "send F2 + F3" method (~line 643 ) instead, and move to receive field /SM0HPL
+          
+        # Try disconnecting the save_contact by pressing return /SM0HPL
+        try:
+            self.callsign.returnPressed.disconnect(self.save_contact)
+        except TypeError:
+            pass
+        # Add "send F2 + F3" method (~line 550 ) instead, and move focus to other_2 field
+        # where saving the contact can happen /SM0HPL
         self.callsign.returnPressed.connect(self.callsign_enter_pressed)
+        #### /SM0HPL
         self.sent.returnPressed.connect(self.save_contact)
         self.receive.returnPressed.connect(self.save_contact)
         self.other_1.returnPressed.connect(self.save_contact)
@@ -544,18 +550,14 @@ class MainWindow(QtWidgets.QMainWindow):
                     "You can udate to the current version by using:\npip install -U not1mm"
                 )
 
-
+        # New method to send F2 and F3 instead of saving to log  /SM0HPL
 
     def callsign_enter_pressed(self):
         self.process_function_key(self.F2)
         self.process_function_key(self.F3)
-        self.receive.setFocus()    
-    
-        """
-        Pressing enter in the callsign field replaced from 
-        being save_contact to F2 + F3 /SM0HPL
+        self.other_2.setFocus()
 
-        """
+        #### /SM0HPL
     
     def fldigi_qso(self, result: str):
         """

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -2329,15 +2329,15 @@ class MainWindow(QtWidgets.QMainWindow):
         """
         Called when a function key is clicked or triggered programmatically.
 
-    Parameters
-    ----------
-    function_key : QPushButton or str
-        Function key to process.
+        Parameters
+        ----------
+        function_key : QPushButton or str
+            Function key to process.
 
-    Returns
-    -------
-    None
-    """
+        Returns
+        -------
+        None
+        """
     if isinstance(function_key, str):
         # If it's a string, find the corresponding function key
         function_key_name = function_key.upper()


### PR DESCRIPTION
A crude proof of concept of the ESM technique. It only halfworks (sometimes it send gibberish instead of CQ) and it only halfworks in RUN mode. I haven't looked into what has to be changed when mode is switched to S&P. In RUN mode:
1. Pressing Enter in empty callsign field sends CQ
2. When callsign of the other station is in the callsign field and Enter is pressed exchange message is sent and focus is changed to "other_2" field (RcvNR in WPX, in CQWW CQ Zone...) for registering the exchange from the other station.
3. When message from other station is registered and Enter is pressed the QSO is logged and focus goes back to callsign window.
This is basically how N1MM+ does it. Swift and easy: Enter, pick callsign, Enter, pick message, Enter.
This makes a HUGE difference when it comes to rythm and ergonomics when working a 48 hours contest. CQWW is coming up in November and it would be nice to stress test not1mm in that one ;)
I'm sure there are a lot of things I haven't thought about, and the S&P mode is completely missing. Any thoughts? Is there another and more efficient way to accomplish what I'm looking for? Five cents from a humble librarian killing time.
73 Anders SM0HPL

