### PR TITLE
@mbridak Fix filename generation in Cabrillo logs to replace '/' with…

### DIFF
--- a/not1mm/plugins/10_10_fall_cw.py
+++ b/not1mm/plugins/10_10_fall_cw.py
@@ -181,7 +181,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/10_10_spring_cw.py
+++ b/not1mm/plugins/10_10_spring_cw.py
@@ -180,7 +180,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/10_10_summer_phone.py
+++ b/not1mm/plugins/10_10_summer_phone.py
@@ -184,7 +184,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/10_10_winter_phone.py
+++ b/not1mm/plugins/10_10_winter_phone.py
@@ -182,7 +182,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/agcw_qrp.py
+++ b/not1mm/plugins/agcw_qrp.py
@@ -420,7 +420,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/ari_40_80.py
+++ b/not1mm/plugins/ari_40_80.py
@@ -177,7 +177,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/ari_dx.py
+++ b/not1mm/plugins/ari_dx.py
@@ -259,7 +259,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/arrl_10m.py
+++ b/not1mm/plugins/arrl_10m.py
@@ -271,7 +271,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/arrl_160m.py
+++ b/not1mm/plugins/arrl_160m.py
@@ -274,7 +274,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/arrl_dx_cw.py
+++ b/not1mm/plugins/arrl_dx_cw.py
@@ -210,7 +210,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/arrl_dx_ssb.py
+++ b/not1mm/plugins/arrl_dx_ssb.py
@@ -210,7 +210,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/arrl_field_day.py
+++ b/not1mm/plugins/arrl_field_day.py
@@ -165,7 +165,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/arrl_rtty_ru.py
+++ b/not1mm/plugins/arrl_rtty_ru.py
@@ -235,7 +235,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/arrl_ss_cw.py
+++ b/not1mm/plugins/arrl_ss_cw.py
@@ -216,7 +216,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/arrl_ss_phone.py
+++ b/not1mm/plugins/arrl_ss_phone.py
@@ -197,7 +197,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/arrl_vhf_jan.py
+++ b/not1mm/plugins/arrl_vhf_jan.py
@@ -236,7 +236,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/arrl_vhf_jun.py
+++ b/not1mm/plugins/arrl_vhf_jun.py
@@ -204,7 +204,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/arrl_vhf_sep.py
+++ b/not1mm/plugins/arrl_vhf_sep.py
@@ -204,7 +204,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/canada_day.py
+++ b/not1mm/plugins/canada_day.py
@@ -232,7 +232,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/cq_160_cw.py
+++ b/not1mm/plugins/cq_160_cw.py
@@ -219,7 +219,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/cq_160_ssb.py
+++ b/not1mm/plugins/cq_160_ssb.py
@@ -219,7 +219,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/cq_wpx_cw.py
+++ b/not1mm/plugins/cq_wpx_cw.py
@@ -253,7 +253,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/cq_wpx_rtty.py
+++ b/not1mm/plugins/cq_wpx_rtty.py
@@ -252,7 +252,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/cq_wpx_ssb.py
+++ b/not1mm/plugins/cq_wpx_ssb.py
@@ -216,7 +216,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/cq_ww_cw.py
+++ b/not1mm/plugins/cq_ww_cw.py
@@ -233,7 +233,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/cq_ww_rtty.py
+++ b/not1mm/plugins/cq_ww_rtty.py
@@ -244,7 +244,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/cq_ww_ssb.py
+++ b/not1mm/plugins/cq_ww_ssb.py
@@ -232,7 +232,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/cwo.py
+++ b/not1mm/plugins/cwo.py
@@ -207,7 +207,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/cwt.py
+++ b/not1mm/plugins/cwt.py
@@ -206,7 +206,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/darc_vhf.py
+++ b/not1mm/plugins/darc_vhf.py
@@ -212,7 +212,7 @@ def edi(self):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.edi"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.edi"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()
@@ -531,7 +531,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/darc_xmas.py
+++ b/not1mm/plugins/darc_xmas.py
@@ -237,7 +237,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/ea_majistad_cw.py
+++ b/not1mm/plugins/ea_majistad_cw.py
@@ -299,7 +299,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/ea_majistad_ssb.py
+++ b/not1mm/plugins/ea_majistad_ssb.py
@@ -290,7 +290,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/ea_rtty.py
+++ b/not1mm/plugins/ea_rtty.py
@@ -303,7 +303,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/es_field_day.py
+++ b/not1mm/plugins/es_field_day.py
@@ -321,7 +321,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/es_ll_kv.py
+++ b/not1mm/plugins/es_ll_kv.py
@@ -291,7 +291,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/es_manual_key.py
+++ b/not1mm/plugins/es_manual_key.py
@@ -346,7 +346,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/es_open.py
+++ b/not1mm/plugins/es_open.py
@@ -290,7 +290,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/helvetia.py
+++ b/not1mm/plugins/helvetia.py
@@ -340,7 +340,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/iaru_fieldday_r1_cw.py
+++ b/not1mm/plugins/iaru_fieldday_r1_cw.py
@@ -243,7 +243,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/iaru_fieldday_r1_ssb.py
+++ b/not1mm/plugins/iaru_fieldday_r1_ssb.py
@@ -243,7 +243,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/iaru_hf.py
+++ b/not1mm/plugins/iaru_hf.py
@@ -216,7 +216,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/icwc_mst.py
+++ b/not1mm/plugins/icwc_mst.py
@@ -195,7 +195,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/jidx_cw.py
+++ b/not1mm/plugins/jidx_cw.py
@@ -224,7 +224,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     result = self.cty_lookup(self.station.get("Call", ""))

