### PR TITLE
Check window lists entries from wrong contest

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -1963,6 +1963,9 @@ class MainWindow(QtWidgets.QMainWindow):
                         """Reset these in case a contest disabled them"""
                         self.other_1.setStyleSheet("text-transform: uppercase;")
                         self.other_2.setStyleSheet("text-transform: uppercase;")
+                        """Inform check window in case this is a change of contest"""
+                        self.check_window.database.current_contest = (self.pref.get("contest"))
+                        
                         self.contest = doimp(self.contest_settings.get("ContestName"))
                         logger.debug("Loaded Contest Name = %s", self.contest.name)
                         self.set_window_title()


### PR DESCRIPTION
If a user changes contests during runtime, the check window still uses the original contest for the "logs" list. This one-liner informs the check window of the new contest number as the new contest is loaded.