### PR TITLE
@mbridak Allow slashes in callsign during ESM check.

### DIFF
--- a/not1mm/plugins/cq_wpx_cw.py
+++ b/not1mm/plugins/cq_wpx_cw.py
@@ -480,7 +480,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             if len(self.callsign.text()) < 3:
                 self.make_button_green(self.esm_dict["CQ"])
                 buttons_to_send.append(self.esm_dict["CQ"])
-            elif len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            elif (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["HISCALL"])
                 self.make_button_green(self.esm_dict["EXCH"])
                 buttons_to_send.append(self.esm_dict["HISCALL"])
@@ -507,7 +510,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
                     self.process_function_key(button)
     else:
         if self.current_widget == "callsign":
-            if len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            if (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["MYCALL"])
                 buttons_to_send.append(self.esm_dict["MYCALL"])
 

--- a/not1mm/plugins/cq_wpx_rtty.py
+++ b/not1mm/plugins/cq_wpx_rtty.py
@@ -557,7 +557,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             if len(self.callsign.text()) < 3:
                 self.make_button_green(self.esm_dict["CQ"])
                 buttons_to_send.append(self.esm_dict["CQ"])
-            elif len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            elif (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["HISCALL"])
                 self.make_button_green(self.esm_dict["EXCH"])
                 buttons_to_send.append(self.esm_dict["HISCALL"])
@@ -586,7 +589,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             self.fldigi_util.send_string(sendstring)
     else:
         if self.current_widget == "callsign":
-            if len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            if (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["MYCALL"])
                 buttons_to_send.append(self.esm_dict["MYCALL"])
 

--- a/not1mm/plugins/cq_wpx_ssb.py
+++ b/not1mm/plugins/cq_wpx_ssb.py
@@ -443,7 +443,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             if len(self.callsign.text()) < 3:
                 self.make_button_green(self.esm_dict["CQ"])
                 buttons_to_send.append(self.esm_dict["CQ"])
-            elif len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            elif (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["HISCALL"])
                 self.make_button_green(self.esm_dict["EXCH"])
                 buttons_to_send.append(self.esm_dict["HISCALL"])
@@ -470,7 +473,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
                     self.process_function_key(button)
     else:
         if self.current_widget == "callsign":
-            if len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            if (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["MYCALL"])
                 buttons_to_send.append(self.esm_dict["MYCALL"])
 

--- a/not1mm/plugins/cq_ww_cw.py
+++ b/not1mm/plugins/cq_ww_cw.py
@@ -431,7 +431,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             if len(self.callsign.text()) < 3:
                 self.make_button_green(self.esm_dict["CQ"])
                 buttons_to_send.append(self.esm_dict["CQ"])
-            elif len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            elif (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["HISCALL"])
                 self.make_button_green(self.esm_dict["EXCH"])
                 buttons_to_send.append(self.esm_dict["HISCALL"])
@@ -458,7 +461,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
                     self.process_function_key(button)
     else:
         if self.current_widget == "callsign":
-            if len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            if (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["MYCALL"])
                 buttons_to_send.append(self.esm_dict["MYCALL"])
 

--- a/not1mm/plugins/cq_ww_rtty.py
+++ b/not1mm/plugins/cq_ww_rtty.py
@@ -546,7 +546,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             if len(self.callsign.text()) < 3:
                 self.make_button_green(self.esm_dict["CQ"])
                 buttons_to_send.append(self.esm_dict["CQ"])
-            elif len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            elif (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["HISCALL"])
                 self.make_button_green(self.esm_dict["EXCH"])
                 buttons_to_send.append(self.esm_dict["HISCALL"])
@@ -575,7 +578,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             self.fldigi_util.send_string(sendstring)
     else:
         if self.current_widget == "callsign":
-            if len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            if (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["MYCALL"])
                 buttons_to_send.append(self.esm_dict["MYCALL"])
 

--- a/not1mm/plugins/cq_ww_ssb.py
+++ b/not1mm/plugins/cq_ww_ssb.py
@@ -429,7 +429,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             if len(self.callsign.text()) < 3:
                 self.make_button_green(self.esm_dict["CQ"])
                 buttons_to_send.append(self.esm_dict["CQ"])
-            elif len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            elif (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["HISCALL"])
                 self.make_button_green(self.esm_dict["EXCH"])
                 buttons_to_send.append(self.esm_dict["HISCALL"])
@@ -456,7 +459,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
                     self.process_function_key(button)
     else:
         if self.current_widget == "callsign":
-            if len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            if (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["MYCALL"])
                 buttons_to_send.append(self.esm_dict["MYCALL"])
 

--- a/not1mm/plugins/cwt.py
+++ b/not1mm/plugins/cwt.py
@@ -441,7 +441,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             if len(self.callsign.text()) < 3:
                 self.make_button_green(self.esm_dict["CQ"])
                 buttons_to_send.append(self.esm_dict["CQ"])
-            elif len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            elif (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["HISCALL"])
                 self.make_button_green(self.esm_dict["EXCH"])
                 buttons_to_send.append(self.esm_dict["HISCALL"])