--- a/not1mm/plugins/jidx_ph.py
+++ b/not1mm/plugins/jidx_ph.py
@@ -193,7 +193,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     result = self.cty_lookup(self.station.get("Call", ""))

--- a/not1mm/plugins/k1usn_sst.py
+++ b/not1mm/plugins/k1usn_sst.py
@@ -186,7 +186,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call','').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call','').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/labre_rs_digi.py
+++ b/not1mm/plugins/labre_rs_digi.py
@@ -220,7 +220,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/lz-dx.py
+++ b/not1mm/plugins/lz-dx.py
@@ -244,7 +244,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/naqp_cw.py
+++ b/not1mm/plugins/naqp_cw.py
@@ -212,7 +212,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/naqp_rtty.py
+++ b/not1mm/plugins/naqp_rtty.py
@@ -213,7 +213,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/naqp_ssb.py
+++ b/not1mm/plugins/naqp_ssb.py
@@ -182,7 +182,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/pacc.py
+++ b/not1mm/plugins/pacc.py
@@ -240,7 +240,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/phone_weekly_test.py
+++ b/not1mm/plugins/phone_weekly_test.py
@@ -202,7 +202,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call','').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call','').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/qso_party_rst.py
+++ b/not1mm/plugins/qso_party_rst.py
@@ -69,6 +69,7 @@ advance_on_space = [True, True, True, True, True]
 dupe_type = 4
 # allow for rovers
 
+
 def init_contest(self):
     """setup plugin"""
     set_tab_next(self)
@@ -88,7 +89,7 @@ def interface(self):
     self.rcv_label.setText("Rcv RST")
     self.receive.setAccessibleName("Rcv")
     self.other_label.setText("County/State/DX")
-    #self.sent.setText("")
+    # self.sent.setText("")
 
 
 def reset_label(self):
@@ -142,18 +143,30 @@ def predupe(self):
 
 def prefill(self):
     """Fill Sent"""
-    qso_mode = self.contact.get("Mode","")
+    qso_mode = self.contact.get("Mode", "")
     match qso_mode:
-        case "LSB"|"USB"|"SSB"|"FM"|"AM":
-            self.sent.setText("599")
-            self.rcv.setText("599") 
-        case "CW"|"CW-U"|"CW-L"|"CW-R"|"CWR":
-            self.sent.setText("59")
-            self.rcv.setText("59")
-        case "FT8"|"FT4"|"RTTY"|"PSK31"|"FSK441"|"MSK144"|"JT65"|"JT9"|"Q65"|"PKTUSB"|"PKTLSB":
+        case "LSB" | "USB" | "SSB" | "FM" | "AM":
             self.sent.setText("599")
             self.rcv.setText("599")
-    # end match 
+        case "CW" | "CW-U" | "CW-L" | "CW-R" | "CWR":
+            self.sent.setText("59")
+            self.rcv.setText("59")
+        case (
+            "FT8"
+            | "FT4"
+            | "RTTY"
+            | "PSK31"
+            | "FSK441"
+            | "MSK144"
+            | "JT65"
+            | "JT9"
+            | "Q65"
+            | "PKTUSB"
+            | "PKTLSB"
+        ):
+            self.sent.setText("599")
+            self.rcv.setText("599")
+    # end match
 
 
 def points(self):
@@ -167,14 +180,26 @@ def points(self):
     if self.contact_is_dupe > 0:
         return 0
 
-    qso_mode = self.contact.get("Mode","")
+    qso_mode = self.contact.get("Mode", "")
     match qso_mode:
