### PR TITLE
@mbridak trying to fix flrig just a bit.

### DIFF
--- a/not1mm/lib/cat_interface.py
+++ b/not1mm/lib/cat_interface.py
@@ -97,6 +97,7 @@ class CAT:
             self.__initialize_rigctrld()
         elif self.interface == "fake":
             self.online = True
+            logger.debug("Using Fake Rig")
         return
 
     def __initialize_rigctrld(self):
@@ -223,7 +224,9 @@ class CAT:
         """Poll the radio using flrig"""
         try:
             self.online = True
-            return self.server.rig.get_vfo()
+            vfo_value = self.server.rig.get_vfo()
+            logger.debug(f"{vfo_value=}")
+            return vfo_value
         except (
             ConnectionRefusedError,
             xmlrpc.client.Fault,
@@ -232,7 +235,7 @@ class CAT:
             http.client.ResponseNotReady,
         ) as exception:
             self.online = False
-            logger.debug("getvfo_flrig: %s", f"{exception}")
+            logger.debug(f"{exception=}")
         return ""
 
     def __getvfo_rigctld(self) -> str:
@@ -244,7 +247,7 @@ class CAT:
                 return self.__get_serial_string().strip()
             except socket.error as exception:
                 self.online = False
-                logger.debug("getvfo_rigctld: %s", f"{exception}")
+                logger.debug(f"{exception=}")
                 self.rigctrlsocket = None
             return ""
 
@@ -268,7 +271,9 @@ class CAT:
         # 7300 ['LSB', 'USB', 'AM', 'FM', 'CW', 'CW-R', 'RTTY', 'RTTY-R', 'LSB-D', 'USB-D', 'AM-D', 'FM-D']
         try:
             self.online = True
-            return self.server.rig.get_mode()
+            mode_value = self.server.rig.get_mode()
+            logger.debug(f"{mode_value=}")
+            return mode_value
         except (
             ConnectionRefusedError,
             xmlrpc.client.Fault,
@@ -282,7 +287,7 @@ class CAT:
 
     def __getmode_rigctld(self) -> str:
         """Returns mode vai rigctld"""
-        # QMX 'AM CW USB LSB RTTY FM CWR RTTYR'
+        # QMX 'DIGI-U DIGI-L CW-U CW-L' or 'LSB', 'USB', 'CW', 'FM', 'AM', 'FSK'
         # 7300 'AM CW USB LSB RTTY FM CWR RTTYR PKTLSB PKTUSB FM-D AM-D'
         if self.rigctrlsocket:
             try:
@@ -316,6 +321,7 @@ class CAT:
         try:
             self.online = True
             bandwidth = self.server.rig.get_bw()
+            logger.debug(f"{bandwidth=}")
             return bandwidth[0]
         except (
             ConnectionRefusedError,
@@ -438,7 +444,9 @@ class CAT:
         """Returns list of modes supported by the radio"""
         try:
             self.online = True
-            return self.server.rig.get_modes()
+            mode_list = self.server.rig.get_modes()
+            logger.debug(f"{mode_list=}")
+            return mode_list
         except (
             ConnectionRefusedError,
             xmlrpc.client.Fault,
@@ -529,7 +537,10 @@ class CAT:
         """Sets the radios mode"""
         try:
             self.online = True
-            return self.server.rig.set_mode(mode)
+            logger.debug(f"{mode=}")
+            set_mode_result = self.server.rig.set_mode(mode)
+            logger.debug(f"self.server.rig.setmode(mode) = {set_mode_result}")
+            return set_mode_result
         except (
             ConnectionRefusedError,
             xmlrpc.client.Fault,
@@ -538,7 +549,7 @@ class CAT:
             http.client.ResponseNotReady,
         ) as exception:
             self.online = False
-            logger.debug("setmode_flrig: %s", f"{exception}")
+            logger.debug(f"{exception=}")
         return False
 
     def __setmode_rigctld(self, mode: str) -> bool:

--- a/not1mm/radio.py
+++ b/not1mm/radio.py
@@ -35,7 +35,16 @@ class Radio(QObject):
     host = None
     port = None
     modes = ""
+    cw_list = ["CW", "CW-L", "CW-U", "CWR"]
+    rtty_list = [
+        "RTTY",
+        "DIGI-L",
+        "PKTLSB",
+        "LSB-D",
+    ]
     last_data_mode = "RTTY"
+    last_cw_mode = "CW"
+    last_ph_mode = "SSB"
 
     def __init__(self, interface: str, host: str, port: int) -> None:
         super().__init__()
@@ -49,6 +58,15 @@ class Radio(QObject):
             self.cat = CAT(self.interface, self.host, self.port)
             self.online = self.cat.online
             self.modes = self.cat.get_mode_list()
+            for pos_cw in self.cw_list:
+                if pos_cw in self.modes:
+                    self.last_cw_mode = pos_cw
+                    break
+            for pos_rtty in self.rtty_list:
+                if pos_rtty in self.modes:
+                    self.last_data_mode = pos_rtty
+                    break
+
         except ConnectionResetError:
             ...
         while not self.time_to_quit:
@@ -97,6 +115,7 @@ class Radio(QObject):
             "USB-D",
             "AM-D",
             "FM-D",
+            "FSK",
             "DIGI-U",
             "DIGI-L",
             "RTTYR",
@@ -105,6 +124,11 @@ class Radio(QObject):
         ]
         if the_mode in datamodes:
             self.last_data_mode = the_mode
+
+        cwmodes = ["CW", "CW-L", "CW-U", "CWR"]
+
+        if the_mode in cwmodes:
+            self.last_cw_mode = the_mode
 
     def sendcw(self, texttosend):
         """..."""


### PR DESCRIPTION
Was unable to change modes on QMX to either CW or RTTY/Data modes using flrig since it's modes register as CW-L, CW-U, DIGI-L, DIGI-U.

So after the CAT control is established it polls the Rig for all supported modes and tries to pick sane defaults for cw and digital modes.

Also during operation it will store the last radio mode used for cw or digi/rtty and use that to switch back to.
  