### PR TITLE
qso party 1st draft

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -3040,6 +3040,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if (
                 self.contest.name != "ICWC Medium Speed Test"
                 and self.contest.name != "RAEM"
+                and self.contest.name != "QSO_PARTY"
             ):
                 if self.current_mode in ("CW", "RTTY"):
                     self.sent.setText("599")
@@ -3049,6 +3050,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     self.receive.setText("59")
             else:
                 self.sent.setText("")
+                self.receive.setText("")
         self.callsign.clear()
         self.other_1.clear()
         self.other_2.clear()
@@ -4496,28 +4498,33 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def setmode(self, mode: str) -> None:
         """Call when the mode changes."""
-        if mode in ("CW", "CW-U", "CW-L", "CWR"):
+        if mode in ("CW", "CW-U", "CW-L", "CWR", "CW-R"):
             if self.current_mode != "CW":
                 self.current_mode = "CW"
-                self.sent.setText("599")
-                self.receive.setText("599")
-                self.read_macros()
                 if self.contest:
-                    if self.contest.name == "ICWC Medium Speed Test":
-                        self.contest.prefill(self)
+                    if self.contest.name != "QSO_PARTY":
+                        self.sent.setText("599")
+                        self.receive.setText("599")
+                        self.read_macros()
+                        if self.contest.name == "ICWC Medium Speed Test":
+                            self.contest.prefill(self)
             return
-        if mode == "SSB":
+
+        if mode in ("LSB", "USB", "SSB", "FM", "AM"):
             if self.current_mode != "SSB":
                 self.current_mode = "SSB"
-                self.sent.setText("59")
-                self.receive.setText("59")
+                if self.contest and self.contest.name != "QSO_PARTY":
+                    self.sent.setText("59")
+                    self.receive.setText("59")
                 self.read_macros()
             return
-        if mode in ("RTTY", "DIGI-U", "DIGI-L"):
+
+        if mode in ("FT8", "FT4", "RTTY", "PSK31", "FSK441", "MSK144", "JT65", "JT9", "Q65", "PKTUSB", "PKTLSB", "DIGI-U", "DIGI-L"):
             if self.current_mode != "RTTY":
                 self.current_mode = "RTTY"
-                self.sent.setText("599")
-                self.receive.setText("599")
+                if self.contest and self.contest.name != "QSO_PARTY":
+                    self.sent.setText("599")
+                    self.receive.setText("599")
                 self.read_macros()
 
     def get_opon(self) -> None:

--- a/not1mm/data/new_contest.ui
+++ b/not1mm/data/new_contest.ui
@@ -454,6 +454,11 @@
      </item>
      <item>
       <property name="text">
+       <string>QSO PARTY SN+County</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
        <string>RAEM</string>
       </property>
      </item>