-        case "LSB"|"USB"|"SSB"|"FM"|"AM":
+        case "LSB" | "USB" | "SSB" | "FM" | "AM":
             return 1
-        case "CW"|"CW-U"|"CW-L"|"CW-R"|"CWR":
+        case "CW" | "CW-U" | "CW-L" | "CW-R" | "CWR":
             return 2
-        case "FT8"|"FT4"|"RTTY"|"PSK31"|"FSK441"|"MSK144"|"JT65"|"JT9"|"Q65"|"PKTUSB"|"PKTLSB":
-            return 2 
+        case (
+            "FT8"
+            | "FT4"
+            | "RTTY"
+            | "PSK31"
+            | "FSK441"
+            | "MSK144"
+            | "JT65"
+            | "JT9"
+            | "Q65"
+            | "PKTUSB"
+            | "PKTLSB"
+        ):
+            return 2
         case _:
             return 0
     # end match
@@ -261,7 +286,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()
@@ -422,29 +447,29 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
-                #if themode == "LSB" or themode == "USB":
+                # if themode == "LSB" or themode == "USB":
                 #    themode = "PH"
 
                 match themode:
-                    case "LSB"|"USB"|"SSB"|"FM"|"AM":
+                    case "LSB" | "USB" | "SSB" | "FM" | "AM":
                         themode = "PH"
-                    case "CW"|"CW-U"|"CW-L"|"CWR"|"CW-R":
+                    case "CW" | "CW-U" | "CW-L" | "CWR" | "CW-R":
                         themode = "CW"
                     # dont simplify digital mode names
-                    #case "FT8"|"FT4"|"RTTY"|"PSK31"|"FSK441"|"MSK144"|"JT65"|"JT9"|"Q65"|"PKTUSB"|"PKTLSB":
+                    # case "FT8"|"FT4"|"RTTY"|"PSK31"|"FSK441"|"MSK144"|"JT65"|"JT9"|"Q65"|"PKTUSB"|"PKTLSB":
                     #    themode = "DI"
-                    #case _:
+                    # case _:
                     #    mode_test = "OTHER"
                 # end match
 
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
-                if contact.get('RoverLocation', ''):
+                if contact.get("RoverLocation", ""):
                     location = f"{contact.get('RoverLocation').ljust(15).upper()}"
-                elif self.contest_settings.get('SentExchange', ''):
+                elif self.contest_settings.get("SentExchange", ""):
                     location = f"{self.contest_settings.get('SentExchange', '').ljust(15).upper()}"
                 else:
-                    # user did not provide any location info, 
+                    # user did not provide any location info,
                     # so insert a placeholder in cabrillo file
                     location = f"*              "
 
@@ -454,7 +479,7 @@ def cabrillo(self, file_encoding):
                     f"QSO: {frequency} {themode} {loggeddate} {loggedtime} "
                     f"{contact.get('StationPrefix', '').ljust(13)} "
                     f"{str(contact.get('SNT', '')).ljust(6)} "
-                    f"{location} " 
+                    f"{location} "
                     f"{contact.get('Call', '').ljust(13)} "
                     f"{str(contact.get('RCV', '')).ljust(6)} "
                     f"{str(contact.get('Exchange1', '')).ljust(15)}",

--- a/not1mm/plugins/qso_party_sn.py
+++ b/not1mm/plugins/qso_party_sn.py
@@ -69,6 +69,7 @@ advance_on_space = [True, True, True, True, True]
 dupe_type = 4
 # allow for rovers
 
+
 def init_contest(self):
     """setup plugin"""
     set_tab_next(self)
@@ -88,7 +89,7 @@ def interface(self):
     self.rcv_label.setText("RcvNR")
     self.receive.setAccessibleName("RcvNR")
     self.other_label.setText("County/State/DX")
-    #self.sent.setText("")
+    # self.sent.setText("")
 
 
 def reset_label(self):
@@ -160,14 +161,26 @@ def points(self):
     if self.contact_is_dupe > 0:
         return 0
 
-    qso_mode = self.contact.get("Mode","")
+    qso_mode = self.contact.get("Mode", "")
     match qso_mode:
-        case "LSB"|"USB"|"SSB"|"FM"|"AM":
+        case "LSB" | "USB" | "SSB" | "FM" | "AM":
             return 1
-        case "CW"|"CW-U"|"CW-L"|"CW-R"|"CWR":
+        case "CW" | "CW-U" | "CW-L" | "CW-R" | "CWR":
             return 2
