### PR TITLE
Make ESC (the key and the button) stop CW and the rotator

### DIFF
--- a/not1mm.tex
+++ b/not1mm.tex
@@ -701,7 +701,7 @@ Once a call is entered and the bearing to contact is calculated you will see a n
 
 At this time you can click on the 'Move' button to point your antenna at the contact. A list of other buttons follows below.
 
-\textbf{Move}: Rotates the antenna at the target.
+\textbf{Move}: Rotates the antenna at the target. Right-click to rotate to long-path (opposite) direction.
 
 \textbf{Stop}: Stops the current movement.
 

--- a/not1mm.tex
+++ b/not1mm.tex
@@ -531,7 +531,7 @@ Next, a request is made to qrz.com\index{QRZ} for the grid square of the callsig
     \hline
     \textbf{Key} & \textbf{Result} \\
     \hline
-    Esc & Stop the cwdaemon\index{cwdaemon} from sending Morse characters.\\
+    Esc & Stop CW sending and antenna rotation.\\
     \hline
     PgUp & Increase the CW sending speed. \\
     \hline

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -409,7 +409,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.log_it.clicked.connect(self.save_contact)
         self.wipe.clicked.connect(self.clearinputs)
-        self.esc_stop.clicked.connect(self.stop_cw)
+        self.esc_stop.clicked.connect(self.stop_all)
         self.mark.clicked.connect(self.mark_spot)
         self.spot_it.clicked.connect(self.spot_dx)
 
@@ -2319,7 +2319,7 @@ class MainWindow(QtWidgets.QMainWindow):
         """
 
         self.show_message_box(
-            "[ESC]\tStops cwdaemon from sending Morse.\n"
+            "[ESC]\tStops CW sending and antenna rotation.\n"
             "[PgUp]\tIncreases the cw sending speed.\n"
             "[PgDown]\tDecreases the cw sending speed.\n"
             "[Arrow-Up] Jump to the next spot above the current VFO cursor\n"
@@ -2657,6 +2657,12 @@ class MainWindow(QtWidgets.QMainWindow):
                     if self.rig_control.interface == "rigctld":
                         self.rig_control.cat.stopcwrigctl()
 
+    def stop_all(self) -> None:
+        """Stop CW and rotator."""
+        self.stop_cw()
+        if self.rotator_window is not None:
+            self.rotator_window.stop()
+
     def mark_spot(self) -> None:
         """"""
         freq = self.radio_state.get("vfoa")
@@ -2811,7 +2817,7 @@ class MainWindow(QtWidgets.QMainWindow):
             event.key() == Qt.Key.Key_Escape
             and modifier != Qt.KeyboardModifier.ControlModifier
         ):
-            self.stop_cw()
+            self.stop_all()
         if event.key() == Qt.Key.Key_Up:
             cmd = {}
             cmd["cmd"] = "PREVSPOT"

--- a/not1mm/data/rotator.ui
+++ b/not1mm/data/rotator.ui
@@ -60,6 +60,9 @@
         <property name="focusPolicy">
          <enum>Qt::FocusPolicy::NoFocus</enum>
         </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Left-click to rotate antenna towards selected station. Right-click to rotate to long-path direction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
         <property name="styleSheet">
          <string notr="true">padding-left: 10px; padding-top: 5px; padding-right: 10px; padding-bottom: 5px;</string>
         </property>

--- a/not1mm/rotator.py
+++ b/not1mm/rotator.py
@@ -53,7 +53,9 @@ class RotatorWindow(QDockWidget):
         self.south_button.clicked.connect(self.set_south_azimuth)
         self.east_button.clicked.connect(self.set_east_azimuth)
         self.west_button.clicked.connect(self.set_west_azimuth)
-        self.move_button.clicked.connect(self.the_eye_of_sauron)
+        self.move_button.clicked.connect(self.the_eye_of_sauron) # left-click
+        self.move_button.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.move_button.customContextMenuRequested.connect(self.rotate_long_path) # right-click
         self.stop_button.clicked.connect(lambda x: self.rotator.send_command("S"))
         self.park_button.clicked.connect(lambda x: self.rotator.send_command("K"))
         self.redrawMap()
@@ -128,8 +130,13 @@ class RotatorWindow(QDockWidget):
 
     def the_eye_of_sauron(self) -> None:
         """Move the antennas azimuth to match the contacts."""
-        if self.rotator.connected:
+        if self.rotator.connected and self.requestedAzimuth is not None:
             self.rotator.set_position(self.requestedAzimuth)
+
+    def rotate_long_path(self) -> None:
+        """Move the antennas azimuth to long-path direction."""
+        if self.rotator.connected and self.requestedAzimuth is not None:
+            self.rotator.set_position((self.requestedAzimuth + 180.0) % 360.0)
 
     def redrawMap(self) -> None:
         """"""

--- a/not1mm/rotator.py
+++ b/not1mm/rotator.py
@@ -56,7 +56,7 @@ class RotatorWindow(QDockWidget):
         self.move_button.clicked.connect(self.the_eye_of_sauron) # left-click
         self.move_button.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.move_button.customContextMenuRequested.connect(self.rotate_long_path) # right-click
-        self.stop_button.clicked.connect(lambda x: self.rotator.send_command("S"))
+        self.stop_button.clicked.connect(self.stop)
         self.park_button.clicked.connect(lambda x: self.rotator.send_command("K"))
         self.redrawMap()
         self.rotator: RotatorInterface = RotatorInterface(self.host, self.port)
@@ -137,6 +137,10 @@ class RotatorWindow(QDockWidget):
         """Move the antennas azimuth to long-path direction."""
         if self.rotator.connected and self.requestedAzimuth is not None:
             self.rotator.set_position((self.requestedAzimuth + 180.0) % 360.0)
+
+    def stop(self) -> None:
+        """Stop the rotator."""
+        self.rotator.send_command("S")
 
     def redrawMap(self) -> None:
         """"""


### PR DESCRIPTION
If something goes wrong with the rotator, hitting ESC is much faster than grabbing the mouse and searching for the "Stop" button in the Rotator widget.

PR based on #533 to avoid merge conflicts.