### PR TITLE
On output to Cabrillo logs, frequencies are now properly rounded.

### DIFF
--- a/not1mm/plugins/10_10_fall_cw.py
+++ b/not1mm/plugins/10_10_fall_cw.py
@@ -340,7 +340,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/10_10_spring_cw.py
+++ b/not1mm/plugins/10_10_spring_cw.py
@@ -339,7 +339,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/10_10_summer_phone.py
+++ b/not1mm/plugins/10_10_summer_phone.py
@@ -343,7 +343,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/10_10_winter_phone.py
+++ b/not1mm/plugins/10_10_winter_phone.py
@@ -341,7 +341,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/ari_40_80.py
+++ b/not1mm/plugins/ari_40_80.py
@@ -338,7 +338,7 @@ def cabrillo(self, file_encoding):
                     themode = "PH"
                 if themode == "RTTY":
                     themode = "RY"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/ari_dx.py
+++ b/not1mm/plugins/ari_dx.py
@@ -420,7 +420,7 @@ def cabrillo(self, file_encoding):
                     themode = "PH"
                 if themode == "RTTY":
                     themode = "RY"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/arrl_10m.py
+++ b/not1mm/plugins/arrl_10m.py
@@ -426,7 +426,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/arrl_160m.py
+++ b/not1mm/plugins/arrl_160m.py
@@ -433,7 +433,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/arrl_dx_cw.py
+++ b/not1mm/plugins/arrl_dx_cw.py
@@ -369,7 +369,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/arrl_dx_ssb.py
+++ b/not1mm/plugins/arrl_dx_ssb.py
@@ -369,7 +369,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/arrl_field_day.py
+++ b/not1mm/plugins/arrl_field_day.py
@@ -326,7 +326,7 @@ def cabrillo(self, file_encoding):
                     themode = "PH"
                 if themode in ("FT8", "FT4", "RTTY"):
                     themode = "DG"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/arrl_rtty_ru.py
+++ b/not1mm/plugins/arrl_rtty_ru.py
@@ -394,7 +394,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/arrl_ss_cw.py
+++ b/not1mm/plugins/arrl_ss_cw.py
@@ -370,7 +370,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/arrl_ss_phone.py
+++ b/not1mm/plugins/arrl_ss_phone.py
@@ -351,7 +351,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/arrl_vhf_jan.py
+++ b/not1mm/plugins/arrl_vhf_jan.py
@@ -408,9 +408,9 @@ def cabrillo(self, file_encoding):
                     "Q65",
                 ):
                     themode = "DG"
-                freq = int(contact.get("Freq", "0")) / 1000
+                freq = contact.get("Freq", "0") / 1000
 
-                frequency = str(int(freq)).rjust(4)
+                frequency = str(round(freq)).rjust(4)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/arrl_vhf_jun.py
+++ b/not1mm/plugins/arrl_vhf_jun.py
@@ -375,9 +375,9 @@ def cabrillo(self, file_encoding):
                     "Q65",
                 ):
                     themode = "DG"
-                freq = int(contact.get("Freq", "0")) / 1000
+                freq = contact.get("Freq", "0") / 1000
 
-                frequency = str(int(freq)).rjust(4)
+                frequency = str(round(freq)).rjust(4)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/arrl_vhf_sep.py
+++ b/not1mm/plugins/arrl_vhf_sep.py
@@ -377,7 +377,7 @@ def cabrillo(self, file_encoding):
                     themode = "DG"
                 freq = int(contact.get("Freq", "0")) / 1000
 
