### PR TITLE
Fix calculate_wpx_prefix

### DIFF
--- a/not1mm/lib/ham_utility.py
+++ b/not1mm/lib/ham_utility.py
@@ -16,19 +16,22 @@ def calculate_wpx_prefix(the_call: str) -> str:
         return ""
     if the_call in ["OPON", "CW", "SSB", "RTTY"]:
         return ""
-    suffix_to_ignore = ["M", "MM", "P", "QRP", "A", "LH", "NLD"]
+    suffix_to_ignore = ["M", "MM", "P", "QRP", "A", "J", "LH", "LGT", "LS", "NLD", "T", "R", "TR" ]
+    for suffix in suffix_to_ignore:
+        the_call = the_call.replace("/"+suffix, "")
     result = None
     working_call = the_call.split("/")
     if len(working_call) > 1:
         result = min(working_call, key=len)
         if not result.isnumeric():
-            if result not in suffix_to_ignore:
-                if any(chr.isdigit() for chr in result):
-                    return result
-                return result + "0"
+            if any(chr.isdigit() for chr in result):
+                return result
+            return result + "0"
 
     working_call = max(working_call, key=len)
     last_digit = re.match(".+([0-9])[^0-9]*$", working_call)
+    if last_digit is None:
+        return working_call[0:2] + "0"
     position = last_digit.start(1)
     prefix = working_call[: position + 1]
     if not result:

--- a/not1mm/lib/ham_utility.py
+++ b/not1mm/lib/ham_utility.py
@@ -18,7 +18,7 @@ def calculate_wpx_prefix(the_call: str) -> str:
         return ""
     suffix_to_ignore = ["M", "MM", "P", "QRP", "A", "J", "LH", "LGT", "LS", "NLD", "T", "R", "TR" ]
     for suffix in suffix_to_ignore:
-        the_call = the_call.replace("/"+suffix, "")
+        the_call = re.sub("/" + suffix + "$", "", the_call)
     result = None
     working_call = the_call.split("/")
     if len(working_call) > 1:


### PR DESCRIPTION
I noticed during WPX CW that not1mm calculated M0RYB/P's mult to be MP which is not correct.

I changed the code to:

1. Completely remove all additions to the callsign that are not relevant for the prefix first, e.g. /P, /M, /MM (I extended the list by a few new ones that are more or less common: /J for Jamboree/Scout stations, /LGT as an alternative to LH (Lighthouses), /LS (Lightship), /T is "Training" in Germany (supervised operation by an unlicensed operator), /R is used to indicate remote operation in some countries, and finally /TR is the combination of training+remote :-)
2. If there is no digit in the call, use the first two letters and add a Zero (as per WPX rules)