### PR TITLE
Fix dupe indicator

### DIFF
--- a/not1mm/lib/database.py
+++ b/not1mm/lib/database.py
@@ -1109,8 +1109,6 @@ class DataBase:
             case _:
                 mode_test = "OTHER"
         # end match
-        debugline = f"{mode_test}"
-        logger.debug("%s", debugline)
  
         try:
             with sqlite3.connect(self.database) as conn:


### PR DESCRIPTION
Adds logic to the database module to simplify the mode being checked, in the same way that the logged modes are checked. This allows the DUPE indicator to appear as it should.