-                frequency = str(int(freq)).rjust(4)
+                frequency = str(round(freq)).rjust(4)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/canada_day.py
+++ b/not1mm/plugins/canada_day.py
@@ -391,7 +391,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/cq_160_cw.py
+++ b/not1mm/plugins/cq_160_cw.py
@@ -378,7 +378,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/cq_160_ssb.py
+++ b/not1mm/plugins/cq_160_ssb.py
@@ -378,7 +378,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/cq_wpx_cw.py
+++ b/not1mm/plugins/cq_wpx_cw.py
@@ -412,7 +412,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/cq_wpx_rtty.py
+++ b/not1mm/plugins/cq_wpx_rtty.py
@@ -411,7 +411,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/cq_wpx_ssb.py
+++ b/not1mm/plugins/cq_wpx_ssb.py
@@ -375,7 +375,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/cq_ww_cw.py
+++ b/not1mm/plugins/cq_ww_cw.py
@@ -392,7 +392,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/cq_ww_rtty.py
+++ b/not1mm/plugins/cq_ww_rtty.py
@@ -420,7 +420,7 @@ def cabrillo(self, file_encoding):
                 exchange1 = contact.get("Exchange1", "")
                 if exchange1 == "":
                     exchange1 = "DX"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/cq_ww_ssb.py
+++ b/not1mm/plugins/cq_ww_ssb.py
@@ -391,7 +391,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/cwo.py
+++ b/not1mm/plugins/cwo.py
@@ -363,7 +363,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/cwt.py
+++ b/not1mm/plugins/cwt.py
@@ -365,7 +365,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/darc_vhf.py
+++ b/not1mm/plugins/darc_vhf.py
@@ -467,7 +467,8 @@ def edi(self):
                     modeCode = 1
                 if themode == "CW" or themode == "CWL" or themode == "CWU":
                     modeCode = 2
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                # Unused variable
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
                 loggedyear = the_date_and_time[2:4]
                 loggedmonth = the_date_and_time[5:7]
                 loggedday = the_date_and_time[8:10]
@@ -689,7 +690,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/darc_xmas.py
+++ b/not1mm/plugins/darc_xmas.py
@@ -396,7 +396,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/ea_majistad_cw.py
+++ b/not1mm/plugins/ea_majistad_cw.py
@@ -460,7 +460,7 @@ def cabrillo(self, file_encoding):
                     themode = "PH"
                 if themode == "RTTY":
                     themode = "RY"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/ea_majistad_ssb.py
+++ b/not1mm/plugins/ea_majistad_ssb.py
@@ -451,7 +451,7 @@ def cabrillo(self, file_encoding):
                     themode = "PH"
                 if themode == "RTTY":
                     themode = "RY"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/ea_rtty.py
+++ b/not1mm/plugins/ea_rtty.py
@@ -464,7 +464,7 @@ def cabrillo(self, file_encoding):
                     themode = "PH"
                 if themode == "RTTY":
                     themode = "RY"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/es_field_day.py
+++ b/not1mm/plugins/es_field_day.py
@@ -480,7 +480,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/es_ll_kv.py
+++ b/not1mm/plugins/es_ll_kv.py
@@ -450,7 +450,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/es_manual_key.py
+++ b/not1mm/plugins/es_manual_key.py
@@ -505,7 +505,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/es_open.py
+++ b/not1mm/plugins/es_open.py
@@ -449,7 +449,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/helvetia.py
+++ b/not1mm/plugins/helvetia.py
@@ -499,7 +499,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/iaru_fieldday_r1_cw.py
+++ b/not1mm/plugins/iaru_fieldday_r1_cw.py
@@ -402,7 +402,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/iaru_fieldday_r1_ssb.py
+++ b/not1mm/plugins/iaru_fieldday_r1_ssb.py
@@ -402,7 +402,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/iaru_hf.py
+++ b/not1mm/plugins/iaru_hf.py
@@ -375,7 +375,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/icwc_mst.py
+++ b/not1mm/plugins/icwc_mst.py
@@ -354,7 +354,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/jidx_cw.py
+++ b/not1mm/plugins/jidx_cw.py
@@ -376,7 +376,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/jidx_ph.py
+++ b/not1mm/plugins/jidx_ph.py
@@ -345,7 +345,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/k1usn_sst.py
+++ b/not1mm/plugins/k1usn_sst.py
@@ -345,7 +345,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/labre_rs_digi.py
+++ b/not1mm/plugins/labre_rs_digi.py
@@ -392,9 +392,9 @@ def cabrillo(self, file_encoding):
                     "Q65",
                 ):
                     themode = "DG"
