### PR TITLE
@mbridak clear inputs when qsy sandp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [25-4-18] Option to clear input fields when QSY in S&P mode.
 - [25-4-17] Testing sending radio voice memory. {VOICE1}, {VOICE2} etc.
 - [25-4-16] Fix serial number not updating when selecing call from checkpartial or bandmap.
 - [25-4-15] Corrected dupe_type 5 check for contest specific function. Fixed wrong ES Open plugin name. Fixed some problems with the specific_contest_check_dupe datetime namespace. And other stuff.

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ generated, 'cause I'm lazy, list of those who've submitted PR's.
 
 ## Recent Changes
 
+- [25-4-18] Option to clear input fields when QSY in S&P mode.
 - [25-4-17] Testing sending radio voice memory. {VOICE1}, {VOICE2} etc.
 - [25-4-16] Fix serial number not updating when selecing call from checkpartial or bandmap.
 - [25-4-15] Corrected dupe_type 5 check for contest specific function. Fixed wrong ES Open plugin name. Fixed some problems with the specific_contest_check_dupe datetime namespace. And other stuff.
@@ -614,6 +615,7 @@ On the Options TAB you can:
 - Select to use Enter Sends Message ([ESM](#esm)), and configure it's function keys.
 - Select whether or not to use [Call History](#call-history-files) info.
 - Select whether or not to send XML score info to online scoreboards.
+- Select whether or not to clear input fields when you QSY while in S&P mode.
 
 ![Options Screen](https://github.com/mbridak/not1mm/blob/master/pic/configuration_options.png?raw=true)
 

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -170,6 +170,7 @@ class MainWindow(QtWidgets.QMainWindow):
     use_esm = False
     use_call_history = False
     esm_dict = {}
+    sandpfreq = 0
 
     radio_thread = QThread()
     voice_thread = QThread()
@@ -3498,6 +3499,9 @@ class MainWindow(QtWidgets.QMainWindow):
         """
         if self.auto_cq is True:
             self.stop_cw()
+        if self.pref.get("sandpqsy") is True and self.radioButton_sp.isChecked():
+            self.sandpfreq = int(self.radio_state.get("vfoa", 0))
+            print(f"{self.sandpfreq=}")
         text = self.callsign.text()
         text = text.upper()
         position = self.callsign.cursorPosition()
@@ -3908,6 +3912,9 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.radio_state.get("vfoa") != vfo:
             info_dirty = True
             self.radio_state["vfoa"] = vfo
+            if self.pref.get("sandpqsy") is True and self.radioButton_sp.isChecked():
+                if max(int(vfo), self.sandpfreq) - min(int(vfo), self.sandpfreq) > 50:
+                    self.clearinputs()
         band = getband(str(vfo))
         self.radio_state["band"] = band
         self.contact["Band"] = get_logged_band(str(vfo))

--- a/not1mm/data/configuration.ui
+++ b/not1mm/data/configuration.ui
@@ -2308,6 +2308,20 @@
            </layout>
           </item>
           <item>
+           <widget class="Line" name="line_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="qsy_on_change">
+            <property name="text">
+             <string>S&amp;&amp;P QSY on Freq Change</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <spacer name="verticalSpacer_8">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -2441,7 +2455,7 @@
   </property>
  </designerdata>
  <buttongroups>
-  <buttongroup name="buttonGroup_2"/>
   <buttongroup name="buttonGroup"/>
+  <buttongroup name="buttonGroup_2"/>
  </buttongroups>
 </ui>

--- a/not1mm/lib/settings.py
+++ b/not1mm/lib/settings.py
@@ -58,6 +58,8 @@ class Settings(QtWidgets.QDialog):
             bool(self.preference.get("use_call_history", False))
         )
 
+        self.qsy_on_change.setChecked(bool(self.preference.get("sandpqsy", False)))
+
         self.use_esm.setChecked(bool(self.preference.get("use_esm", False)))
 
         value = self.preference.get("esm_agn", "DISABLED")
@@ -229,6 +231,9 @@ class Settings(QtWidgets.QDialog):
         self.auto_cq_delay.setText(str(self.preference.get("auto_cq_interval", "15")))
 
         self.preference["use_call_history"] = self.use_call_history.isChecked()
+
+        self.preference["sandpqsy"] = self.qsy_on_change.isChecked()
+
         self.preference["use_esm"] = self.use_esm.isChecked()
         self.preference["esm_cq"] = self.esm_cq.currentText()
         self.preference["esm_agn"] = self.esm_agn.currentText()

--- a/not1mm/lib/version.py
+++ b/not1mm/lib/version.py
@@ -1,3 +1,3 @@
 """It's the version"""
 
-__version__ = "25.4.17"
+__version__ = "25.4.18"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "not1mm" 
-version = "25.4.17"
+version = "25.4.18"
 description = "NOT1MM Logger"
 license = { text = "GPL-3.0-or-later" }
 readme = "README.md"


### PR DESCRIPTION
Add config option to enable QSY input clearing when in S&P mode.
