### PR TITLE
Color callsign red on dupes

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -1101,8 +1101,10 @@ class MainWindow(QtWidgets.QMainWindow):
                         self.contact_is_dupe = result
                         if result is not False:
                             self.dupe_indicator.show()
+                            self.callsign.setStyleSheet("color: red;")
                         else:
                             self.dupe_indicator.hide()
+                            self.callsign.setStyleSheet("")
 
                     if json_data.get("subject") == "POST":
                         self.remove_confirmed_commands(json_data)
@@ -3039,6 +3041,7 @@ class MainWindow(QtWidgets.QMainWindow):
         """
 
         self.dupe_indicator.hide()
+        self.callsign.setStyleSheet("")
         self.contact = self.database.empty_contact.copy()
         self.heading_distance.setText("")
         self.history_info.setText("")
@@ -4282,6 +4285,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.check_window:
             self.check_window.msg_from_main(cmd)
         self.dupe_indicator.hide()
+        self.callsign.setStyleSheet("")
         if len(stripped_text) >= 3:
             self.check_callsign(stripped_text)
             self.check_dupe(stripped_text)
@@ -4541,8 +4545,10 @@ class MainWindow(QtWidgets.QMainWindow):
             self.contact_is_dupe = result.get("isdupe", False)
             if bool(result.get("isdupe", False)) is not False:
                 self.dupe_indicator.show()
+                self.callsign.setStyleSheet("color: red;")
             else:
                 self.dupe_indicator.hide()
+                self.callsign.setStyleSheet("")
 
     def setmode(self, mode: str) -> None:
         """Call when the mode changes."""


### PR DESCRIPTION
With so many elements on the screen, the big "Dupe" warning is still easy to miss when the eyes are only on the callsign field. This is especially true when grabbing a spot from the bandmap which might be far away, so the "Dupe" warning appearing might be missed.

Color the callsign text red, then it's really visible. (N1MM does that as well.)

<img width="396" height="151" alt="Bildschirmfoto vom 2026-04-25 22-20-38" src="https://github.com/user-attachments/assets/b23f7dd0-ad62-480a-9d7c-e43c9a6f302f" />
