### PR TITLE
Show rotator azimuth in dock window title

### DIFF
--- a/not1mm/rotator.py
+++ b/not1mm/rotator.py
@@ -102,10 +102,12 @@ class RotatorWindow(QDockWidget):
 
     def set_antenna_azimuth(self, azimuth: float) -> None:
         if isinstance(azimuth, float):
+            self.setWindowTitle(f"Rotator: {azimuth:.0f}°")
             self.antennaAzimuth = azimuth
             self.antennaNeedle.setRotation(self.antennaAzimuth)
             self.antennaNeedle.show()
         else:
+            self.setWindowTitle("Rotator")
             self.antennaNeedle.hide()
 
     def set_north_azimuth(self) -> None:


### PR DESCRIPTION
Sometimes one might want to know the antenna direction in degrees. Show it in the dock window title:

<img width="314" height="340" alt="Bildschirmfoto vom 2026-04-30 00-07-44" src="https://github.com/user-attachments/assets/143ecc52-ad6e-4ef8-ba36-965af8ec8173" />
