### PR TITLE
Natersoz/fix darwin vfo

### DIFF
--- a/not1mm/vfo.py
+++ b/not1mm/vfo.py
@@ -6,6 +6,7 @@ GPL V3
 Class: VfoWindow
 Purpose: Provide onscreen widget that interacts with DIY VFO knob and remote rig.
 """
+
 # pylint: disable=no-name-in-module, unused-import, no-member, invalid-name, logging-fstring-interpolation, c-extension-no-member
 
 # 115200 pico default speed


### PR DESCRIPTION
On Darwin, fix USB device rummaging stall

- Set the timeout for talking to serial ports to 1.0 seconds, not 1000 seconds.
- Trim the list of usb devices found and make it a set: `new_usb_devices`.
- Only attempt to access USB devices that are newly discovered to save time.
- Add logging.debug: USB device attempts.