### PR TITLE
@ki4mcw Issue #374 add digits in bandmap

### DIFF
--- a/not1mm/bandmap.py
+++ b/not1mm/bandmap.py
@@ -586,7 +586,8 @@ class BandMapWindow(QDockWidget):
             )
             if i % 5 == 0:  # Add Frequency
                 freq = self.currentBand.start + step * i
-                text = f"{freq:.3f}"
+                #text = f"{freq:.3f}"
+                text = "{1:.{0}f}".format(_digits, freq)
                 self.something = self.bandmap_scene.addText(text)
                 self.something.setFont(self.thefont)
                 self.something.setDefaultTextColor(self.text_color)
@@ -770,13 +771,13 @@ class BandMapWindow(QDockWidget):
     def determine_step_digits(self):
         """doc"""
         return_zoom = {
-            1: (0.0001, 4),
-            2: (0.00025, 4),
-            3: (0.0005, 4),
-            4: (0.001, 3),
-            5: (0.0025, 3),
+            1: (0.0001, 5),
+            2: (0.00025, 5),
+            3: (0.0005, 5),
+            4: (0.001, 5),
+            5: (0.0025, 5),
             6: (0.005, 3),
-            7: (0.01, 2),
+            7: (0.01, 3),
         }
         step, digits = return_zoom.get(self.zoom, (0.0001, 4))
 

--- a/not1mm/data/main.ui
+++ b/not1mm/data/main.ui
@@ -736,6 +736,9 @@
                  <property name="text">
                   <string>Callsign</string>
                  </property>
+                 <property name="alignment">
+                  <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+                 </property> 
                 </widget>
                </item>
                <item>


### PR DESCRIPTION
Per issue #374, the labels in the bandmap seem to repeat at high zoom levels. This is because the labels are rounded to 3 decimal places, ignoring the return_zoom array settings. Added code to round to X places based on zoom level, as seemed to be the original intent. Bandmap now shows sane values at all zoom levels. 