### PR TITLE
Add worked stations to bandmap and teach it about bands

### DIFF
--- a/not1mm.tex
+++ b/not1mm.tex
@@ -552,9 +552,9 @@ Next, a request is made to qrz.com\index{QRZ} for the grid square of the callsig
     \hline
     F1-F12 & Send (CW/RTTY/Voice) macros. \\
     \hline
-    CTRL-S & Spot Callsign to the cluster. \\
+    CTRL-S & Spot callsign to the cluster. \\
     \hline
-    CTRL-M & Highlight Callsign in the bandmap window. \\
+    CTRL-M & Mark callsign in the bandmap window. \\
     \hline
     CTRL-G & Tune to a spot matching partial text in the callsign entry field (CAT\index{CAT} Required). \\
     \hline
@@ -610,7 +610,7 @@ You cannot directly edit the multiplier\index{multiplier} status of a contact. S
 
 \textbf{Window >> Bandmap}`
 
-The bandmap displays spots drawn from the Cluster node specified in the Configuration Settings. Enter your callsign and press the Connect button. When CAT\index{CAT} is enabled, the bandmap\index{bandmap} will track with the VFO\index{VFO}. This is still a work in progress. 
+The bandmap displays worked stations and spots drawn from the Cluster node specified in the Configuration Settings. Enter your callsign and press the Connect button. When CAT\index{CAT} is enabled, the bandmap\index{bandmap} will track with the VFO\index{VFO}. This is still a work in progress.
 
 \vspace{0.5cm}
 \includegraphics[width=0.5\linewidth]{pic/bandmap.png}
@@ -622,7 +622,7 @@ The VFO\index{VFO} frequency is indicated with a small green triangle above the 
 \includegraphics[width=0.5\linewidth]{pic/VFO_and_bandwidth_markers.png}
 \vspace{0.5cm}
 
-Clicking on a spot\index{spot} sets the VFO\index{VFO} and populates the callsign field. Previously worked callsigns are displayed in red. Callsigns marked with CTRL-M are highlighted in yellow. A small icon after the callsign indicates the mode as follows:\\
+Clicking on a spot\index{spot} sets the VFO\index{VFO} and populates the callsign field. Previously worked callsigns are displayed in gray. Callsigns marked with CTRL-M are highlighted in yellow. A small icon after the callsign indicates the mode as follows:\\
 
 Primary Modes:
 \begin{itemize}

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -410,7 +410,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.log_it.clicked.connect(self.save_contact)
         self.wipe.clicked.connect(self.clearinputs)
         self.esc_stop.clicked.connect(self.stop_all)
-        self.mark.clicked.connect(self.mark_spot)
+        self.mark.clicked.connect(lambda: self.mark_spot(f"{self.current_mode} MARKED"))
         self.spot_it.clicked.connect(self.spot_dx)
 
         self.F1.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
@@ -2665,7 +2665,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.rotator_window is not None:
             self.rotator_window.stop()
 
-    def mark_spot(self) -> None:
+    def mark_spot(self, comment="") -> None:
         """"""
         freq = self.radio_state.get("vfoa")
         dx = self.callsign.text()
@@ -2674,6 +2674,7 @@ class MainWindow(QtWidgets.QMainWindow):
             cmd["cmd"] = "MARKDX"
             cmd["dx"] = dx
             cmd["freq"] = float(int(freq) / 1000)
+            cmd["comment"] = comment
             if self.bandmap_window:
                 self.bandmap_window.msg_from_main(cmd)
 
@@ -2773,15 +2774,7 @@ class MainWindow(QtWidgets.QMainWindow):
             event.key() == Qt.Key.Key_M
             and modifier == Qt.KeyboardModifier.ControlModifier
         ):
-            freq = self.radio_state.get("vfoa")
-            dx = self.callsign.text()
-            if freq and dx:
-                cmd = {}
-                cmd["cmd"] = "MARKDX"
-                cmd["dx"] = dx
-                cmd["freq"] = float(int(freq) / 1000)
-                if self.bandmap_window:
-                    self.bandmap_window.msg_from_main(cmd)
+            self.mark_spot(comment=f"{self.current_mode} MARKED")
             return
         if (
             event.key() == Qt.Key.Key_G
@@ -3240,6 +3233,9 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.n1mm.send_contact_info()
 
         self.database.log_contact(self.contact)
+        if not self.pref["run_state"]: # in S&P mode, put the contact into the bandmap
+            self.mark_spot(comment=self.current_mode)
+
         # Copy the last contact so it can be sent to the cluster:
         self.previous_contact = dict(self.contact)
         self.current_sn = None
@@ -3609,7 +3605,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.save_contact()
         if "{MARK}" in macro:
             macro = macro.replace("{MARK}", "")
-            self.mark_spot()
+            self.mark_spot(comment=f"{self.current_mode} MARKED")
         if "{SPOT}" in macro:
             macro = macro.replace("{SPOT}", "")
             self.spot_dx()

--- a/not1mm/bandmap.py
+++ b/not1mm/bandmap.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 PIXELSPERSTEP = 10
 UPDATE_INTERVAL = 2000
+CLEAR_FREQ = 0.0001 # 100 Hz
 
 
 class Band:
@@ -46,7 +47,7 @@ class Band:
         "40m": (7.0, 7.3),
         "30m": (10.1, 10.15),
         "20m": (14.0, 14.35),
-        "17m": (18.069, 18.168),
+        "17m": (18.068, 18.168),
         "15m": (21.0, 21.45),
         "12m": (24.89, 25.0),
         "10m": (28.0, 29.7),
@@ -82,6 +83,13 @@ class Band:
         self.name = band
         self.altname = self.othername.get(band, 0.0)
 
+    def new_from_freq(freq: float) -> (float, float):
+        """Find band matching a frequency."""
+
+        for band, edges in Band.bands.items():
+            if edges[0] <= freq <= edges[1]:
+                return Band(band)
+        return Band("unknown")
 
 class Database:
     """
@@ -149,9 +157,10 @@ class Database:
             logger.debug("%s", exception)
             return {}
 
-    def addspot(self, spot: dict, erase=True) -> None:
+    def addspot(self, spot: dict, clear_freq=False) -> None:
         """
-        Add spot to database, replacing any previous spots with the same call.
+        Add spot to database, replacing any previous spots with the same call
+        on the same band.
 
         Parameters
         ----------
@@ -159,26 +168,25 @@ class Database:
         A dict of the form: {'ts': datetime, 'callsign': str, 'freq': float,
         'band': str,'mode': str,'spotter': str, 'comment': str}
 
-        erase: bool
-        If True, delete any previous spots with the same callsign.
-        If False, do not delete any previous spots with the same callsign.
-        Default is True.
+        clear_freq: bool
+        If True, delete any previous spots around this frequency.
 
         Returns
         -------
         Nothing.
         """
+        if 'band' in spot:
+            band = Band(spot.get("band"))
+        else:
+            band = Band.new_from_freq(spot.get("freq"))
+
         try:
-            if spot.get("comment", None) == "MARKED":
-                delete_call = "delete from spots where callsign = ?;"
-                self.cursor.execute(delete_call, (spot.get("callsign"),))
-                self.db.commit()
-            elif erase:
-                delete_call = (
-                    "delete from spots where callsign = ? AND comment != 'MARKED';"
-                )
-                self.cursor.execute(delete_call, (spot.get("callsign"),))
-                self.db.commit()
+            delete_call_q = "delete from spots where callsign = ? and freq between ? and ?;"
+            self.cursor.execute(delete_call_q, (spot.get("callsign"), band.start, band.end))
+
+            if clear_freq:
+                clear_freq_q = "delete from spots where freq between ? and ?;"
+                self.cursor.execute(clear_freq_q, (spot.get("freq") - CLEAR_FREQ, spot.get("freq") + CLEAR_FREQ))
 
             self.cursor.execute(
                 "INSERT INTO spots(callsign, ts, freq, mode, spotter, comment) VALUES(?, ?, ?, ?, ?, ?)",
@@ -343,6 +351,7 @@ class BandMapWindow(QDockWidget):
     worked_list = {}
     multicast_interface = None
     text_color = QColor(45, 45, 45)
+    worked_color= QColor(128, 128, 128)
     cluster_expire = pyqtSignal(str)
     message = pyqtSignal(dict)
     date_pattern = r"^\d{2}-[A-Za-z]{3}-\d{4}$"
@@ -467,6 +476,7 @@ class BandMapWindow(QDockWidget):
             dx = packet.get("dx", "")
             freq = packet.get("freq", 0.0)
             the_UTC_time = datetime.now(timezone.utc).isoformat(" ")[:19].split()[1]
+            comment = packet.get("comment", "")
             spot = {
                 "ts": "2099-01-01 " + the_UTC_time,
                 "callsign": dx,
@@ -474,9 +484,9 @@ class BandMapWindow(QDockWidget):
                 "band": self.currentBand.name,
                 "mode": "DX",
                 "spotter": platform.node(),
-                "comment": "MARKED",
+                "comment": comment,
             }
-            self.spots.addspot(spot, erase=False)
+            self.spots.addspot(spot, clear_freq=True)
             self.update_stations()
             return
 
@@ -495,6 +505,7 @@ class BandMapWindow(QDockWidget):
         if packet.get("cmd", "") == "WORKED":
             self.worked_list = packet.get("worked", {})
             logger.debug("%s", f"{self.worked_list}")
+            self.update_stations()
             return
         if packet.get("cmd", "") == "CALLCHANGED":
             call = packet.get("call", "")
@@ -530,9 +541,11 @@ class BandMapWindow(QDockWidget):
         setdarkmode = self.is_it_dark()
         if setdarkmode is True:
             self.text_color = QColorConstants.White
+            self.worked_color = QColor(108, 108, 108)
             self.update()
         else:
             self.text_color = QColorConstants.Black
+            self.worked_color = QColor(178, 178, 178)
             self.update()
 
     def connect(self):
@@ -758,12 +771,12 @@ class BandMapWindow(QDockWidget):
                     flag += "[S]"
 
                 pen_color = self.text_color
-                if items.get("comment") == "MARKED":
+                if "MARKED" in items.get("comment"):
                     pen_color = QColor(254, 194, 17)
                 if items.get("callsign") in self.worked_list:
                     call_bandlist = self.worked_list.get(items.get("callsign"))
                     if self.currentBand.altname in call_bandlist:
-                        pen_color = QColor(255, 47, 47)
+                        pen_color = self.worked_color
                 freq_y = (
                     (items.get("freq") - self.currentBand.start) / step
                 ) * PIXELSPERSTEP


### PR DESCRIPTION
When in S&P mode, add stations worked to the bandmap to mark them when repeatedly scrolling over the band. This makes the bandmap also useful when working unassisted, i.e. not connected to a cluster. Worked stations are shown in gray in the bandmap. (It was red, but this should indicate new multipliers in the future.)

Teach the bandmap about bands. Adding a new spot (either manually, by working a station, or from the cluster) will delete spots for this call only on the current band. This is important for multi-op or SO2R stations that are QRV on several bands at once. (We assume that a station is only calling CQ on a single frequency per band.)

Replace the addspot(erase) flag by clear_freq. If we work a station, or mark it using Ctrl-M, we know this station is on this frequency, so clear all other spots on this frequency +- 0.1 kHz. On the other hand, cluster spots are less trustworthy, so these don't clear the frequency, but add new entries. (Cluster spots still clear all spots for a station on a given band, mis-spots on the wrong frequency happen less often.)