### PR TITLE
@mbridak Fix the time of the marked spot in the bandmap.

### DIFF
--- a/not1mm/bandmap.py
+++ b/not1mm/bandmap.py
@@ -493,8 +493,9 @@ class BandMapWindow(QDockWidget):
             if packet.get("cmd", "") == "MARKDX":
                 dx = packet.get("dx", "")
                 freq = packet.get("freq", 0.0)
+                the_UTC_time = datetime.now(timezone.utc).isoformat(" ")[:19].split()[1]
                 spot = {
-                    "ts": "2099-01-01 01:00:00",
+                    "ts": "2099-01-01 " + the_UTC_time,
                     "callsign": dx,
                     "freq": freq / 1000,
                     "band": self.currentBand.name,


### PR DESCRIPTION
Fixes fake datetime placed on marked spots in the bandmap to be still fake but have an accurate time.

Old:

```python
                spot = {
                    "ts": "2099-01-01 01:00:00",
                    "callsign": dx,
                    "freq": freq / 1000,
                    "band": self.currentBand.name,
                    "mode": "DX",
                    "spotter": platform.node(),
                    "comment": "MARKED",
                }
```

New:
```python
                the_UTC_time = datetime.now(timezone.utc).isoformat(" ")[:19].split()[1]
                spot = {
                    "ts": "2099-01-01 " + the_UTC_time,
                    "callsign": dx,
                    "freq": freq / 1000,
                    "band": self.currentBand.name,
                    "mode": "DX",
                    "spotter": platform.node(),
                    "comment": "MARKED",
                }
```

