### PR TITLE
Sort bands in Stats window

### DIFF
--- a/not1mm/statistics.py
+++ b/not1mm/statistics.py
@@ -107,7 +107,7 @@ class StatsWindow(QDockWidget):
         self.tableWidget.setSelectionMode(
             QtWidgets.QAbstractItemView.SelectionMode.NoSelection
         )
-        query = f"select DISTINCT(Band) as band from DXLOG where ContestNR = {self.database.current_contest};"
+        query = f"select DISTINCT(Band) as band from DXLOG where ContestNR = {self.database.current_contest} ORDER BY band DESC;"
         result = self.database.exec_sql_mult(query)
         self.tableWidget.setRowCount(len(result) + 1)
         row = 0


### PR DESCRIPTION
Before, bands would appear in the order they were first worked. If that's not any serial order, the list looks weird on screen. Sort the bands so the high bands appear first ("high" on screen).

Without patch:
<img width="289" height="200" alt="Bildschirmfoto vom 2026-04-25 21-57-46" src="https://github.com/user-attachments/assets/395dd9fa-a675-4e05-ac01-e48693094b52" />

With patch:
<img width="289" height="200" alt="Bildschirmfoto vom 2026-04-25 21-53-57" src="https://github.com/user-attachments/assets/14c24cc1-d925-4745-843b-70f6806ea4cd" />
