### PR TITLE
@ki4mcw Make all window titles system font

### DIFF
--- a/not1mm/data/bandmap.ui
+++ b/not1mm/data/bandmap.ui
@@ -10,15 +10,15 @@
     <height>700</height>
    </rect>
   </property>
-  <property name="font">
-   <font>
-    <family>JetBrains Mono</family>
-   </font>
-  </property>
   <property name="windowTitle">
    <string>BandMap</string>
   </property>
   <widget class="QWidget" name="widget">
+   <property name="font">
+    <font>
+     <family>JetBrains Mono</family>
+    </font>
+   </property>
    <layout class="QVBoxLayout" name="verticalLayout_2">
     <property name="spacing">
      <number>6</number>

--- a/not1mm/data/checkwindow.ui
+++ b/not1mm/data/checkwindow.ui
@@ -10,11 +10,6 @@
     <height>374</height>
    </rect>
   </property>
-  <property name="font">
-   <font>
-    <family>JetBrains Mono</family>
-   </font>
-  </property>
   <property name="focusPolicy">
    <enum>Qt::NoFocus</enum>
   </property>
@@ -22,6 +17,11 @@
    <string>CheckPartial</string>
   </property>
   <widget class="QWidget" name="widget">
+   <property name="font">
+    <font>
+     <family>JetBrains Mono</family>
+    </font>
+   </property>
    <layout class="QGridLayout" name="checkpartialgridlayout">
     <property name="margin" stdset="0">
      <number>2</number>

--- a/not1mm/data/ratewindow.ui
+++ b/not1mm/data/ratewindow.ui
@@ -22,15 +22,15 @@
     <height>200</height>
    </size>
   </property>
-  <property name="font">
-   <font>
-    <family>JetBrains Mono</family>
-   </font>
-  </property>
   <property name="windowTitle">
    <string>RateWindow</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
+   <property name="font">
+    <font>
+     <family>JetBrains Mono</family>
+    </font>
+   </property>
    <property name="sizePolicy">
     <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
      <horstretch>0</horstretch>

--- a/not1mm/data/statistics.ui
+++ b/not1mm/data/statistics.ui
@@ -10,15 +10,15 @@
     <height>192</height>
    </rect>
   </property>
-  <property name="font">
-   <font>
-    <family>JetBrains Mono</family>
-   </font>
-  </property>
   <property name="windowTitle">
    <string>Stats</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
+   <property name="font">
+    <font>
+     <family>JetBrains Mono</family>
+    </font>
+   </property>
    <layout class="QGridLayout" name="gridLayout">
     <item row="1" column="2">
      <widget class="QTableWidget" name="tableWidget"/>

--- a/not1mm/data/vfo.ui
+++ b/not1mm/data/vfo.ui
@@ -10,11 +10,6 @@
     <height>107</height>
    </rect>
   </property>
-  <property name="font">
-   <font>
-    <family>JetBrains Mono</family>
-   </font>
-  </property>
   <property name="features">
    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
   </property>


### PR DESCRIPTION
Another aesthetic change. Some windows use the system font for their titles, and some use JetBrains. This change moves the font declarations from the window objects to the widget objects, so that the window titles all appear in the system font. 