-        case "FT8"|"FT4"|"RTTY"|"PSK31"|"FSK441"|"MSK144"|"JT65"|"JT9"|"Q65"|"PKTUSB"|"PKTLSB":
-            return 2 
+        case (
+            "FT8"
+            | "FT4"
+            | "RTTY"
+            | "PSK31"
+            | "FSK441"
+            | "MSK144"
+            | "JT65"
+            | "JT9"
+            | "Q65"
+            | "PKTUSB"
+            | "PKTLSB"
+        ):
+            return 2
         case _:
             return 0
     # end match
@@ -253,7 +266,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()
@@ -416,14 +429,14 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
 
                 match themode:
-                    case "LSB"|"USB"|"SSB"|"FM"|"AM":
+                    case "LSB" | "USB" | "SSB" | "FM" | "AM":
                         themode = "PH"
-                    case "CW"|"CW-U"|"CW-L"|"CWR"|"CW-R":
+                    case "CW" | "CW-U" | "CW-L" | "CWR" | "CW-R":
                         themode = "CW"
                     # dont simplify digital mode names
-                    #case "FT8"|"FT4"|"RTTY"|"PSK31"|"FSK441"|"MSK144"|"JT65"|"JT9"|"Q65"|"PKTUSB"|"PKTLSB":
+                    # case "FT8"|"FT4"|"RTTY"|"PSK31"|"FSK441"|"MSK144"|"JT65"|"JT9"|"Q65"|"PKTUSB"|"PKTLSB":
                     #    themode = "DI"
-                    #case _:
+                    # case _:
                     #    mode_test = "OTHER"
                 # end match
 
@@ -431,12 +444,12 @@ def cabrillo(self, file_encoding):
 
                 loggeddate = the_date_and_time[:10]
                 loggedtime = the_date_and_time[11:13] + the_date_and_time[14:16]
-                if contact.get('RoverLocation', ''):
+                if contact.get("RoverLocation", ""):
                     location = f"{contact.get('RoverLocation').ljust(15).upper()}"
-                elif self.contest_settings.get('SentExchange', ''):
+                elif self.contest_settings.get("SentExchange", ""):
                     location = f"{self.contest_settings.get('SentExchange', '').ljust(15).upper()}"
                 else:
-                    # user did not provide any location info, 
+                    # user did not provide any location info,
                     # so insert a placeholder in cabrillo file
                     location = f"*              "
 

--- a/not1mm/plugins/raem.py
+++ b/not1mm/plugins/raem.py
@@ -304,7 +304,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/ref_cw.py
+++ b/not1mm/plugins/ref_cw.py
@@ -345,7 +345,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/ref_ssb.py
+++ b/not1mm/plugins/ref_ssb.py
@@ -359,7 +359,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/rsgb_80m_cc.py
+++ b/not1mm/plugins/rsgb_80m_cc.py
@@ -189,7 +189,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/rsgb_iota.py
+++ b/not1mm/plugins/rsgb_iota.py
@@ -283,7 +283,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/sac_cw.py
+++ b/not1mm/plugins/sac_cw.py
@@ -274,7 +274,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/sac_ssb.py
+++ b/not1mm/plugins/sac_ssb.py
@@ -274,7 +274,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/spdx.py
+++ b/not1mm/plugins/spdx.py
@@ -216,7 +216,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/stew_perry_topband.py
+++ b/not1mm/plugins/stew_perry_topband.py
@@ -180,7 +180,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/ukeidx.py
+++ b/not1mm/plugins/ukeidx.py
@@ -275,7 +275,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/vhf_sprint.py
+++ b/not1mm/plugins/vhf_sprint.py
@@ -202,7 +202,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/wag.py
+++ b/not1mm/plugins/wag.py
@@ -302,7 +302,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/weekly_rtty.py
+++ b/not1mm/plugins/weekly_rtty.py
@@ -192,7 +192,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call','').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call','').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()

--- a/not1mm/plugins/winter_field_day.py
+++ b/not1mm/plugins/winter_field_day.py
@@ -174,7 +174,7 @@ def cabrillo(self, file_encoding):
     filename = (
         str(Path.home())
         + "/"
-        + f"{self.station.get('Call', '').upper()}_{cabrillo_name}_{date_time}.log"
+        + f"{self.station.get('Call', '').upper().replace('/','-')}_{cabrillo_name}_{date_time}.log"
     )
     logger.debug("%s", filename)
     log = self.database.fetch_all_contacts_asc()


### PR DESCRIPTION
… '-' in station call signs

Updated multiple plugin files to ensure that the station call sign used in the filename for Cabrillo logs replaces any '/' characters with '-' to prevent issues with file paths.
