### PR TITLE
fix window close pref update

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -745,6 +745,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.bandmap_window.cluster_expire.connect(self.cluster_expire_updated)
         self.bandmap_window.message.connect(self.dockwidget_message)
         self.bandmap_window.callsignField.setText(self.current_op)
+        self.bandmap_window.bandmapwindow_closed.connect(self.launch_bandmap_window)
 
         self.show_splash_msg("Setting up CheckWindow.")
         self.check_window = CheckWindow(self.actionCheck_Window)
@@ -754,6 +755,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.check_window)
         self.check_window.hide()
         self.check_window.message.connect(self.dockwidget_message)
+        self.check_window.checkwindow_closed.connect(self.launch_check_window)
 
         self.show_splash_msg("Setting up RateWindow.")
         self.rate_window = RateWindow(self.actionRate_Window)
@@ -763,6 +765,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.rate_window)
         self.rate_window.hide()
         self.rate_window.message.connect(self.dockwidget_message)
+        self.rate_window.ratewindow_closed.connect(self.launch_rate_window)
 
         self.show_splash_msg("Setting up StatisticsWindow.")
         self.statistics_window = StatsWindow(self.actionStatistics)
@@ -774,6 +777,7 @@ class MainWindow(QtWidgets.QMainWindow):
         )
         self.statistics_window.hide()
         self.statistics_window.message.connect(self.dockwidget_message)
+        self.statistics_window.statisticswindow_closed.connect(self.launch_stats_window)
 
         self.show_splash_msg("Setting up GroupChatWindow.")
         self.chat_window = ChatWindow(self.actionGroup_Chat)
@@ -784,6 +788,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.chat_window.hide()
         self.chat_window.message.connect(self.dockwidget_message)
         self.chat_window.mycall = self.current_op
+        self.chat_window.chatwindow_closed.connect(self.launch_chat_window)
 
         self.show_splash_msg("Setting up DXCCWindow.")
         self.dxcc_window = DXCCWindow(self.actionDXCC)
@@ -793,6 +798,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.dxcc_window)
         self.dxcc_window.hide()
         self.dxcc_window.message.connect(self.dockwidget_message)
+        self.dxcc_window.dxcc_trackerwindow_closed.connect(self.launch_dxcc_window)
 
         self.show_splash_msg("Setting up ZoneWindow.")
         self.zone_window = ZoneWindow(self.actionZone)
@@ -802,6 +808,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.zone_window)
         self.zone_window.hide()
         self.zone_window.message.connect(self.dockwidget_message)
+        self.zone_window.zone_trackerwindow_closed.connect(self.launch_zone_window)
 
         self.show_splash_msg("Setting up RotatorWindow.")
         self.rotator_window = RotatorWindow(
@@ -817,6 +824,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.rotator_window.hide()
         self.rotator_window.message.connect(self.dockwidget_message)
         self.rotator_window.set_mygrid(self.station.get("GridSquare", ""))
+        self.rotator_window.rotatorwindow_closed.connect(self.launch_rotator_window)
 
         self.show_splash_msg("Setting up VFOWindow.")
         self.vfo_window = VfoWindow(self.actionVFO)
@@ -825,6 +833,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.vfo_window.setFeatures(dockfeatures)
         self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.vfo_window)
         self.vfo_window.hide()
+        self.vfo_window.vfowindow_closed.connect(self.launch_vfo)
 
         self.show_splash_msg("Setting up LogWindow.")
         self.log_window = LogWindow(self.actionLog_Window)
@@ -834,6 +843,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.addDockWidget(Qt.DockWidgetArea.TopDockWidgetArea, self.log_window)
         self.log_window.hide()
         self.log_window.message.connect(self.dockwidget_message)
+        self.log_window.logwindow_closed.connect(self.launch_log_window)
 
         self.clearinputs()
         self.show_splash_msg("Loading contest.")
@@ -2382,7 +2392,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.resolve_dirty_records()
 
     def launch_log_window(self) -> None:
-        """Launch the log window"""
+        """Launch or close the log window"""
         self.pref["logwindow"] = self.actionLog_Window.isChecked()
         self.write_preference()
         if self.actionLog_Window.isChecked():
@@ -2391,7 +2401,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.log_window.hide()
 
     def launch_bandmap_window(self) -> None:
-        """Launch the bandmap window"""
+        """Launch or close the bandmap window"""
         self.pref["bandmapwindow"] = self.actionBandmap.isChecked()
         self.write_preference()
         if self.actionBandmap.isChecked():
@@ -2402,7 +2412,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.bandmap_window.setActive(False)
 
     def launch_check_window(self) -> None:
-        """Launch the check window"""
+        """Launch or close the check window"""
         self.pref["checkwindow"] = self.actionCheck_Window.isChecked()
         self.write_preference()
         if self.actionCheck_Window.isChecked():
@@ -2413,7 +2423,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.check_window.setActive(False)
 
     def launch_rate_window(self) -> None:
