### PR TITLE
Improve checkpartial contrast if not using dark mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- [25-7-10] Improved checkpartial contrast if not using dark mode.
 - [25-7-3] Fixed CAT online indicator.
 - [25-6-21] Remove range check on vfo display.
 - [25-6-20] Added a Rotator tab in the configuration dialog.


### PR DESCRIPTION
I'm **not** using dark mode. So black letters on white (or bright) background it is for me.

When using the "check partial" feature, I found the background colors signaling what's up with the character rather dark, leaving not enough contrast with the black letters, causing difficulty in reading.

This pull request fixes this problem.

73, DJ3EI