### PR TITLE
Configurable CW stepping

### DIFF
--- a/not1mm.tex
+++ b/not1mm.tex
@@ -306,6 +306,16 @@ Under the `CW` tab, there are three options:
  \item `CAT` can be used if your radio supports it. Morse characters are sent via `rigctld`\index{rigctld}.
 \end{itemize}
 
+Other options:
+
+\begin{itemize}
+ \item CW Sent Nr Pad Character: Pad serial numbers with this character. Sensible choices are "T", "0" and maybe "O".
+
+ \item CW Sent Nr Pad Length: Pad serial numbers to this length. Sensible choices are 3 and 1 (= no padding).
+
+ \item CW PgUp/PgDown Stepping: The PgUp and PgDown keys will change the CW speed by this many wpm. Defaults to 1. A value of 2 is a good compromise between faster adjustments and still having fine-grained steps.
+\end{itemize}
+
 \subsection{Cluster}
 
 \vspace{0.5cm}
@@ -534,9 +544,9 @@ Next, a request is made to qrz.com\index{QRZ} for the grid square of the callsig
     \hline
     Esc & Stop CW sending and antenna rotation.\\
     \hline
-    PgUp & Increase the CW sending speed by 2 wpm. \\
+    PgUp & Increase the CW sending speed. \\
     \hline
-    PgDown & Decrease the CW sending speed by 2 wpm. \\
+    PgDown & Decrease the CW sending speed. \\
     \hline
     Arrow-Up & Jump to the next spot above the current VFO\index{VFO} cursor in the bandmap window (CAT\index{CAT} Required). \\
     \hline

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -2830,7 +2830,7 @@ class MainWindow(QtWidgets.QMainWindow):
             and modifier != Qt.KeyboardModifier.ControlModifier
         ):
             if self.cw is not None:
-                self.cw.speed += 2
+                self.cw.speed += self.pref.get("cwstepping", 1)
                 self.cw_speed.setValue(self.cw.speed)
                 if self.cw.servertype == 1:
                     self.cw.sendcw(f"\x1b2{self.cw.speed}")
@@ -2842,7 +2842,7 @@ class MainWindow(QtWidgets.QMainWindow):
             and modifier != Qt.KeyboardModifier.ControlModifier
         ):
             if self.cw is not None:
-                self.cw.speed -= 2
+                self.cw.speed -= self.pref.get("cwstepping", 1)
                 self.cw_speed.setValue(self.cw.speed)
                 if self.cw.servertype == 1:
                     self.cw.sendcw(f"\x1b2{self.cw.speed}")

--- a/not1mm/data/configuration.ui
+++ b/not1mm/data/configuration.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>699</width>
+    <width>767</width>
     <height>499</height>
    </rect>
   </property>
@@ -50,7 +50,7 @@
       <enum>QTabWidget::TabShape::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <property name="elideMode">
       <enum>Qt::TextElideMode::ElideNone</enum>
@@ -225,7 +225,7 @@
           <string>Password:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -243,7 +243,7 @@
           <string>User Name:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -274,7 +274,7 @@
        <item row="2" column="0">
         <spacer name="horizontalSpacer">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -287,7 +287,7 @@
        <item row="2" column="6">
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -317,7 +317,7 @@
        <item row="3" column="0">
         <spacer name="verticalSpacer_4">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -333,7 +333,7 @@
           <string>Output Sound Device</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignCenter</set>
+          <set>Qt::AlignmentFlag::AlignCenter</set>
          </property>
         </widget>
        </item>
@@ -353,7 +353,7 @@
        <item row="0" column="0">
         <spacer name="verticalSpacer_5">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -404,7 +404,7 @@
        <item row="5" column="0" colspan="4">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -438,7 +438,7 @@
        <item row="3" column="1" colspan="3">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -462,7 +462,7 @@
           <string>Rig Control IP:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -474,7 +474,7 @@
          <item>
           <spacer name="horizontalSpacer_4">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -569,7 +569,7 @@
          <item>
           <spacer name="horizontalSpacer_3">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -595,14 +595,14 @@
           <string>Port:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
        <item row="0" column="2">
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -636,80 +636,7 @@
        <string>CW</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_6">
