### PR TITLE
Refactor serial number handling in MainWindow class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [25-10-6] Bugfix: Fix 70cm frequency ranges not showing in bandmap.
   - Bugfix: Fix broken dupe checking when not multi-multi.
+  - Bugfix: Fix sending SN when not fetched.
 - [25-10-5] Add Multi Multi dupe checking.
   - Add Multi Multi Serial Number support.
 - [25-9-29] Fix Cabrillo output for CQWW RTTY.

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ generated, 'cause I'm lazy, list of those who've submitted PR's.
 
 - [25-10-6] Bugfix: Fix 70cm frequency ranges not showing in bandmap.
   - Bugfix: Fix broken dupe checking when not multi-multi.
+  - Bugfix: Fix sending SN when not fetched.
 - [25-10-5] Add Multi Multi dupe checking.
   - Add Multi Multi Serial Number support.
 

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -3329,12 +3329,10 @@ class MainWindow(QtWidgets.QMainWindow):
         Processed macro.
         """
 
-        # result = self.database.get_serial()
-        # next_serial = str(result.get("serial_nr", "1"))
-        # if next_serial == "None":
-        #     next_serial = "1"
         if self.current_sn is not None:
             next_serial = str(self.current_sn)
+        else:
+            next_serial = ""
 
         result = self.database.get_last_serial()
         prev_serial = str(result.get("serial_nr", "1")).zfill(3)

--- a/not1mm/lib/version.py
+++ b/not1mm/lib/version.py
@@ -1,3 +1,3 @@
 """It's the version"""
 
-__version__ = "25.10.6.1"
+__version__ = "25.10.6.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "not1mm" 
-version = "25.10.6.1"
+version = "25.10.6.2"
 description = "NOT1MM Logger"
 license = { text = "GPL-3.0-or-later" }
 readme = "README.md"


### PR DESCRIPTION
If the app is freshly launched, there is no SN to send with macros and crashes.

Added a default "" value.
 