### PR TITLE
@ki4mcw Issue #380 Dupe indicator

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -1188,6 +1188,10 @@ class MainWindow(QtWidgets.QMainWindow):
                     self.statistics_window.msg_from_main(msg)
                 if self.dxcc_window:
                     self.dxcc_window.msg_from_main(msg)
+                if self.check_dupe(self.callsign.text()):
+                    self.dupe_indicator.show()
+                else:
+                    self.dupe_indicator.hide()
 
             if msg.get("cmd", "") == "GETCOLUMNS":
                 if hasattr(self.contest, "columns"):


### PR DESCRIPTION
Resolves Issue #380 where Dupe indicator stays on even after a contact is changed or deleted in the log window. 