### PR TITLE
Set desktop file name so icon is shown in task bar

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -5065,6 +5065,7 @@ def install_icons() -> None:
         os.system(
             f"xdg-desktop-menu install {fsutils.APP_DATA_PATH}/k6gte-not1mm.desktop"
         )
+        QtGui.QGuiApplication.setDesktopFileName("k6gte-not1mm")
 
 
 def doimp(modname: str) -> object:
@@ -5090,6 +5091,8 @@ def run() -> None:
     """
     Main Entry
     """
+
+    install_icons()
     splash.show()
     # app.processEvents()
     splash.showMessage(
@@ -5108,7 +5111,6 @@ def run() -> None:
     logger.debug(
         f"\nResolved OS file system paths:\nAPP_DATA_PATH {fsutils.APP_DATA_PATH}\nMODULE_PATH {fsutils.MODULE_PATH}\nUSER_DATA_PATH {fsutils.USER_DATA_PATH}\nCONFIG_PATH {fsutils.CONFIG_PATH}\nLOG_FILE {fsutils.LOG_FILE}"
     )
-    install_icons()
     sys.exit(app.exec())
 
 


### PR DESCRIPTION
Also, call install_icons earlier so the files are available before the windows open.

Before, gnome used a standard stock icon.

<img width="288" height="176" alt="Bildschirmfoto vom 2026-04-29 23-48-36" src="https://github.com/user-attachments/assets/929dd3bd-7cb5-4ff2-90a5-bfc96146d440" />
