### PR TITLE
Support rotating to long-path direction

### DIFF
--- a/not1mm.tex
+++ b/not1mm.tex
@@ -701,7 +701,7 @@ Once a call is entered and the bearing to contact is calculated you will see a n
 
 At this time you can click on the 'Move' button to point your antenna at the contact. A list of other buttons follows below.
 
-\textbf{Move}: Rotates the antenna at the target.
+\textbf{Move}: Rotates the antenna at the target. Right-click to rotate to long-path (opposite) direction.
 
 \textbf{Stop}: Stops the current movement.
 

--- a/not1mm/data/rotator.ui
+++ b/not1mm/data/rotator.ui
@@ -60,6 +60,9 @@
         <property name="focusPolicy">
          <enum>Qt::FocusPolicy::NoFocus</enum>
         </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Left-click to rotate antenna towards selected station. Right-click to rotate to long-path direction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
         <property name="styleSheet">
          <string notr="true">padding-left: 10px; padding-top: 5px; padding-right: 10px; padding-bottom: 5px;</string>
         </property>

--- a/not1mm/rotator.py
+++ b/not1mm/rotator.py
@@ -53,7 +53,9 @@ class RotatorWindow(QDockWidget):
         self.south_button.clicked.connect(self.set_south_azimuth)
         self.east_button.clicked.connect(self.set_east_azimuth)
         self.west_button.clicked.connect(self.set_west_azimuth)
-        self.move_button.clicked.connect(self.the_eye_of_sauron)
+        self.move_button.clicked.connect(self.the_eye_of_sauron) # left-click
+        self.move_button.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.move_button.customContextMenuRequested.connect(self.rotate_long_path) # right-click
         self.stop_button.clicked.connect(lambda x: self.rotator.send_command("S"))
         self.park_button.clicked.connect(lambda x: self.rotator.send_command("K"))
         self.redrawMap()
@@ -128,8 +130,13 @@ class RotatorWindow(QDockWidget):
 
     def the_eye_of_sauron(self) -> None:
         """Move the antennas azimuth to match the contacts."""
-        if self.rotator.connected:
+        if self.rotator.connected and self.requestedAzimuth is not None:
             self.rotator.set_position(self.requestedAzimuth)
+
+    def rotate_long_path(self) -> None:
+        """Move the antennas azimuth to long-path direction."""
+        if self.rotator.connected and self.requestedAzimuth is not None:
+            self.rotator.set_position((self.requestedAzimuth + 180.0) % 360.0)
 
     def redrawMap(self) -> None:
         """"""


### PR DESCRIPTION
Right-click on "Move" button to rotate to long-path direction. Sometimes the long path is better. Also, some antennas point backwards on some bands (for example the Maria Maluca tribander).

Also guard the_eye_of_sauron() and rotate_long_path() against being called with a None requestedAzimuth, before the first call sign was entered.