-        """Launch the check window"""
+        """Launch or close the rate window"""
         self.pref["ratewindow"] = self.actionRate_Window.isChecked()
         self.write_preference()
         if self.actionRate_Window.isChecked():
@@ -2424,7 +2434,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.rate_window.setActive(False)
 
     def launch_stats_window(self) -> None:
-        """Launch the check window"""
+        """Launch or close the stats window"""
         self.pref["statisticswindow"] = self.actionStatistics.isChecked()
         self.write_preference()
         if self.actionStatistics.isChecked():
@@ -2436,7 +2446,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.statistics_window.setActive(False)
 
     def launch_dxcc_window(self) -> None:
-        """Launch the dxcc window"""
+        """Launch or close the dxcc window"""
         self.pref["dxccwindow"] = self.actionDXCC.isChecked()
         self.write_preference()
         if self.actionDXCC.isChecked():
@@ -2448,7 +2458,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.dxcc_window.setActive(False)
 
     def launch_zone_window(self) -> None:
-        """Launch the zone window"""
+        """Launch or close the zone window"""
         self.pref["zonewindow"] = self.actionZone.isChecked()
         self.write_preference()
         if self.actionZone.isChecked():
@@ -2460,7 +2470,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.zone_window.setActive(False)
 
     def launch_rotator_window(self) -> None:
-        """Launch the rotator window"""
+        """Launch or close the rotator window"""
         self.pref["rotatorwindow"] = self.actionRotator.isChecked()
         self.write_preference()
         if self.actionRotator.isChecked():
@@ -2471,7 +2481,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.rotator_window.setActive(False)
 
     def launch_vfo(self) -> None:
-        """Launch the VFO window"""
+        """Launch or close the VFO window"""
         self.pref["vfowindow"] = self.actionVFO.isChecked()
         self.write_preference()
         if self.actionVFO.isChecked():
@@ -2480,7 +2490,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.vfo_window.hide()
 
     def launch_chat_window(self) -> None:
-        """Launch the check window"""
+        """Launch or close the chat window"""
         self.pref["chatwindow"] = self.actionGroup_Chat.isChecked()
         self.write_preference()
         if self.actionGroup_Chat.isChecked():

--- a/not1mm/bandmap.py
+++ b/not1mm/bandmap.py
@@ -349,6 +349,7 @@ class BandMapWindow(QDockWidget):
     wwv_pattern = (
         r"(\d{2}-\w{3}-\d{4})\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(.*?)\s+<(\w+)>"
     )
+    bandmapwindow_closed = pyqtSignal()
 
     def __init__(self, action):
         super().__init__()
@@ -969,3 +970,5 @@ class BandMapWindow(QDockWidget):
         """Triggered when instance closes."""
         self.close_cluster()
         self.action.setChecked(False)
+        self.bandmapwindow_closed.emit()
+        _event.accept()

--- a/not1mm/chat.py
+++ b/not1mm/chat.py
@@ -22,6 +22,7 @@ class ChatWindow(QDockWidget):
     """The stats window. Shows something important."""
 
     message = pyqtSignal(dict)
+    chatwindow_closed = pyqtSignal()
     mycall = ""
     poll_time = datetime.datetime.now() + datetime.timedelta(milliseconds=1000)
 
@@ -92,7 +93,8 @@ class ChatWindow(QDockWidget):
 
     def closeEvent(self, event) -> None:
         self.action.setChecked(False)
-
+        self.chatwindow_closed.emit()
+        event.accept()
 
 if __name__ == "__main__":
     print("This is not a program.\nTry Again.")

--- a/not1mm/checkwindow.py
+++ b/not1mm/checkwindow.py
@@ -49,6 +49,7 @@ class CheckWindow(QDockWidget):
     dxcLayout: QVBoxLayout = None
     qsoLayout: QVBoxLayout = None
     background_colors_cache: Optional[BackgroundColors] = None
+    checkwindow_closed = pyqtSignal()
 
     masterScrollWidget: QWidget = None
 
@@ -274,6 +275,8 @@ class CheckWindow(QDockWidget):
 
     def closeEvent(self, event) -> None:
         self.action.setChecked(False)
+        self.checkwindow_closed.emit()
+        event.accept()
 
 
 class CallLabel(QLabel):

--- a/not1mm/dxcc_tracker.py
+++ b/not1mm/dxcc_tracker.py
@@ -32,6 +32,8 @@ class DXCCWindow(QDockWidget):
         6: "10m",
         7: "Total",
     }
+    dxcc_trackerwindow_closed = pyqtSignal()
+
 
     def __init__(self, action):
         super().__init__()
@@ -196,3 +198,5 @@ class DXCCWindow(QDockWidget):
 
     def closeEvent(self, event) -> None:
         self.action.setChecked(False)
+        self.dxcc_trackerwindow_closed.emit()
+        event.accept()

--- a/not1mm/logwindow.py
+++ b/not1mm/logwindow.py
@@ -93,6 +93,8 @@ class LogWindow(QDockWidget):
         21: "UUID",
         22: "Operator",
     }
