### PR TITLE
PgUp/PgDown change CW speed by 2 wpm

### DIFF
--- a/not1mm.tex
+++ b/not1mm.tex
@@ -533,9 +533,9 @@ Next, a request is made to qrz.com\index{QRZ} for the grid square of the callsig
     \hline
     Esc & Stop the cwdaemon\index{cwdaemon} from sending Morse characters.\\
     \hline
-    PgUp & Increase the CW sending speed. \\
+    PgUp & Increase the CW sending speed by 2 wpm. \\
     \hline
-    PgDown & Decrease the CW sending speed. \\
+    PgDown & Decrease the CW sending speed by 2 wpm. \\
     \hline
     Arrow-Up & Jump to the next spot above the current VFO\index{VFO} cursor in the bandmap window (CAT\index{CAT} Required). \\
     \hline

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -2829,7 +2829,7 @@ class MainWindow(QtWidgets.QMainWindow):
             and modifier != Qt.KeyboardModifier.ControlModifier
         ):
             if self.cw is not None:
-                self.cw.speed += 1
+                self.cw.speed += 2
                 self.cw_speed.setValue(self.cw.speed)
                 if self.cw.servertype == 1:
                     self.cw.sendcw(f"\x1b2{self.cw.speed}")
@@ -2841,7 +2841,7 @@ class MainWindow(QtWidgets.QMainWindow):
             and modifier != Qt.KeyboardModifier.ControlModifier
         ):
             if self.cw is not None:
-                self.cw.speed -= 1
+                self.cw.speed -= 2
                 self.cw_speed.setValue(self.cw.speed)
                 if self.cw.servertype == 1:
                     self.cw.sendcw(f"\x1b2{self.cw.speed}")

--- a/not1mm/data/not1mm.html
+++ b/not1mm/data/not1mm.html
@@ -412,11 +412,11 @@ While I&#39;m not watching TV, Right vs Left political &#39;News&#39; programs, 
 </tr>
 <tr>
 <td>[PgUp]</td>
-<td>Increases the cw sending speed.</td>
+<td>Increases the cw sending speed by 2 wpm.</td>
 </tr>
 <tr>
 <td>[PgDown]</td>
-<td>Decreases the cw sending speed.</td>
+<td>Decreases the cw sending speed by 2 wpm.</td>
 </tr>
 <tr>
 <td>[Arrow-Up]</td>


### PR DESCRIPTION
If a station is calling much slower than the current speed, it's a long way from 30 to 22 wpm if the stepping is only 1 wpm. Steps of 2 wpm are still fine-grained enough to adjust to any speed desired, but make bigger jumps feasible in practice. (This is also the default (and only) stepping of tlf.)