@@ -467,7 +470,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
                     self.process_function_key(button)
     else:
         if self.current_widget == "callsign":
-            if len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            if (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["MYCALL"])
                 buttons_to_send.append(self.esm_dict["MYCALL"])
 

--- a/not1mm/plugins/k1usn_sst.py
+++ b/not1mm/plugins/k1usn_sst.py
@@ -416,7 +416,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             if len(self.callsign.text()) < 3:
                 self.make_button_green(self.esm_dict["CQ"])
                 buttons_to_send.append(self.esm_dict["CQ"])
-            elif len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            elif (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["HISCALL"])
                 self.make_button_green(self.esm_dict["EXCH"])
                 buttons_to_send.append(self.esm_dict["HISCALL"])
@@ -442,7 +445,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
                     self.process_function_key(button)
     else:
         if self.current_widget == "callsign":
-            if len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            if (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["MYCALL"])
                 buttons_to_send.append(self.esm_dict["MYCALL"])
 

--- a/not1mm/plugins/naqp_cw.py
+++ b/not1mm/plugins/naqp_cw.py
@@ -442,7 +442,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             if len(self.callsign.text()) < 3:
                 self.make_button_green(self.esm_dict["CQ"])
                 buttons_to_send.append(self.esm_dict["CQ"])
-            elif len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            elif (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["HISCALL"])
                 self.make_button_green(self.esm_dict["EXCH"])
                 buttons_to_send.append(self.esm_dict["HISCALL"])
@@ -483,7 +486,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
                     self.process_function_key(button)
     else:
         if self.current_widget == "callsign":
-            if len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            if (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["MYCALL"])
                 buttons_to_send.append(self.esm_dict["MYCALL"])
 

--- a/not1mm/plugins/naqp_rtty.py
+++ b/not1mm/plugins/naqp_rtty.py
@@ -547,7 +547,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             if len(self.callsign.text()) < 3:
                 self.make_button_green(self.esm_dict["CQ"])
                 buttons_to_send.append(self.esm_dict["CQ"])
-            elif len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            elif (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["HISCALL"])
                 self.make_button_green(self.esm_dict["EXCH"])
                 buttons_to_send.append(self.esm_dict["HISCALL"])
@@ -590,7 +593,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             self.fldigi_util.send_string(sendstring)
     else:
         if self.current_widget == "callsign":
-            if len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            if (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["MYCALL"])
                 buttons_to_send.append(self.esm_dict["MYCALL"])
 

--- a/not1mm/plugins/naqp_ssb.py
+++ b/not1mm/plugins/naqp_ssb.py
@@ -412,7 +412,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             if len(self.callsign.text()) < 3:
                 self.make_button_green(self.esm_dict["CQ"])
                 buttons_to_send.append(self.esm_dict["CQ"])
-            elif len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            elif (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["HISCALL"])
                 self.make_button_green(self.esm_dict["EXCH"])
                 buttons_to_send.append(self.esm_dict["HISCALL"])
@@ -453,7 +456,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
                     self.process_function_key(button)
     else:
         if self.current_widget == "callsign":
-            if len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            if (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["MYCALL"])
                 buttons_to_send.append(self.esm_dict["MYCALL"])
 

--- a/not1mm/plugins/weekly_rtty.py
+++ b/not1mm/plugins/weekly_rtty.py
@@ -491,7 +491,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             if len(self.callsign.text()) < 3:
                 self.make_button_green(self.esm_dict["CQ"])
                 buttons_to_send.append(self.esm_dict["CQ"])
-            elif len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            elif (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["HISCALL"])
                 self.make_button_green(self.esm_dict["EXCH"])
                 buttons_to_send.append(self.esm_dict["HISCALL"])
@@ -520,7 +523,10 @@ def process_esm(self, new_focused_widget=None, with_enter=False):
             self.fldigi_util.send_string(sendstring)
     else:
         if self.current_widget == "callsign":
-            if len(self.callsign.text()) > 2 and self.callsign.text().isalnum():
+            if (
+                len(self.callsign.text()) > 2
+                and self.callsign.text().replace("/", "").isalnum()
+            ):
                 self.make_button_green(self.esm_dict["MYCALL"])
                 buttons_to_send.append(self.esm_dict["MYCALL"])
 

--- a/not1mm/testing/multicast_listener.py
+++ b/not1mm/testing/multicast_listener.py
@@ -7,7 +7,7 @@ import threading
 import queue
 
 multicast_port = 2239
-multicast_group = "224.1.1.1"
+multicast_group = "239.1.1.1"
 interface_ip = "0.0.0.0"
 
 fifo = queue.Queue()
@@ -42,5 +42,5 @@ while 1:
     # print("Waiting...")
     while not fifo.empty():
         timestamp = time.strftime("%H:%M:%S", time.gmtime())
-        print(f"[{timestamp}] {fifo.get()}\n")
+        print(f"[{timestamp}] {fifo.get().decode()}\n")
     time.sleep(1)


### PR DESCRIPTION
Calls were rejected if they contained a '/' during ESM check.
fixed that.
