### PR TITLE
@ki4mcw Dont force uppercase Name, Comment in general logging

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -1960,6 +1960,9 @@ class MainWindow(QtWidgets.QMainWindow):
                 try:
                     self.database.current_contest = self.pref.get("contest")
                     if self.contest_settings.get("ContestName"):
+                        """Reset these in case a contest disabled them"""
+                        self.other_1.setStyleSheet("text-transform: uppercase;")
+                        self.other_2.setStyleSheet("text-transform: uppercase;")
                         self.contest = doimp(self.contest_settings.get("ContestName"))
                         logger.debug("Loaded Contest Name = %s", self.contest.name)
                         self.set_window_title()

--- a/not1mm/data/main.ui
+++ b/not1mm/data/main.ui
@@ -736,6 +736,9 @@
                  <property name="text">
                   <string>Callsign</string>
                  </property>
+                 <property name="alignment">
+                  <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+                 </property> 
                 </widget>
                </item>
                <item>

--- a/not1mm/plugins/general_logging.py
+++ b/not1mm/plugins/general_logging.py
@@ -51,6 +51,9 @@ def interface(self):
     self.field3.setAccessibleName("Name")
     self.exch_label.setText("Comment")
     self.field4.setAccessibleName("Comment")
+    """Disable forced uppercase from main.ui"""
+    self.other_1.setStyleSheet("text-transform: none;")
+    self.other_2.setStyleSheet("text-transform: none;")
 
 
 def reset_label(self):


### PR DESCRIPTION
Main.ui uses text-transform in the stylesheet to force the other_1 and other_2 fields to display in uppercase. For most plugins, this is not a problem, because the plugin converts the data to upper before saving it. But in general_logging.py, the user might want to use mixed case for the Name and Comment fields. This change disables the text-transform on those two fields - only for this one plugin - to make this possible.