-       <item row="1" column="2" colspan="2">
-        <widget class="QLineEdit" name="cwport_field">
-         <property name="font">
-          <font>
-           <family>JetBrains Mono</family>
-           <pointsize>12</pointsize>
-           <strikeout>false</strikeout>
-          </font>
-         </property>
-         <property name="accessibleName">
-          <string>c w port number</string>
-         </property>
-         <property name="accessibleDescription">
-          <string>port number of c w keyer.</string>
-         </property>
-         <property name="inputMethodHints">
-          <set>Qt::InputMethodHint::ImhDigitsOnly</set>
-         </property>
-         <property name="text">
-          <string>6789</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QLabel" name="label_11">
-         <property name="font">
-          <font>
-           <family>JetBrains Mono</family>
-           <pointsize>12</pointsize>
-           <strikeout>false</strikeout>
-          </font>
-         </property>
-         <property name="text">
-          <string>CW_Port:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <spacer name="horizontalSpacer_5">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="2" column="2" alignment="Qt::AlignHCenter">
-        <widget class="QRadioButton" name="usepywinkeyer_radioButton">
-         <property name="font">
-          <font>
-           <family>JetBrains Mono</family>
-           <pointsize>12</pointsize>
-           <strikeout>false</strikeout>
-          </font>
-         </property>
-         <property name="accessibleName">
-          <string>pywinkeyer</string>
-         </property>
-         <property name="accessibleDescription">
-          <string>use pie win keyer.</string>
-         </property>
-         <property name="text">
-          <string>PyWinkeyer</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="3" alignment="Qt::AlignHCenter">
+       <item row="2" column="3" alignment="Qt::AlignmentFlag::AlignHCenter">
         <widget class="QRadioButton" name="usecwviacat_radioButton">
          <property name="font">
           <font>
@@ -726,93 +653,6 @@
          </property>
          <property name="text">
           <string>CAT</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2" colspan="2">
-        <widget class="QLineEdit" name="cwip_field">
-         <property name="font">
-          <font>
-           <family>JetBrains Mono</family>
-           <pointsize>12</pointsize>
-           <strikeout>false</strikeout>
-          </font>
-         </property>
-         <property name="accessibleName">
-          <string>c w address</string>
-         </property>
-         <property name="accessibleDescription">
-          <string>i p address or hostname of c w keyer.</string>
-         </property>
-         <property name="text">
-          <string>localhost</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1" alignment="Qt::AlignHCenter">
-        <widget class="QRadioButton" name="usecwdaemon_radioButton">
-         <property name="font">
-          <font>
-           <family>JetBrains Mono</family>
-           <pointsize>12</pointsize>
-           <strikeout>false</strikeout>
-          </font>
-         </property>
-         <property name="accessibleName">
-          <string>cwdaemon</string>
-         </property>
-         <property name="accessibleDescription">
-          <string>use c w daemon</string>
-         </property>
-         <property name="text">
-          <string>cwdaemon</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLabel" name="label_10">
-         <property name="font">
-          <font>
-           <family>JetBrains Mono</family>
-           <pointsize>12</pointsize>
-           <strikeout>false</strikeout>
-          </font>
-         </property>
-         <property name="text">
-          <string>CW_Address:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="4">
-        <spacer name="horizontalSpacer_6">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="3" column="1">
-        <widget class="QLabel" name="label_31">
-         <property name="font">
-          <font>
-           <family>JetBrains Mono</family>
-           <pointsize>12</pointsize>
-           <strikeout>false</strikeout>
-          </font>
-         </property>
-         <property name="text">
-          <string>CW Sent Nr Pad Character:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -839,8 +679,41 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
-        <widget class="QLabel" name="label_32">
+       <item row="2" column="4">
+        <spacer name="horizontalSpacer_6">
+         <property name="orientation">
+          <enum>Qt::Orientation::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignHCenter">
+        <widget class="QRadioButton" name="usecwdaemon_radioButton">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="accessibleName">
+          <string>cwdaemon</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>use c w daemon</string>
+         </property>
+         <property name="text">
+          <string>cwdaemon</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLabel" name="label_31">
          <property name="font">
           <font>
            <family>JetBrains Mono</family>
@@ -849,15 +722,48 @@
           </font>
          </property>
          <property name="text">
