### PR TITLE
Fix ssb modes send to radio when crossing between the 10M boundary.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [24-10-27-1] Fixed setting radios ssb mode when crossing 10M boundary.
 - [24-10-27] Fix bug where a contacts info could be carried over to new contact if no new value was written.
 - [24-10-26] Clear inputs when seeking to a call from the bandmap via the arrow up and down. Fixed bandmap crash from bad telnet data. Drop beacons from bandmap.
 - [24-10-25] Add File Menu option to create either an ASCII or UTF8 Cabrillo.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ generated, 'cause I'm lazy, list of those who've submitted PR's.
 
 ## Recent Changes (Polishing the Turd)
 
+- [24-10-27-1] Fixed setting radios ssb mode when crossing 10M boundary.
 - [24-10-27] Fix bug where a contacts info could be carried over to new contact if no new value was written.
 - [24-10-26] Clear inputs when seeking to a call from the bandmap via the arrow up and down. Fixed bandmap crash from bad telnet data. Drop beacons from bandmap.
 - [24-10-25] Add File Menu option to create either an ASCII or UTF8 Cabrillo.

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -1041,7 +1041,9 @@ class MainWindow(QtWidgets.QMainWindow):
         if mode in ["CW", "SSB", "RTTY"]:
             freq = fakefreq(str(band), mode)
             self.change_freq(freq)
-            self.change_mode(mode)
+            vfo = float(freq)
+            vfo = int(vfo * 1000)
+            self.change_mode(mode, intended_freq=vfo)
 
     def quit_app(self) -> None:
         """
@@ -3125,12 +3127,12 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def change_freq(self, stripped_text: str) -> None:
         """
-        Change VFO to given frequency in Khz and set the band indicator.
-        Send the new frequency to the rig control.
+        Change Radios VFO to given frequency in Khz.
 
         Parameters
         ----------
-        stripped_text : str
+        stripped_text: str
+
         Stripped of any spaces.
 
         Returns
@@ -3160,7 +3162,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.bandmap_window:
             self.bandmap_window.msg_from_main(cmd)
 
-    def change_mode(self, mode: str) -> None:
+    def change_mode(self, mode: str, intended_freq=None) -> None:
         """
         Change mode to given mode.
         Send the new mode to the rig control.
@@ -3208,10 +3210,16 @@ class MainWindow(QtWidgets.QMainWindow):
             self.read_cw_macros()
             return
         if mode == "SSB":
-            if int(self.radio_state.get("vfoa", 0)) > 10000000:
+            if intended_freq:
+                freq = intended_freq
+            else:
+                freq = int(self.radio_state.get("vfoa", 0))
+
+            if freq > 10000000:
                 self.radio_state["mode"] = "USB"
             else:
                 self.radio_state["mode"] = "LSB"
+
             if self.rig_control and self.rig_control.online:
                 self.rig_control.set_mode(self.radio_state.get("mode"))
             else:

--- a/not1mm/lib/version.py
+++ b/not1mm/lib/version.py
@@ -1,3 +1,3 @@
 """It's the version"""
 
-__version__ = "24.10.27"
+__version__ = "24.10.27.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "not1mm" 
-version = "24.10.27"
+version = "24.10.27.1"
 description = "NOT1MM Logger"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Fixing a previous problem, created this new problem. 

When the band/mode indicator was clicked first the radio vfo is set to the freq, and the mode is changed. But when the mode is changed the poll of the radio state had not been done yet. So the internal state still showed the old vfo freq. So when crossing the 10M boundary sometimes the wrong USB/LSB mode was sent.

All this resulted in me thinking I was having a stroke, because I couldn't understand anything I was tuning to.

It's fixed now. Sanity is restored.
 