+    logwindow_closed = pyqtSignal()       
+
 
     def __init__(self, action):
         super().__init__()
@@ -102,7 +104,7 @@ class LogWindow(QDockWidget):
         self.udp_fifo = queue.Queue()
         self.n1mm = None
         self.load_pref()
-
+ 
         self.dbname = fsutils.USER_DATA_PATH / self.pref.get(
             "current_database", "ham.db"
         )
@@ -1114,3 +1116,5 @@ class LogWindow(QDockWidget):
 
     def closeEvent(self, event) -> None:
         self.action.setChecked(False)
+        self.logwindow_closed.emit()
+        event.accept()

--- a/not1mm/ratewindow.py
+++ b/not1mm/ratewindow.py
@@ -33,6 +33,8 @@ class RateWindow(QDockWidget):
     dbname = None
     pref = {}
     poll_time = datetime.datetime.now() + datetime.timedelta(milliseconds=1000)
+    ratewindow_closed = pyqtSignal()
+
 
     def __init__(self, action):
         super().__init__()
@@ -46,6 +48,7 @@ class RateWindow(QDockWidget):
         self.database.current_contest = self.pref.get("contest", 0)
 
         uic.loadUi(fsutils.APP_DATA_PATH / "ratewindow.ui", self)
+
         self.timer = QTimer()
         self.timer.timeout.connect(self.get_run_and_total_qs)
         self.timer.start(10000)
@@ -194,3 +197,5 @@ class RateWindow(QDockWidget):
 
     def closeEvent(self, event) -> None:
         self.action.setChecked(False)
+        self.ratewindow_closed.emit()
+        event.accept()

--- a/not1mm/rotator.py
+++ b/not1mm/rotator.py
@@ -36,6 +36,7 @@ class RotatorWindow(QDockWidget):
     GLOBE_RADIUS: float = 100.0
     requestedAzimuthNeedle: QGraphicsPathItem | None = None
     antennaNeedle: QGraphicsPathItem | None = None
+    rotatorwindow_closed = pyqtSignal()
 
     def __init__(self, action, host: str = "127.0.0.1", port: int = 4533):
         super().__init__()
@@ -370,3 +371,5 @@ class RotatorWindow(QDockWidget):
 
     def closeEvent(self, event) -> None:
         self.action.setChecked(False)
+        self.rotatorwindow_closed.emit()
+        event.accept()

--- a/not1mm/statistics.py
+++ b/not1mm/statistics.py
@@ -24,6 +24,7 @@ class StatsWindow(QDockWidget):
     dbname = None
     pref = {}
     poll_time = datetime.datetime.now() + datetime.timedelta(milliseconds=1000)
+    statisticswindow_closed = pyqtSignal()
 
     def __init__(self, action):
         super().__init__()
@@ -201,6 +202,8 @@ class StatsWindow(QDockWidget):
 
     def closeEvent(self, event) -> None:
         self.action.setChecked(False)
+        self.statisticswindow_closed.emit()
+        event.accept()
 
 
 if __name__ == "__main__":

--- a/not1mm/vfo.py
+++ b/not1mm/vfo.py
@@ -21,7 +21,7 @@ import sys
 
 import serial
 from PyQt6 import QtWidgets, uic
-from PyQt6.QtCore import QTimer
+from PyQt6.QtCore import QTimer, pyqtSignal
 from PyQt6.QtWidgets import QDockWidget
 from PyQt6.QtGui import QPalette
 
@@ -41,6 +41,7 @@ class VfoWindow(QDockWidget):
     current_palette: QPalette | None = None
     device_reconnect: bool = False
     stale: datetime.datetime = datetime.datetime.now()
+    vfowindow_closed = pyqtSignal()
 
     def __init__(self, action):
         super().__init__()
@@ -297,3 +298,5 @@ class VfoWindow(QDockWidget):
 
     def closeEvent(self, event) -> None:
         self.action.setChecked(False)
+        self.vfowindow_closed.emit()
+        event.accept()

--- a/not1mm/zone_tracker.py
+++ b/not1mm/zone_tracker.py
@@ -30,6 +30,7 @@ class ZoneWindow(QDockWidget):
         6: "10m",
         7: "Total",
     }
+    zone_trackerwindow_closed = pyqtSignal()
 
     def __init__(self, action):
         super().__init__()
@@ -169,3 +170,5 @@ class ZoneWindow(QDockWidget):
 
     def closeEvent(self, event) -> None:
         self.action.setChecked(False)
+        self.zone_trackerwindow_closed.emit()
+        event.accept()


### PR DESCRIPTION
Fix update to pref(erences) when closing windows

I came across an odd bug where the state of secondary windows (bandmap, rate, stats, etc.) only gets updated to pref if the window is closed by un-checking its entry on the Window menu, but does NOT get saved to pref if the window is closed via the X button. This PR creates a signal for each window's close event. These signals are connected to the existing launch routines in __main__, which were already set up to handle window closures.