### PR TITLE
Prevent rotator, dxcc and zone windows from stealing focus

### DIFF
--- a/not1mm/data/dxcc_tracker.ui
+++ b/not1mm/data/dxcc_tracker.ui
@@ -17,6 +17,9 @@
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
      <widget class="QCheckBox" name="scrolltoCheckBox">
+      <property name="focusPolicy">
+       <enum>Qt::FocusPolicy::NoFocus</enum>
+      </property>
       <property name="text">
        <string>Scroll to</string>
       </property>
@@ -28,7 +31,7 @@
     <item>
      <widget class="QTableWidget" name="dxcc_table">
       <property name="focusPolicy">
-       <enum>Qt::NoFocus</enum>
+       <enum>Qt::FocusPolicy::NoFocus</enum>
       </property>
      </widget>
     </item>

--- a/not1mm/data/rotator.ui
+++ b/not1mm/data/rotator.ui
@@ -99,7 +99,7 @@
     <item>
      <widget class="QGraphicsView" name="compassView">
       <property name="focusPolicy">
-       <enum>Qt::FocusPolicy::ClickFocus</enum>
+       <enum>Qt::FocusPolicy::NoFocus</enum>
       </property>
       <property name="frameShape">
        <enum>QFrame::Shape::NoFrame</enum>

--- a/not1mm/data/zone_tracker.ui
+++ b/not1mm/data/zone_tracker.ui
@@ -17,6 +17,9 @@
    <layout class="QGridLayout" name="gridLayout">
     <item row="0" column="0">
      <widget class="QCheckBox" name="scrolltoCheckBox">
+      <property name="focusPolicy">
+       <enum>Qt::FocusPolicy::NoFocus</enum>
+      </property>
       <property name="text">
        <string>Scroll to</string>
       </property>
@@ -42,6 +45,9 @@
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="QRadioButton" name="cqButton">
+         <property name="focusPolicy">
+          <enum>Qt::FocusPolicy::NoFocus</enum>
+         </property>
          <property name="text">
           <string>CQ</string>
          </property>
@@ -52,6 +58,9 @@
        </item>
        <item>
         <widget class="QRadioButton" name="ituButton">
+         <property name="focusPolicy">
+          <enum>Qt::FocusPolicy::NoFocus</enum>
+         </property>
          <property name="text">
           <string>ITU</string>
          </property>
@@ -63,7 +72,7 @@
     <item row="1" column="0" colspan="2">
      <widget class="QTableWidget" name="zone_table">
       <property name="focusPolicy">
-       <enum>Qt::NoFocus</enum>
+       <enum>Qt::FocusPolicy::NoFocus</enum>
       </property>
      </widget>
     </item>


### PR DESCRIPTION
Clicking the rotator map would steal the focus. When the DXCC or zone check windows were open, hitting Tab would jump to the checkbox in there with no keyboard way to get back.