### PR TITLE
Add settings for CW padding when sending serial number

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -2869,7 +2869,7 @@ class MainWindow(QtWidgets.QMainWindow):
             next_serial = "1"
         macro = macro.upper()
         if self.radio_state.get("mode") == "CW":
-            macro = macro.replace("#", next_serial.rjust(3, "T"))
+            macro = macro.replace("#", next_serial.rjust(self.pref["cwpaddinglength"], self.pref["cwpaddingchar"]))
         else:
             macro = macro.replace("#", next_serial)
         macro = macro.replace("{MYCALL}", self.station.get("Call", ""))
@@ -2882,7 +2882,7 @@ class MainWindow(QtWidgets.QMainWindow):
             macro = macro.replace("{SNT}", self.sent.text())
         if self.radio_state.get("mode") == "CW":
             macro = macro.replace(
-                "{SENTNR}", self.other_1.text().lstrip("0").rjust(3, "T")
+                "{SENTNR}", self.other_1.text().lstrip("0").rjust(self.pref["cwpaddinglength"], self.pref["cwpaddingchar"])
             )
         else:
             macro = macro.replace("{SENTNR}", self.other_1.text())

--- a/not1mm/data/configuration.ui
+++ b/not1mm/data/configuration.ui
@@ -799,6 +799,86 @@
          </property>
         </spacer>
        </item>
+       <item row="3" column="1">
+        <widget class="QLabel" name="label_31">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono ExtraLight</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="text">
+          <string>CW Sent Nr Padding:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="2">
+        <widget class="QLineEdit" name="cwpaddingchar_field">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono ExtraLight</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="accessibleName">
+          <string>c w padding character</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>padding character when sending c w exchange number.</string>
+         </property>
+         <property name="inputMethodHints">
+          <set>Qt::InputMethodHint::ImhDigitsOnly</set>
+         </property>
+         <property name="text">
+          <string>T</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QLabel" name="label_32">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono ExtraLight</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="text">
+          <string>CW Sent Nr Padding Length:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <widget class="QLineEdit" name="cwpaddinglength_field">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono ExtraLight</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="accessibleName">
+          <string>c w padding character</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>number of padding characters to send when sending c w exchange number.</string>
+         </property>
+         <property name="inputMethodHints">
+          <set>Qt::InputMethodHint::ImhDigitsOnly</set>
+         </property>
+         <property name="text">
+          <string>3</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="cluster_tab">

--- a/not1mm/lib/settings.py
+++ b/not1mm/lib/settings.py
@@ -138,6 +138,8 @@ class Settings(QtWidgets.QDialog):
             self.set_winkeyer_port_hint()
         elif self.preference.get("cwtype") == 3:
             self.set_catforcw_port_hint()
+        self.cwpaddingchar_field.setText(self.preference.get("cwpaddingchar", "T"))
+        self.cwpaddinglength_field.setText(str(self.preference.get("cwpaddinglength", "3")))
 
         self.connect_to_server.setChecked(bool(self.preference.get("useserver")))
         self.multicast_group.setText(str(self.preference.get("multicast_group", "")))
@@ -266,6 +268,8 @@ class Settings(QtWidgets.QDialog):
         except ValueError:
             self.preference["cwport"] = None
             ...
+        self.preference["cwpaddingchar"] = self.cwpaddingchar_field.text()
+        self.preference["cwpaddinglength"] = int(self.cwpaddinglength_field.text())
         self.preference["cwtype"] = 0
         if self.usecwdaemon_radioButton.isChecked():
             self.preference["cwtype"] = 1


### PR DESCRIPTION
This PR will add a couple of CW settings to customize what character and how many of that character to send when executing the serial macro. This will be useful if you don't want to set 0 as a cut number, or don't send any leading zeros at all.

I'm not sure if this is the correct way of adding fields to the UI.