### PR TITLE
serial_devices.py: serial device discovery

### DIFF
--- a/not1mm/serial_devices.py
+++ b/not1mm/serial_devices.py
@@ -1,0 +1,151 @@
+"""Serial device discovery."""
+
+import logging
+import argparse
+from typing import Iterable
+
+import serial
+from serial.tools import list_ports
+from serial.tools.list_ports_common import ListPortInfo
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+VFOKNOB_BAUD_RATE = 115200
+
+PICO_VID = 0x2E8A
+PICO_PID = 0x0005
+
+COLUMNS_WIDTH = (40, 6, 6, 20, 20, 10)
+
+
+# -------------------------
+# USB discovery
+# -------------------------
+def probe(port: ListPortInfo) -> bool:
+    """Return True if this port is a vfoknob device."""
+    try:
+        with serial.Serial(port.device, VFOKNOB_BAUD_RATE, timeout=1.0) as ser:
+            ser.write(b"whatareyou\r")
+            response = ser.readline()
+            vfoknob_found = b"vfoknob" in response
+            logger.debug(
+                "Probing port '%s': response: '%s', found: %s",
+                port.device,
+                response,
+                vfoknob_found,
+            )
+            return vfoknob_found
+    except serial.SerialException as e:
+        logger.debug("Probing port '%s': exception: '%s'", port.device, e)
+        return False
+
+
+def serial_device_candidate_ports() -> Iterable[ListPortInfo]:
+    """
+    Yield (generator for) likely candidate USB serial  ports.
+    - Search for known VID/PID
+    - Fallback probe on likely USB serial devices
+    Yield for each serial device candidate.
+    """
+    for port in list_ports.comports():
+
+        # Prefer exact VID/PID match
+        if port.vid == PICO_VID and port.pid == PICO_PID:
+            yield port
+            continue
+
+        # Fallback heuristic
+        name = port.device.lower()
+        if any(s in name for s in ("usb", "acm", "modem")):
+            yield port
+
+
+def get_serial_device_ports() -> Iterable[ListPortInfo]:
+    """
+    Return a tuple of serial devices.
+    """
+    return (device for device in serial_device_candidate_ports())
+
+
+def find_vfoknob() -> ListPortInfo | None:
+    """
+    Discover the vfoknob USB device and if it probes correctly, return it.
+    If no vfoknob is found, return None.
+    """
+    for port in serial_device_candidate_ports():
+        if probe(port):
+            return port
+
+    return None
+
+
+# -------------------------
+# Printing helpers
+# -------------------------
+def _fmt(value: str, width: int) -> str:
+    """Return a column formatted string"""
+    return f"{value:{width}s}" if value else f"{'None':{width}s}"
+
+
+def _fmt_hex(value: int, width: int) -> str:
+    """Return a column formatted integer value as hex"""
+    hex_width = width - len("0x")
+    return f"0x{value:0{hex_width}X}" if value else f"{'None':{width}s}"
+
+
+def print_serial_device_header() -> None:
+    """Print the device header for a table"""
+    headers = ("Device", "VID", "PID", "Manufacturer", "Product", "Location")
+
+    print(*(f"{h:{w}s}" for h, w in zip(headers, COLUMNS_WIDTH)))
+    print(*(("=" * w) for w in COLUMNS_WIDTH))
+
+
+def print_serial_device(device: ListPortInfo) -> None:
+    """Print a Serial device row element"""
+    print(
+        f"{device.device:{COLUMNS_WIDTH[0]}s}",
+        _fmt_hex(device.vid, COLUMNS_WIDTH[1]),
+        _fmt_hex(device.pid, COLUMNS_WIDTH[2]),
+        _fmt(device.manufacturer, COLUMNS_WIDTH[3]),
+        _fmt(device.product, COLUMNS_WIDTH[4]),
+        _fmt(device.location, COLUMNS_WIDTH[5]),
+    )
+
+
+def discover_and_print_serial_devices() -> None:
+    """Discover and print serial devices"""
+    print_serial_device_header()
+    for port in list_ports.comports():
+        print_serial_device(port)
+
+
+def main() -> None:
+    """CLI for playing with serial devices"""
+    parser = argparse.ArgumentParser(description="USB device utilities")
+
+    parser.add_argument(
+        "-d", "--discover", action="store_true", help="List all serial devices"
+    )
+
+    parser.add_argument(
+        "-v", "--vfoknob", action="store_true", help="Discover vfoknob device"
+    )
+
+    args = parser.parse_args()
+
+    if args.discover:
+        discover_and_print_serial_devices()
+
+    if args.vfoknob:
+        device = find_vfoknob()
+
+        if device is None:
+            print("No vfoknob device found")
+        else:
+            print_serial_device_header()
+            print_serial_device(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/not1mm/vfo.py
+++ b/not1mm/vfo.py
@@ -20,6 +20,8 @@ from json import loads
 import sys
 
 import serial
+from serial.tools.list_ports_common import ListPortInfo
+
 from PyQt6 import QtWidgets, uic
 from PyQt6.QtCore import QTimer, pyqtSignal
 from PyQt6.QtWidgets import QDockWidget
@@ -27,6 +29,7 @@ from PyQt6.QtGui import QPalette
 
 import not1mm.fsutils as fsutils
 from not1mm.lib.cat_interface import CAT
+from not1mm import serial_devices
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -59,7 +62,7 @@ class VfoWindow(QDockWidget):
         self.poll_rig_timer.timeout.connect(self.poll_radio)
         self.poll_rig_timer.start(500)
         self.visibilityChanged.connect(self.window_state_changed)
-        self.usb_devices = set()
+        self.serial_ports = set()
 
     def load_pref(self) -> None:
         """
@@ -100,58 +103,26 @@ class VfoWindow(QDockWidget):
             )
             self.timer.start(100)
 
-    def discover_device(self) -> str | None:
-        """
-        Poll all serial devices looking for correct one.
+    def discover_device(self) -> ListPortInfo | None:
+        """Return the serial port device that is the vfoknob."""
+        serial_ports = serial_devices.get_serial_device_ports()
 
-        Rummage thru /dev/serial/by-id/ looking for Raspberry Picos
-        Ask each if it's a vfoknob.
-        Return the device ID if it is, or None if not found.
-        """
+        if serial_ports is None:  # or len(serial_ports) == 0:
+            return None
 
-        devices: list[str] | None = self.get_devices()
-        data: bytes | None = None
-        if devices is None:
-            return None
-        if sys.platform == "darwin":
-            usb_devices = set([device for device in devices if "usb" in device])
-            new_usb_devices = usb_devices - self.usb_devices
-            self.usb_devices = usb_devices
-            if len(new_usb_devices) == 0:
-                return None
-            logger.debug(f"new_usb_devices: {new_usb_devices}")
-            for device in new_usb_devices:
-                try:
-                    with serial.Serial("/dev/" + device, 115200) as ser:
-                        logger.debug(f"trying usb device: {device}")
-                        ser.timeout = 1.0
-                        ser.write(b"whatareyou\r")
-                        data = ser.readline()
-                except serial.serialutil.SerialException as ex:
-                    logger.debug(f"writing usb_device: {device} failed: {ex}")
-                    return None
-                if "vfoknob" in data.decode().strip():
-                    return "/dev/" + device
-            return None
-        for device in devices:
-            if "usb-Raspberry_Pi_Pico" in device:
-                try:
-                    with serial.Serial("/dev/serial/by-id/" + device, 115200) as ser:
-                        ser.timeout = 1000
-                        ser.write(b"whatareyou\r")
-                        data = ser.readline()
-                except serial.serialutil.SerialException:
-                    return None
-                if "vfoknob" in data.decode().strip():
-                    return "/dev/serial/by-id/" + device
+        serial_ports = set(serial_ports)
+        new_serial_ports = serial_ports - self.serial_ports
+        self.serial_ports = serial_ports
 
-    def get_devices(self) -> list[str] | None:
-        try:
-            if sys.platform != "darwin":
-                return os.listdir("/dev/serial/by-id")
-            return os.listdir("/dev/")
-        except FileNotFoundError:
+        if len(new_serial_ports) == 0:
             return None
+        logger.debug(f"new_serial_ports: {new_serial_ports}")
+
+        for port in new_serial_ports:
+            if serial_devices.probe(port):
+                logger.debug(f"vfoknob: found {port}")
+                return port
+
         return None
 
     def window_state_changed(self) -> None:
@@ -165,14 +136,15 @@ class VfoWindow(QDockWidget):
         Setup the device returned by discover_device()
         Or display message saying we didn't find one.
         """
-
         if not self.isVisible():
             return
 
-        device: str | None = self.discover_device()
+        device: ListPortInfo | None = self.discover_device()
         if device is not None:
             try:
-                self.pico: serial.Serial = serial.Serial(device, 115200)
+                self.pico: serial.Serial = serial.Serial(
+                    device.device, serial_devices.VFOKNOB_BAUD_RATE
+                )
                 self.pico.timeout = 100
                 self.lcdNumber.setStyleSheet("QLCDNumber { color: white; }")
                 self.device_reconnect: bool = True


### PR DESCRIPTION
Move serial device discovery logic
out of vfo.py into serial_devices.py.

This also makes the macos (darwin) functionality 
the same as Linux.