-          <string>CW Sent Nr Pad Length:</string>
+          <string>CW Sent Nr Pad Character:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <spacer name="horizontalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Orientation::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+        <widget class="QRadioButton" name="usepywinkeyer_radioButton">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="accessibleName">
+          <string>pywinkeyer</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>use pie win keyer.</string>
+         </property>
+         <property name="text">
+          <string>PyWinkeyer</string>
          </property>
         </widget>
        </item>
        <item row="4" column="2">
-        <widget class="QLineEdit" name="cwpaddinglength_field">
+        <widget class="QSpinBox" name="cwpaddinglength_field">
          <property name="font">
           <font>
            <family>JetBrains Mono</family>
@@ -874,8 +780,137 @@
          <property name="inputMethodHints">
           <set>Qt::InputMethodHint::ImhDigitsOnly</set>
          </property>
-         <property name="text">
+         <property name="text" stdset="0">
           <string>3</string>
+         </property>
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>10</number>
+         </property>
+         <property name="value">
+          <number>3</number>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="label_11">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="text">
+          <string>CW_Port:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2" colspan="2">
+        <widget class="QLineEdit" name="cwip_field">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="accessibleName">
+          <string>c w address</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>i p address or hostname of c w keyer.</string>
+         </property>
+         <property name="text">
+          <string>localhost</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QLabel" name="label_32">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="text">
+          <string>CW Sent Nr Pad Length:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2" colspan="2">
+        <widget class="QLineEdit" name="cwport_field">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="accessibleName">
+          <string>c w port number</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>port number of c w keyer.</string>
+         </property>
+         <property name="inputMethodHints">
+          <set>Qt::InputMethodHint::ImhDigitsOnly</set>
+         </property>
+         <property name="text">
+          <string>6789</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="label_10">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="text">
+          <string>CW_Address:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QLabel" name="label_36">
+         <property name="text">
+          <string>CW PgUp/PgDown Stepping:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="2">
+        <widget class="QSpinBox" name="cwstepping_field">
+         <property name="accessibleName">
+          <string>c w page up/down stepping</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>The page up/down keys change the sending speed by this many w p m.</string>
+         </property>
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>10</number>
          </property>
         </widget>
        </item>
@@ -944,7 +979,7 @@
        <item row="7" column="1">
         <spacer name="verticalSpacer_7">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -960,14 +995,14 @@
           <string>Port:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
        <item row="6" column="0">
         <spacer name="horizontalSpacer_7">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -980,7 +1015,7 @@
        <item row="0" column="1">
         <spacer name="verticalSpacer_6">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -993,7 +1028,7 @@
        <item row="6" column="5">
         <spacer name="horizontalSpacer_10">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1009,7 +1044,7 @@
           <string>Filter:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -1019,14 +1054,14 @@
           <string>Mode:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
        <item row="6" column="3">
         <spacer name="horizontalSpacer_9">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1039,7 +1074,7 @@
        <item row="6" column="1">
         <spacer name="horizontalSpacer_8">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1055,14 +1090,14 @@
           <string>Server:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
        <item row="6" column="4">
         <spacer name="horizontalSpacer_11">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1108,7 +1143,7 @@
           <string>Password:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -1169,7 +1204,7 @@
           <string>Interface IP:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -1231,7 +1266,7 @@
           <string>Multicast Port:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -1248,7 +1283,7 @@
           <string>Multicast Group:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -1306,7 +1341,7 @@
           <string>Lookup:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -1369,7 +1404,7 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="0" colspan="6" alignment="Qt::AlignHCenter">
+       <item row="0" column="0" colspan="6" alignment="Qt::AlignmentFlag::AlignHCenter">
         <widget class="QCheckBox" name="send_n1mm_packets">
          <property name="font">
           <font>
@@ -1405,7 +1440,7 @@
           <string>Score:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -1474,7 +1509,7 @@
           <string>Radio:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -1590,7 +1625,7 @@
           <string>Contact:</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
@@ -2308,7 +2343,7 @@
           <item>
            <widget class="Line" name="line">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
            </widget>
           </item>
@@ -2366,7 +2401,7 @@
                <string>Post Interval (minutes)</string>
               </property>
               <property name="alignment">
