### PR TITLE
Update cat_interface.py

### DIFF
--- a/not1mm/lib/cat_interface.py
+++ b/not1mm/lib/cat_interface.py
@@ -208,7 +208,7 @@ class CAT:
         if self.rigctrlsocket:
             try:
                 self.online = True
-                self.rigctrlsocket.send(bytes("\\stop_morse", "utf-8"))
+                self.rigctrlsocket.send(bytes("\\stop_morse\n", "utf-8"))
                 _ = self.__get_serial_string()
                 return True
             except socket.error as exception:


### PR DESCRIPTION
Added \n to the stop_morse call. I guess this is needed. I can't stop with the ESC key when keying via CAT.