### PR TITLE
Fix crash when there is a / in an edited macro

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -19,7 +19,6 @@ from logging.handlers import RotatingFileHandler
 import os
 import queue
 import socket
-import sh
 import sys
 import uuid
 
@@ -3453,14 +3452,19 @@ class MainWindow(QtWidgets.QMainWindow):
         old_string = self.edit_macro_dialog.old_macro
         new_string = f"{self.edit_macro_dialog.the_macro.text()}"
 
-        sed_string = f"s/{rm}|{fkey}|{old_label}|{old_string}/{rm}|{fkey}|{new_label}|{new_string}/g"
-
         macro_file = str(self.get_macro_filename())
 
         try:
-            sh.sed("-i", sed_string, macro_file)
-        except sh.ErrorReturnCode_2:
-            ...
+            with open(macro_file, 'r') as file:
+                content = file.read()
+            # Perform the replacement
+            new_content = content.replace(f"{rm}|{fkey}|{old_label}|{old_string}", f"{rm}|{fkey}|{new_label}|{new_string}")
+
+            # Write the modified content back to the file
+            with open(macro_file, 'w') as file:
+                file.write(new_content)
+        except Exception as e:
+            logger.error(f"Failed to update macro file: {macro_file}. Error: {e}")
 
     def process_macro(self, macro: str) -> str:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "rapidfuzz",
     "appdata",
     "adif_io",
-    "sh>=2.2.2",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
To reproduce:

 1. Launch not1mm
 2. R-click a macro button
 3. Add the macro text "{TX/RX}"

not1mm will crash with a coredump and this on the console:

```
Traceback (most recent call last):
  File "/home/chris/projects/not1mm/not1mm/__main__.py", line 3461, in edited_macro
    sh.sed("-i", sed_string, macro_file)
  File "/home/chris/.local/share/pipx/venvs/not1mm/lib/python3.12/site-packages/sh.py", line 1511, in __call__
    rc = self.__class__.RunningCommandCls(cmd, call_args, stdin, stdout, stderr)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/chris/.local/share/pipx/venvs/not1mm/lib/python3.12/site-packages/sh.py", line 734, in __init__
    self.wait()
  File "/home/chris/.local/share/pipx/venvs/not1mm/lib/python3.12/site-packages/sh.py", line 796, in wait
    self.handle_command_exit_code(exit_code)
  File "/home/chris/.local/share/pipx/venvs/not1mm/lib/python3.12/site-packages/sh.py", line 823, in handle_command_exit_code
    raise exc
sh.ErrorReturnCode_1: 
  RAN: /usr/bin/sed -i 's/S|F6|empty|/S|F6|empty|{TX/RX}/g' '/home/chris/.local/share/not1mm/Winter Field Day/ssbmacros.txt'
  STDOUT:
  STDERR:
/usr/bin/sed: -e expression #1, char 30: unknown option to `s'
Aborted (core dumped)
```

My solution is to eliminate the "sh.sed" call (and the newly added "sh" dependency), preferring a string-safe native implementation instead.

Also, instead of swallowing the exception (and somehow still crashing?), an error log is now generated if there was a failure to update the macro file. (Though the default logging level is set to CRITICAL, so it won't be seen unless debugging is enabled.)