-                freq = int(contact.get("Freq", "0")) / 1000
+                freq = contact.get("Freq", "0") / 1000
 
-                frequency = str(int(freq)).rjust(4)
+                frequency = str(round(freq)).rjust(4)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/lz-dx.py
+++ b/not1mm/plugins/lz-dx.py
@@ -403,7 +403,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/naqp_cw.py
+++ b/not1mm/plugins/naqp_cw.py
@@ -371,7 +371,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/naqp_rtty.py
+++ b/not1mm/plugins/naqp_rtty.py
@@ -388,7 +388,7 @@ def cabrillo(self, file_encoding):
                     "PKTUSB",
                 ):
                     themode = "RY"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/naqp_ssb.py
+++ b/not1mm/plugins/naqp_ssb.py
@@ -341,7 +341,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/phone_weekly_test.py
+++ b/not1mm/plugins/phone_weekly_test.py
@@ -361,7 +361,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/raem.py
+++ b/not1mm/plugins/raem.py
@@ -459,7 +459,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/ref_cw.py
+++ b/not1mm/plugins/ref_cw.py
@@ -504,7 +504,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/ref_ssb.py
+++ b/not1mm/plugins/ref_ssb.py
@@ -518,7 +518,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/rsgb_80m_cc.py
+++ b/not1mm/plugins/rsgb_80m_cc.py
@@ -334,7 +334,7 @@ def cabrillo(self, file_encoding):
                     themode = "RY"
                 if themode == "PSK":
                     themode = "PS"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/sac_cw.py
+++ b/not1mm/plugins/sac_cw.py
@@ -433,7 +433,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/sac_ssb.py
+++ b/not1mm/plugins/sac_ssb.py
@@ -433,7 +433,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/spdx.py
+++ b/not1mm/plugins/spdx.py
@@ -375,7 +375,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/stew_perry_topband.py
+++ b/not1mm/plugins/stew_perry_topband.py
@@ -339,7 +339,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/ukeidx.py
+++ b/not1mm/plugins/ukeidx.py
@@ -433,7 +433,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/vhf_sprint.py
+++ b/not1mm/plugins/vhf_sprint.py
@@ -373,9 +373,9 @@ def cabrillo(self, file_encoding):
                     "Q65",
                 ):
                     themode = "DG"
-                freq = int(contact.get("Freq", "0")) / 1000
+                freq = contact.get("Freq", "0") / 1000
 
-                frequency = str(int(freq)).rjust(4)
+                frequency = str(round(freq)).rjust(4)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/wag.py
+++ b/not1mm/plugins/wag.py
@@ -461,7 +461,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/weekly_rtty.py
+++ b/not1mm/plugins/weekly_rtty.py
@@ -351,7 +351,7 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "RTTY":
                     themode = "RY"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]

--- a/not1mm/plugins/winter_field_day.py
+++ b/not1mm/plugins/winter_field_day.py
@@ -334,7 +334,7 @@ def cabrillo(self, file_encoding):
                     themode = "PH"
                 if themode == "RTTY":
                     themode = "DG"
-                frequency = str(int(contact.get("Freq", "0"))).rjust(5)
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]


### PR DESCRIPTION
I noticed that a QSO had a real QRG of 21.04999 (according to the ADI log written by `not1mm`). In the Cabrillo file, this needs to be rounded to a full kHz, so I expected 21050. But instead, `not1mm` exports 21049.

This pull requests fixes that bug.

(FWIW, I recommend object orientation, where some base class has line generation like it is needed in most contests, and only the few contests that actually need something special use specific code. Imho, this would increase maintainability.)