### PR TITLE
Fix space between adjacent macros

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -3739,11 +3739,9 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         if self.cw:
             if self.pref.get("cwtype") == 3 and self.rig_control is not None:
-                self.rig_control.sendcw(self.process_macro(function_key.toolTip()))
-                self.rig_control.sendcw(" ")
+                self.rig_control.sendcw(self.process_macro(function_key.toolTip()) + " ")
                 return
-            self.cw.sendcw(self.process_macro(function_key.toolTip()))
-            self.cw.sendcw(" ")
+            self.cw.sendcw(self.process_macro(function_key.toolTip()) + " ")
             if self.pref.get("cwtype") == 2:
                 # I put this back in 'cause no one will know to update winkeyerserial.
                 time.sleep(0.2)

--- a/not1mm/lib/cat_interface.py
+++ b/not1mm/lib/cat_interface.py
@@ -202,7 +202,7 @@ class CAT:
             try:
                 self.online = True
                 if hasattr(self.rigctrlsocket, "send"):
-                    self.rigctrlsocket.send(bytes(f"b{texttosend}\n", "utf-8"))
+                    self.rigctrlsocket.send(bytes(f"b {texttosend}\n", "utf-8"))
                 else:
                     self.rigctrlsocket = None
                     self.online = False


### PR DESCRIPTION
When several macros were sent using CAT keying, the space between them was missing. The Run F2 F3 sequence was sent as "DL0ABC5NN 001".

The problem is that rigctl is not recognizing "b " as a command to send a space, it has to be "b  ". So add a space after "b" in the rigctrlsocket command, just like the other commands do.

Also, instead of using two commands to send the macro and a space, just append the space to the message, saving one extra command.

Either of these two changes is enough to fix the problem, but since both changes make sense, do them both.