-               <set>Qt::AlignCenter</set>
+               <set>Qt::AlignmentFlag::AlignCenter</set>
               </property>
              </widget>
             </item>
@@ -2376,7 +2411,7 @@
                <string>2</string>
               </property>
               <property name="alignment">
-               <set>Qt::AlignCenter</set>
+               <set>Qt::AlignmentFlag::AlignCenter</set>
               </property>
              </widget>
             </item>
@@ -2385,7 +2420,7 @@
           <item>
            <widget class="Line" name="line_3">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
            </widget>
           </item>
@@ -2413,7 +2448,7 @@
                <string>15</string>
               </property>
               <property name="alignment">
-               <set>Qt::AlignCenter</set>
+               <set>Qt::AlignmentFlag::AlignCenter</set>
               </property>
              </widget>
             </item>
@@ -2422,7 +2457,7 @@
           <item>
            <widget class="Line" name="line_2">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
            </widget>
           </item>
@@ -2443,7 +2478,7 @@
           <item>
            <spacer name="verticalSpacer_8">
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -2460,7 +2495,7 @@
      </widget>
     </widget>
    </item>
-   <item row="2" column="2" alignment="Qt::AlignHCenter">
+   <item row="2" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -2479,7 +2514,7 @@
       <enum>Qt::LayoutDirection::LeftToRight</enum>
      </property>
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Save</set>
@@ -2571,7 +2606,7 @@
   </property>
  </designerdata>
  <buttongroups>
-  <buttongroup name="buttonGroup"/>
   <buttongroup name="buttonGroup_2"/>
+  <buttongroup name="buttonGroup"/>
  </buttongroups>
 </ui>

--- a/not1mm/data/not1mm.html
+++ b/not1mm/data/not1mm.html
@@ -412,11 +412,11 @@ While I&#39;m not watching TV, Right vs Left political &#39;News&#39; programs, 
 </tr>
 <tr>
 <td>[PgUp]</td>
-<td>Increases the cw sending speed by 2 wpm.</td>
+<td>Increases the cw sending speed.</td>
 </tr>
 <tr>
 <td>[PgDown]</td>
-<td>Decreases the cw sending speed by 2 wpm.</td>
+<td>Decreases the cw sending speed.</td>
 </tr>
 <tr>
 <td>[Arrow-Up]</td>

--- a/not1mm/lib/settings.py
+++ b/not1mm/lib/settings.py
@@ -147,9 +147,8 @@ class Settings(QtWidgets.QDialog):
         elif self.preference.get("cwtype") == 3:
             self.set_catforcw_port_hint()
         self.cwpaddingchar_field.setText(self.preference.get("cwpaddingchar", "T"))
-        self.cwpaddinglength_field.setText(
-            str(self.preference.get("cwpaddinglength", "3"))
-        )
+        self.cwpaddinglength_field.setValue(self.preference.get("cwpaddinglength", 3))
+        self.cwstepping_field.setValue(self.preference.get("cwstepping", 1))
 
         self.connect_to_server.setChecked(bool(self.preference.get("useserver", False)))
         self.be_the_master.setChecked(bool(self.preference.get("im_the_master", False)))
@@ -297,10 +296,8 @@ class Settings(QtWidgets.QDialog):
             self.preference["cwport"] = None
             ...
         self.preference["cwpaddingchar"] = self.cwpaddingchar_field.text()
-        try:
-            self.preference["cwpaddinglength"] = int(self.cwpaddinglength_field.text())
-        except ValueError:
-            self.preference["cwpaddinglength"] = 3
+        self.preference["cwpaddinglength"] = self.cwpaddinglength_field.value()
+        self.preference["cwstepping"] = self.cwstepping_field.value()
         self.preference["cwtype"] = 0
         if self.usecwdaemon_radioButton.isChecked():
             self.preference["cwtype"] = 1


### PR DESCRIPTION
Add a new config option "cwstepping", defaulting to 1. This replaces the fixed PgUp/PgDown wpm stepping. Can be set between 1 and 10 in the config settings window. (See discussion #510)

Since we are touching configuration.ui anyway, convert cwpaddinglength_field into a spinbox (valid values also between 1 and 10), and make the window a bit wider so the list of tabs is fully visible.