--- a/not1mm/plugins/qso_party_sn+county.py
+++ b/not1mm/plugins/qso_party_sn+county.py
@@ -1,0 +1,578 @@
+"""
+Generic State QSO Party (S/N + County)
+-------------------------------------------------
+Status:	Active
+Geographic Focus:	US
+Participation:	Worldwide
+Mode:	CW, SSB, Digital
+Bands:	160, 80, 40, 20, 15, 10, 6, 2m, 70cm
+Classes:	Single Op (QRP/Low/High)
+            Multi-Single (QRP/Low/High)
+            Multi-Multi (QRP/Low/High)
+Max operating hours:	Varies
+Max power:	HP: >100 watts
+LP: 100 watts
+QRP: 5 watts
+Exchange:	Serial No. + County/State/Country
+Work stations:	Once per band per mode per location
+
+Scoring:
+Contact via phone: 1 point
+Contact via CW: 2 points
+Contact via digital: 2 points
+
+Multipliers: County, State, or Country (aside from US/Canada) across all modes/bands: 1 point
+
+Score Calculation:	Total score = total QSO points x total mults + bonus points
+E-mail logs to:	(varies)
+Mail logs to:	(varies)
+Find rules at:	(varies)
+Cabrillo name:	QSO_PARTY
+"""
+
+import datetime
+import logging
+import platform
+
+from pathlib import Path
+
+from PyQt6 import QtWidgets
+
+from not1mm.lib.plugin_common import gen_adif, imp_adif, get_points
+
+from not1mm.lib.version import __version__
+
+logger = logging.getLogger(__name__)
+
+EXCHANGE_HINT = "S/N County"
+
+name = "QSO_PARTY"
+cabrillo_name = "QSO_PARTY"
+mode = "BOTH"  # CW SSB BOTH RTTY
+
+columns = [
+    "YYYY-MM-DD HH:MM:SS",
+    "Call",
+    "Freq",
+    "Mode",
+    "SentNr",
+    "RcvNr",
+    "Exchange1",
+    "M1",
+    "PTS",
+    "Operator",
+]
+
+advance_on_space = [True, True, True, True, True]
+
+# 1 once per contest, 2 work each band, 3 each band/mode, 4 no dupe checking
+dupe_type = 4
+# allow for rovers
+
+def init_contest(self):
+    """setup plugin"""
+    set_tab_next(self)
+    set_tab_prev(self)
+    interface(self)
+    self.next_field = self.receive
+
+
+def interface(self):
+    """Setup user interface"""
+    self.field1.show()
+    self.field2.show()
+    self.field3.show()
+    self.field4.hide()
+    self.snt_label.setText("SentNR")
+    self.sent.setAccessibleName("SentNR")
+    self.rcv_label.setText("RcvNR")
+    self.receive.setAccessibleName("RcvNR")
+    self.other_label.setText("County/State/DX")
+    #self.sent.setText("")
+
+
+def reset_label(self):
+    """reset label after field cleared"""
+
+
+def set_tab_next(self):
+    """Set TAB Advances"""
+    self.tab_next = {
+        self.callsign: self.sent,
+        self.sent: self.receive,
+        self.receive: self.other_1,
+        self.other_1: self.callsign,
+    }
+
+
+def set_tab_prev(self):
+    """Set Shift-TAB Advances"""
+    self.tab_prev = {
+        self.callsign: self.other_1,
+        self.sent: self.callsign,
+        self.receive: self.sent,
+        self.other_1: self.receive,
+    }
+
+
+def set_contact_vars(self):
+    """Contest Specific"""
+    self.contact["SentNr"] = self.sent.text()
+    self.contact["NR"] = self.receive.text()
+    self.contact["Exchange1"] = self.other_1.text().upper()
+
+    self.contact["IsMultiplier1"] = 0
+    self.contact["IsMultiplier2"] = 0
+
+    county = self.contact.get("Exchange1", "").upper()
+    query = (
+        f"select count(*) as county_count from dxlog where "
+        f"Exchange1 = '{county}' "
+        f"and ContestNR = {self.pref.get('contest', '1')};"
+    )
+    result = self.database.exec_sql(query)
+    count = int(result.get("county_count", 0))
+    if count == 0:
+        self.contact["IsMultiplier1"] = 1
+
+
+def predupe(self):
+    """called after callsign entered"""
+
+
+def prefill(self):
+    """Fill SentNR"""
+    serial_nr = str(self.current_sn).zfill(3)
+    if serial_nr == "None":
+        serial_nr = "001"
+    if len(self.sent.text()) == 0:
+        self.sent.setText(serial_nr)
+
+
+def points(self):
+    """
+    Scoring:
+    Phone = 1 point
+    CW = 2 points
+    Digital = 2 points
+    """
+
+    if self.contact_is_dupe > 0:
+        return 0
+
+    qso_mode = self.contact.get("Mode","")
+    match qso_mode:
+        case "LSB"|"USB"|"SSB"|"FM"|"AM":
+            return 1
+        case "CW"|"CW-U"|"CW-L"|"CW-R"|"CWR":
+            return 2
+        case "FT8"|"FT4"|"RTTY"|"PSK31"|"FSK441"|"MSK144"|"JT65"|"JT9"|"Q65"|"PKTUSB"|"PKTLSB":
+            return 2 
+        case _:
+            return 0
+    # end match
+
+
+def show_mults(self, rtc=None):
+    """Return display string for mults"""
+    one = int(self.database.fetch_mult_count(1).get("count", 0))
+    two = int(self.database.fetch_mult_count(2).get("count", 0))
+    if rtc is not None:
+        return (two, one)
+
+    return one + two
+
+
+def show_qso(self):
+    """Return qso count"""
+    result = self.database.fetch_qso_count()
+    if result:
+        return int(result.get("qsos", 0))
+    return 0
+
+
+def calc_score(self):
+    """Return calculated score"""
+    result = self.database.fetch_points()
+    if result is not None:
+        score = result.get("Points", "0")
+        if score is None:
+            score = "0"
+        contest_points = int(score)
+        mults = show_mults(self)
+        return contest_points * mults
+    return 0
+
+
+def recalculate_mults(self):
+    """Recalculates multipliers after change in logged qso."""
+
+    all_contacts = self.database.fetch_all_contacts_asc()
+    for contact in all_contacts:
+
+        contact["IsMultiplier1"] = 0
+        contact["IsMultiplier2"] = 0
+
+        time_stamp = contact.get("TS", "")
+        county = contact.get("Exchange1", "")
+        query = (
+            f"select count(*) as county_count from dxlog where  TS < '{time_stamp}' "
+            f"and Exchange1 = '{county.upper()}' "
+            f"and ContestNR = {self.pref.get('contest', '1')};"
+        )
+        result = self.database.exec_sql(query)
+        count = int(result.get("county_count", 0))
+        if count == 0:
+            contact["IsMultiplier1"] = 1
+
+        self.database.change_contact(contact)
+
+    cmd = {}
+    cmd["cmd"] = "UPDATELOG"
+    if self.log_window:
+        self.log_window.msg_from_main(cmd)
+
+
+def adif(self):
+    """Call the generate ADIF function"""
+    gen_adif(self, cabrillo_name, "QSO_PARTY")
+
+
+def output_cabrillo_line(line_to_output, ending, file_descriptor, file_encoding):
+    """"""
+    print(
+        line_to_output.encode(file_encoding, errors="ignore").decode(),
+        end=ending,
+        file=file_descriptor,
+    )
+
+
+def cabrillo(self, file_encoding):
+    """Generates Cabrillo file. Maybe."""
+    # https://www.cqwpx.com/cabrillo.htm
+    logger.debug("******Cabrillo*****")
+    logger.debug("Station: %s", f"{self.station}")
+    logger.debug("Contest: %s", f"{self.contest_settings}")
+    now = datetime.datetime.now()
+    date_time = now.strftime("%Y-%m-%d_%H-%M-%S")
+    filename = (
+        str(Path.home())
+        + "/"
+        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+    )
+    logger.debug("%s", filename)
+    log = self.database.fetch_all_contacts_asc()
+    try:
+        with open(filename, "w", encoding=file_encoding, newline="") as file_descriptor:
+            output_cabrillo_line(
+                "START-OF-LOG: 3.0",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            output_cabrillo_line(
+                f"CREATED-BY: Not1MM v{__version__}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            output_cabrillo_line(
+                f"CONTEST: {cabrillo_name}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            if self.station.get("Club", ""):
+                output_cabrillo_line(
+                    f"CLUB: {self.station.get('Club', '').upper()}",
+                    "\r\n",
+                    file_descriptor,
+                    file_encoding,
+                )
+            output_cabrillo_line(
+                f"CALLSIGN: {self.station.get('Call','')}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            output_cabrillo_line(
+                f"LOCATION: {self.station.get('ARRLSection', '')}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            output_cabrillo_line(
+                f"CATEGORY-OPERATOR: {self.contest_settings.get('OperatorCategory','')}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            output_cabrillo_line(
+                f"CATEGORY-ASSISTED: {self.contest_settings.get('AssistedCategory','')}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            output_cabrillo_line(
+                f"CATEGORY-BAND: {self.contest_settings.get('BandCategory','')}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            mode = self.contest_settings.get("ModeCategory", "")
+            if mode in ["SSB+CW", "SSB+CW+DIGITAL"]:
+                mode = "MIXED"
+            output_cabrillo_line(
+                f"CATEGORY-MODE: {mode}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            output_cabrillo_line(
+                f"CATEGORY-TRANSMITTER: {self.contest_settings.get('TransmitterCategory','')}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            if self.contest_settings.get("OverlayCategory", "") != "N/A":
+                output_cabrillo_line(
+                    f"CATEGORY-OVERLAY: {self.contest_settings.get('OverlayCategory','')}",
+                    "\r\n",
+                    file_descriptor,
+                    file_encoding,
+                )
+            output_cabrillo_line(
+                f"GRID-LOCATOR: {self.station.get('GridSquare','')}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            output_cabrillo_line(
+                f"CATEGORY-POWER: {self.contest_settings.get('PowerCategory','')}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+
+            output_cabrillo_line(
+                f"CLAIMED-SCORE: {calc_score(self)}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            ops = ""
+            list_of_ops = self.database.get_ops()
+            for op in list_of_ops:
+                ops += f"{op.get('Operator', '')}, "
+            if self.station.get("Call", "") not in ops:
+                ops += f"@{self.station.get('Call','')}"
+            else:
+                ops = ops.rstrip(", ")
+            output_cabrillo_line(
+                f"OPERATORS: {ops}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            output_cabrillo_line(
+                f"NAME: {self.station.get('Name', '')}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            output_cabrillo_line(
+                f"ADDRESS: {self.station.get('Street1', '')}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            output_cabrillo_line(
+                f"ADDRESS-CITY: {self.station.get('City', '')}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            output_cabrillo_line(
+                f"ADDRESS-STATE-PROVINCE: {self.station.get('State', '')}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            output_cabrillo_line(
+                f"ADDRESS-POSTALCODE: {self.station.get('Zip', '')}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            output_cabrillo_line(
+                f"ADDRESS-COUNTRY: {self.station.get('Country', '')}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            output_cabrillo_line(
+                f"EMAIL: {self.station.get('Email', '')}",
+                "\r\n",
+                file_descriptor,
+                file_encoding,
+            )
+            for contact in log:
+                the_date_and_time = contact.get("TS", "")
+                themode = contact.get("Mode", "")
+                #if themode == "LSB" or themode == "USB":
+                #    themode = "PH"
+
+                match themode:
+                    case "LSB"|"USB"|"SSB"|"FM"|"AM":
+                        themode = "PH"
+                    case "CW"|"CW-U"|"CW-L"|"CWR"|"CW-R":
+                        themode = "CW"
+                    # dont simplify digital mode names
+                    #case "FT8"|"FT4"|"RTTY"|"PSK31"|"FSK441"|"MSK144"|"JT65"|"JT9"|"Q65"|"PKTUSB"|"PKTLSB":
+                    #    themode = "DI"
+                    #case _:
+                    #    mode_test = "OTHER"
+                # end match
+
+                frequency = str(round(contact.get("Freq", "0"))).rjust(5)
+
+                loggeddate = the_date_and_time[:10]
+                loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]
+                output_cabrillo_line(
+                    f"QSO: {frequency} {themode} {loggeddate} {loggedtime} "
+                    f"{contact.get('StationPrefix', '').ljust(13)} "
+                    f"{str(contact.get('SentNr', '')).ljust(6)} "
+                    f"{str(contact.get('RcvNr', '')).ljust(6)} "
+                    f"{contact.get('Call', '').ljust(13)} "
+                    f"{str(contact.get('County', '')).ljust(25)}",
+                    "\r\n",
+                    file_descriptor,
+                    file_encoding,
+                )
+            output_cabrillo_line("END-OF-LOG:", "\r\n", file_descriptor, file_encoding)
+        self.show_message_box(f"Cabrillo saved to: {filename}")
+    except IOError as exception:
+        logger.critical("cabrillo: IO error: %s, writing to %s", exception, filename)
+        self.show_message_box(f"Error saving Cabrillo: {exception} {filename}")
+        return
+
+
+def populate_history_info_line(self):
+    result = self.database.fetch_call_history(self.callsign.text())
+    if result:
+        self.history_info.setText(
+            f"{result.get('Call', '')}, {result.get('County', '')}"
+        )
+    else:
+        self.history_info.setText("")
+
+
+def check_call_history(self):
+    """"""
+    result = self.database.fetch_call_history(self.callsign.text())
+    print(f"{result=}")
+    if result:
+        self.history_info.setText(f"{result.get('County','')}")
+
+
+def process_esm(self, new_focused_widget=None, with_enter=False):
+    """ESM State Machine"""
+
+    # self.pref["run_state"]
+
+    # -----===== Assigned F-Keys =====-----
+    # self.esm_dict["CQ"]
+    # self.esm_dict["EXCH"]
+    # self.esm_dict["QRZ"]
+    # self.esm_dict["AGN"]
+    # self.esm_dict["HISCALL"]
+    # self.esm_dict["MYCALL"]
+    # self.esm_dict["QSOB4"]
+
+    # ----==== text fields ====----
+    # self.callsign
+    # self.sent
+    # self.receive
+    # self.other_1
+    # self.other_2
+
+    if new_focused_widget is not None:
+        self.current_widget = self.inputs_dict.get(new_focused_widget)
+
+    # print(f"checking esm {self.current_widget=} {with_enter=} {self.pref.get("run_state")=}")
+
+    for a_button in [
+        self.esm_dict["CQ"],
+        self.esm_dict["EXCH"],
+        self.esm_dict["QRZ"],
+        self.esm_dict["AGN"],
+        self.esm_dict["HISCALL"],
+        self.esm_dict["MYCALL"],
+        self.esm_dict["QSOB4"],
+    ]:
+        if a_button is not None:
+            self.restore_button_color(a_button)
+
+    buttons_to_send = []
+
+    if self.pref.get("run_state"):
+        if self.current_widget == "callsign":
+            if len(self.callsign.text()) < 3:
+                self.make_button_green(self.esm_dict["CQ"])
+                buttons_to_send.append(self.esm_dict["CQ"])
+            elif len(self.callsign.text()) > 2:
+                self.make_button_green(self.esm_dict["HISCALL"])
+                self.make_button_green(self.esm_dict["EXCH"])
+                buttons_to_send.append(self.esm_dict["HISCALL"])
+                buttons_to_send.append(self.esm_dict["EXCH"])
+
+        elif self.current_widget == "other_1":
+            if self.other_1.text() == "":
+                self.make_button_green(self.esm_dict["AGN"])
+                buttons_to_send.append(self.esm_dict["AGN"])
+            else:
+                self.make_button_green(self.esm_dict["QRZ"])
+                buttons_to_send.append(self.esm_dict["QRZ"])
+                buttons_to_send.append("LOGIT")
+
+        if with_enter is True and bool(len(buttons_to_send)):
+            for button in buttons_to_send:
+                if button:
+                    if button == "LOGIT":
+                        self.save_contact()
+                        continue
+                    self.process_function_key(button)
+    else:
+        if self.current_widget == "callsign":
+            if len(self.callsign.text()) > 2:
+                self.make_button_green(self.esm_dict["MYCALL"])
+                buttons_to_send.append(self.esm_dict["MYCALL"])
+
+        elif self.current_widget == "other_1":
+            if self.other_1.text() == "":
+                self.make_button_green(self.esm_dict["AGN"])
+                buttons_to_send.append(self.esm_dict["AGN"])
+            else:
+                self.make_button_green(self.esm_dict["EXCH"])
+                buttons_to_send.append(self.esm_dict["EXCH"])
+                buttons_to_send.append("LOGIT")
+
+        if with_enter is True and bool(len(buttons_to_send)):
+            for button in buttons_to_send:
+                if button:
+                    if button == "LOGIT":
+                        self.save_contact()
+                        continue
+                    self.process_function_key(button)
+
+
+def get_mults(self):
+    """Get mults for RTC XML"""
+    mults = {}
+    mults["country"], mults["state"] = show_mults(self, rtc=True)
+    return mults
+
+
+def just_points(self):
+    """Get points for RTC XML"""
+    return get_points(self)


### PR DESCRIPTION
First draft of a QSO Party plugin. This is intended to be generic, but is based on the rules for the Virginia QSO Party (guess where =I= live).

* This is specifically for QPs where the exchange is Serial Number and County/State/Country.

* There is no input validation for the County field. Sorry.

* Dupe checking is DISABLED to allow for roving stations (which may have the same callsign+band+mode, but a different county and still be valid). Note that there is no defined dupe-check routine to handle this case.

* Multipliers are one per county/state/country in the entire log, so same county in different modes or calls only nets the one multiplier. Not sure if this is how all of them work, but that's how the Virginia QP works.

* To get two serial numbers and one additional exchange field, I am re-purposing the RST fields in the UI to input serial numbers. This required a tweak to __main__.py to avoid pre-populating these fields with 59 or 599. This re-use seems to be working, but could have side effects.

* I have not tested this in a multi-multi environment (yet). 

* This is pre-ALPHA-quality code. Use at your own risk. That said, feedback is welcome!

* As the contest name (QSO PARTY SN+COUNTY) implies, there could also be QP plugins for other generic QP exchange types (maybe RST+County, or whatever). 