### PR TITLE
Send serials with CW cut numbers

### DIFF
--- a/not1mm.tex
+++ b/not1mm.tex
@@ -309,11 +309,15 @@ Under the `CW` tab, there are three options:
 Other options:
 
 \begin{itemize}
- \item CW Sent Nr Pad Character: Pad serial numbers with this character. Sensible choices are "T", "0" and maybe "O".
+ \item PgUp/PgDown Stepping: The PgUp and PgDown keys will change the CW speed by this many wpm. Defaults to 1. A value of 2 is a good compromise between faster adjustments and still having fine-grained steps.
 
- \item CW Sent Nr Pad Length: Pad serial numbers to this length. Sensible choices are 3 and 1 (= no padding).
+ \item Sent RST: Send "599" either in full, or abbreviated as "5NN" or "ENN".
 
- \item CW PgUp/PgDown Stepping: The PgUp and PgDown keys will change the CW speed by this many wpm. Defaults to 1. A value of 2 is a good compromise between faster adjustments and still having fine-grained steps.
+ \item Sent Nr Pad Character: Pad serial numbers with this character. Choices are "0", "O" and "T".
+
+ \item Sent Nr Pad Length: Pad serial numbers to this length. Sensible choices are 3 and 1 (= no padding).
+
+ \item Sent Nr 1, 9, 0: Send numbers in serials as-is or as an abbreviated "cut number".
 \end{itemize}
 
 \subsection{Cluster}

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -5,6 +5,7 @@ Email: michael.bridak@gmail.com
 GPL V3
 Purpose: Provides main logging window and a crap ton more.
 """
+
 # pylint: disable=unused-import, c-extension-no-member, no-member, invalid-name, too-many-lines, no-name-in-module
 # pylint: disable=logging-fstring-interpolation, logging-not-lazy, line-too-long, bare-except
 
@@ -3233,7 +3234,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.n1mm.send_contact_info()
 
         self.database.log_contact(self.contact)
-        if not self.pref["run_state"]: # in S&P mode, put the contact into the bandmap
+        if not self.pref["run_state"]:  # in S&P mode, put the contact into the bandmap
             self.mark_spot(comment=self.current_mode)
 
         # Copy the last contact so it can be sent to the cluster:
@@ -3517,6 +3518,38 @@ class MainWindow(QtWidgets.QMainWindow):
         except Exception as e:
             logger.error(f"Failed to update macro file: {macro_file}. Error: {e}")
 
+    def format_serial(self, serial: str) -> str:
+        """
+        Pad serial number to desired length (all modes) and do CW cut numbers replacements.
+        """
+
+        serial = serial.lstrip("0")
+        if self.radio_state.get("mode") == "CW":
+            serial = (
+                serial.replace("1", self.pref.get("cwserial_1", "1"))
+                .replace("9", self.pref.get("cwserial_9", "9"))
+                .replace("0", self.pref.get("cwserial_0", "0"))
+            )
+            padding = self.pref.get("cwpaddingchar", "T")
+        else:
+            padding = "0"
+        serial = serial.rjust(self.pref.get("cwpaddinglength", 3), padding)
+        return serial
+
+    def format_rst(self, rst: str) -> str:
+        """
+        Apply CW cut numbers to RST sent.
+        """
+
+        if self.radio_state.get("mode") == "CW":
+            # Only send "E" if the full report is 599, we shouldn't end up with
+            # something mixed like "E8N"
+            if self.pref.get("cwsentrst", "5NN") == "ENN" and rst == "599":
+                return "ENN"
+            if self.pref.get("cwsentrst", "5NN") in ("5NN", "ENN"):
+                return rst.replace("9", "N")
+        return rst
+
     def process_macro(self, macro: str) -> str:
         """
         Process CW macro substitutions for contest.
@@ -3540,49 +3573,17 @@ class MainWindow(QtWidgets.QMainWindow):
         result = self.database.get_last_serial()
         prev_serial = str(result.get("serial_nr", "1")).zfill(3)
         macro = macro.upper()
-        if self.radio_state.get("mode") == "CW":
-            macro = macro.replace(
-                "#",
-                next_serial.rjust(
-                    self.pref.get("cwpaddinglength", 3),
-                    self.pref.get("cwpaddingchar", "T"),
-                ),
-            )
-        else:
-            macro = macro.replace("#", next_serial)
+        macro = macro.replace(  # handle EXCH first so it can contain more macros
+            "{EXCH}", self.contest_settings.get("SentExchange", "xxx")
+        )
+        macro = macro.replace("#", self.format_serial(next_serial))
         macro = macro.replace("{MYCALL}", self.station.get("Call", ""))
         macro = macro.replace("{HISCALL}", self.callsign.text())
         macro = macro.replace("{OTHER1}", self.other_1.text())
         macro = macro.replace("{OTHER2}", self.other_2.text())
-        if self.radio_state.get("mode") == "CW":
-            macro = macro.replace("{SNT}", self.sent.text().replace("9", "n"))
-        else:
-            macro = macro.replace("{SNT}", self.sent.text())
-        macro = macro.replace(
-            "{EXCH}", self.contest_settings.get("SentExchange", "xxx")
-        )
-        if self.radio_state.get("mode") == "CW":
-            macro = macro.replace(
-                "{SENTNR}",
-                self.other_1.text()
-                .lstrip("0")
-                .rjust(
-                    self.pref.get("cwpaddinglength", 3),
-                    self.pref.get("cwpaddingchar", "T"),
-                ),
-            )
-            macro = macro.replace(
-                "{PREVNR}",
-                str(prev_serial)
-                .lstrip("0")
-                .rjust(
-                    self.pref.get("cwpaddinglength", 3),
-                    self.pref.get("cwpaddingchar", "T"),
-                ),
-            )
-        else:
-            macro = macro.replace("{SENTNR}", self.other_1.text())
-            macro = macro.replace("{PREVNR}", str(prev_serial))
+        macro = macro.replace("{SNT}", self.format_rst(self.sent.text()))
+        macro = macro.replace("{SENTNR}", self.format_serial(self.other_1.text()))
+        macro = macro.replace("{PREVNR}", self.format_serial(str(prev_serial)))
 
         if "{TX}" in macro:
             macro = macro.replace("{TX}", "")
@@ -3744,7 +3745,9 @@ class MainWindow(QtWidgets.QMainWindow):
             return
         if self.cw:
             if self.pref.get("cwtype") == 3 and self.rig_control is not None:
-                self.rig_control.sendcw(self.process_macro(function_key.toolTip()) + " ")
+                self.rig_control.sendcw(
+                    self.process_macro(function_key.toolTip()) + " "
+                )
                 return
             self.cw.sendcw(self.process_macro(function_key.toolTip()) + " ")
             if self.pref.get("cwtype") == 2:

--- a/not1mm/data/configuration.ui
+++ b/not1mm/data/configuration.ui
@@ -22,10 +22,7 @@
    <string notr="true"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2"/>
-   </item>
-   <item row="1" column="2">
+   <item row="1" column="1">
     <widget class="QTabWidget" name="tabWidget">
      <property name="enabled">
       <bool>true</bool>
@@ -101,7 +98,7 @@
           <string>Use HamQTH</string>
          </property>
          <attribute name="buttonGroup">
-          <string notr="true">buttonGroup_2</string>
+          <string notr="true">lookup_method_group</string>
          </attribute>
         </widget>
        </item>
@@ -131,7 +128,7 @@
           <string>Use QRZ</string>
          </property>
          <attribute name="buttonGroup">
-          <string notr="true">buttonGroup_2</string>
+          <string notr="true">lookup_method_group</string>
          </attribute>
         </widget>
        </item>
@@ -154,7 +151,7 @@
           <string>None</string>
          </property>
          <attribute name="buttonGroup">
-          <string notr="true">buttonGroup_2</string>
+          <string notr="true">lookup_method_group</string>
          </attribute>
         </widget>
        </item>
@@ -207,7 +204,7 @@
           <string>Use HamDB</string>
          </property>
          <attribute name="buttonGroup">
-          <string notr="true">buttonGroup_2</string>
+          <string notr="true">lookup_method_group</string>
          </attribute>
         </widget>
        </item>
@@ -513,7 +510,7 @@
             <string>rigctld</string>
            </property>
            <attribute name="buttonGroup">
-            <string notr="true">buttonGroup</string>
+            <string notr="true">cat_method_group</string>
            </attribute>
           </widget>
          </item>
@@ -539,7 +536,7 @@
             <string>flrig</string>
            </property>
            <attribute name="buttonGroup">
-            <string notr="true">buttonGroup</string>
+            <string notr="true">cat_method_group</string>
            </attribute>
           </widget>
          </item>
@@ -562,7 +559,7 @@
             <string>None</string>
            </property>
            <attribute name="buttonGroup">
-            <string notr="true">buttonGroup</string>
+            <string notr="true">cat_method_group</string>
            </attribute>
           </widget>
          </item>
@@ -636,8 +633,8 @@
        <string>CW</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_6">
-       <item row="2" column="3" alignment="Qt::AlignmentFlag::AlignHCenter">
-        <widget class="QRadioButton" name="usecwviacat_radioButton">
+       <item row="2" column="1" colspan="3">
+        <widget class="QLineEdit" name="cwport_field">
          <property name="font">
           <font>
            <family>JetBrains Mono</family>
@@ -646,103 +643,99 @@
           </font>
          </property>
          <property name="accessibleName">
-          <string>CAT</string>
+          <string>c w port number</string>
          </property>
          <property name="accessibleDescription">
-          <string>use cat for c w</string>
-         </property>
-         <property name="text">
-          <string>CAT</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="2">
-        <widget class="QLineEdit" name="cwpaddingchar_field">
-         <property name="font">
-          <font>
-           <family>JetBrains Mono</family>
-           <pointsize>12</pointsize>
-           <strikeout>false</strikeout>
-          </font>
-         </property>
-         <property name="accessibleName">
-          <string>c w padding character</string>
-         </property>
-         <property name="accessibleDescription">
-          <string>padding character when sending c w exchange number.</string>
+          <string>port number of c w keyer.</string>
          </property>
          <property name="inputMethodHints">
           <set>Qt::InputMethodHint::ImhDigitsOnly</set>
          </property>
          <property name="text">
-          <string>T</string>
+          <string>6789</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="4">
-        <spacer name="horizontalSpacer_6">
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignHCenter">
-        <widget class="QRadioButton" name="usecwdaemon_radioButton">
-         <property name="font">
-          <font>
-           <family>JetBrains Mono</family>
-           <pointsize>12</pointsize>
-           <strikeout>false</strikeout>
-          </font>
+       <item row="4" column="2">
+        <widget class="QRadioButton" name="cwsentrst_5nn">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Send 599 as 5NN&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="accessibleName">
-          <string>cwdaemon</string>
+          <string>5 n n</string>
          </property>
          <property name="accessibleDescription">
-          <string>use c w daemon</string>
+          <string>send 5 9 9 as 5 n n</string>
          </property>
          <property name="text">
-          <string>cwdaemon</string>
+          <string>5NN</string>
          </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwsentrst_group</string>
+         </attribute>
         </widget>
        </item>
-       <item row="3" column="1">
-        <widget class="QLabel" name="label_31">
-         <property name="font">
-          <font>
-           <family>JetBrains Mono</family>
-           <pointsize>12</pointsize>
-           <strikeout>false</strikeout>
-          </font>
+       <item row="12" column="2">
+        <widget class="QRadioButton" name="cwserial_0_as_o">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Send 0 as O (oscar) in serial numbers&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="accessibleName">
+          <string>o</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>send 0 in serials as o</string>
          </property>
          <property name="text">
-          <string>CW Sent Nr Pad Character:</string>
+          <string>O</string>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwserial_0_group</string>
+         </attribute>
         </widget>
        </item>
-       <item row="2" column="0">
-        <spacer name="horizontalSpacer_5">
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
+       <item row="10" column="2">
+        <widget class="QRadioButton" name="cwserial_1_as_a">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Send 1 as A in serial numbers&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
+         <property name="accessibleName">
+          <string>a</string>
          </property>
-        </spacer>
+         <property name="accessibleDescription">
+          <string>send 1 in serials as a</string>
+         </property>
+         <property name="text">
+          <string>A</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwserial_1_group</string>
+         </attribute>
+        </widget>
        </item>
-       <item row="2" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+       <item row="5" column="1">
+        <widget class="QRadioButton" name="cwpaddingchar_0">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pad serial number with 0 (zeros)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="accessibleName">
+          <string>0</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>pad serial numbers with zero</string>
+         </property>
+         <property name="text">
+          <string>0</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwpaddingchar_group</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="0" column="2">
         <widget class="QRadioButton" name="usepywinkeyer_radioButton">
          <property name="font">
           <font>
@@ -760,9 +753,353 @@
          <property name="text">
           <string>PyWinkeyer</string>
          </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwkeying_group</string>
+         </attribute>
         </widget>
        </item>
-       <item row="4" column="2">
+       <item row="5" column="0">
+        <widget class="QLabel" name="cwpaddingchar_label">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="text">
+          <string>Sent Nr Pad Character:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="cwaddress_label">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="text">
+          <string>Network Address:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QRadioButton" name="usecwdaemon_radioButton">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="accessibleName">
+          <string>cwdaemon</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>use c w daemon</string>
+         </property>
+         <property name="text">
+          <string>cwdaemon</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwkeying_group</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="QRadioButton" name="usecwviacat_radioButton">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="accessibleName">
+          <string>CAT</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>use cat for c w</string>
+         </property>
+         <property name="text">
+          <string>CAT</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwkeying_group</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="5" column="3">
+        <widget class="QRadioButton" name="cwpaddingchar_t">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pad serial number with T&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="accessibleName">
+          <string>t</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>pad serial numbers with letter t</string>
+         </property>
+         <property name="text">
+          <string>T</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwpaddingchar_group</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <widget class="QLabel" name="cwserial_1_label">
+         <property name="text">
+          <string>Sent Nr 1:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="cwport_label">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="text">
+          <string>Network Port:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="1">
+        <widget class="QRadioButton" name="cwserial_0_as_0">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Send 0 as 0 (zero) in serial numbers&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="accessibleName">
+          <string>0</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>send 0 in serials as-is</string>
+         </property>
+         <property name="text">
+          <string>0</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwserial_0_group</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="cwstepping_label">
+         <property name="text">
+          <string>PgUp/PgDown Stepping:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <widget class="QRadioButton" name="cwserial_1_as_1">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Send 1 as 1 in serial numbers&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="accessibleName">
+          <string>1</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>send 1 in serials as-is</string>
+         </property>
+         <property name="text">
+          <string>1</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwserial_1_group</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="12" column="0">
+        <widget class="QLabel" name="cwserial_0_label">
+         <property name="text">
+          <string>Sent Nr 0:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="cwkeying_label">
+         <property name="text">
+          <string>CW Keying Method:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="3">
+        <widget class="QRadioButton" name="cwserial_0_as_t">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Send 0 as T in serial numbers&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="accessibleName">
+          <string>t</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>send 0 in serials as t</string>
+         </property>
+         <property name="text">
+          <string>T</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwserial_0_group</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="11" column="2">
+        <widget class="QRadioButton" name="cwserial_9_as_n">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Send 9 as N in serial numbers&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="accessibleName">
+          <string>n</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>send 9 in serials as n</string>
+         </property>
+         <property name="text">
+          <string>N</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwserial_9_group</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <widget class="QRadioButton" name="cwserial_9_as_9">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Send 9 as 9 in serial numbers&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="accessibleName">
+          <string>9</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>send 9 in serials as-is</string>
+         </property>
+         <property name="text">
+          <string>9</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwserial_9_group</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QLabel" name="cwserial_9_label">
+         <property name="text">
+          <string>Sent Nr 9:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1" colspan="3">
+        <widget class="QLineEdit" name="cwip_field">
+         <property name="font">
+          <font>
+           <family>JetBrains Mono</family>
+           <pointsize>12</pointsize>
+           <strikeout>false</strikeout>
+          </font>
+         </property>
+         <property name="accessibleName">
+          <string>c w address</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>i p address or hostname of c w keyer.</string>
+         </property>
+         <property name="text">
+          <string>localhost</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="3">
+        <widget class="QRadioButton" name="cwsentrst_enn">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Send 599 as ENN&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="accessibleName">
+          <string>e n n</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>send 5 9 9 as e n n</string>
+         </property>
+         <property name="text">
+          <string>ENN</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwsentrst_group</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="cwsentrst_label">
+         <property name="text">
+          <string>Sent RST:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QRadioButton" name="cwsentrst_599">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Send 599 as 599&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="accessibleName">
+          <string>5 9 9</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>send 5 9 9 as-is</string>
+         </property>
+         <property name="text">
+          <string>599</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwsentrst_group</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="7" column="1" colspan="3">
         <widget class="QSpinBox" name="cwpaddinglength_field">
          <property name="font">
           <font>
@@ -794,8 +1131,8 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
-        <widget class="QLabel" name="label_11">
+       <item row="7" column="0">
+        <widget class="QLabel" name="cwpaddinglength_label">
          <property name="font">
           <font>
            <family>JetBrains Mono</family>
@@ -804,94 +1141,7 @@
           </font>
          </property>
          <property name="text">
-          <string>CW_Port:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2" colspan="2">
-        <widget class="QLineEdit" name="cwip_field">
-         <property name="font">
-          <font>
-           <family>JetBrains Mono</family>
-           <pointsize>12</pointsize>
-           <strikeout>false</strikeout>
-          </font>
-         </property>
-         <property name="accessibleName">
-          <string>c w address</string>
-         </property>
-         <property name="accessibleDescription">
-          <string>i p address or hostname of c w keyer.</string>
-         </property>
-         <property name="text">
-          <string>localhost</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QLabel" name="label_32">
-         <property name="font">
-          <font>
-           <family>JetBrains Mono</family>
-           <pointsize>12</pointsize>
-           <strikeout>false</strikeout>
-          </font>
-         </property>
-         <property name="text">
-          <string>CW Sent Nr Pad Length:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2" colspan="2">
-        <widget class="QLineEdit" name="cwport_field">
-         <property name="font">
-          <font>
-           <family>JetBrains Mono</family>
-           <pointsize>12</pointsize>
-           <strikeout>false</strikeout>
-          </font>
-         </property>
-         <property name="accessibleName">
-          <string>c w port number</string>
-         </property>
-         <property name="accessibleDescription">
-          <string>port number of c w keyer.</string>
-         </property>
-         <property name="inputMethodHints">
-          <set>Qt::InputMethodHint::ImhDigitsOnly</set>
-         </property>
-         <property name="text">
-          <string>6789</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLabel" name="label_10">
-         <property name="font">
-          <font>
-           <family>JetBrains Mono</family>
-           <pointsize>12</pointsize>
-           <strikeout>false</strikeout>
-          </font>
-         </property>
-         <property name="text">
-          <string>CW_Address:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QLabel" name="label_36">
-         <property name="text">
-          <string>CW PgUp/PgDown Stepping:</string>
+          <string>Sent Nr Pad Length:</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
@@ -899,6 +1149,25 @@
         </widget>
        </item>
        <item row="5" column="2">
+        <widget class="QRadioButton" name="cwpaddingchar_o">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pad serial number with O (oscar)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="accessibleName">
+          <string>o</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>pad serial numbers with letter o</string>
+         </property>
+         <property name="text">
+          <string>O</string>
+         </property>
+         <attribute name="buttonGroup">
+          <string notr="true">cwpaddingchar_group</string>
+         </attribute>
+        </widget>
+       </item>
+       <item row="3" column="1" colspan="3">
         <widget class="QSpinBox" name="cwstepping_field">
          <property name="accessibleName">
           <string>c w page up/down stepping</string>
@@ -2495,7 +2764,7 @@
      </widget>
     </widget>
    </item>
-   <item row="2" column="2" alignment="Qt::AlignmentFlag::AlignHCenter">
+   <item row="2" column="1" alignment="Qt::AlignmentFlag::AlignHCenter">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -2540,10 +2809,7 @@
   <tabstop>radioButton</tabstop>
   <tabstop>rigcontrolport_field</tabstop>
   <tabstop>cwport_field</tabstop>
-  <tabstop>usepywinkeyer_radioButton</tabstop>
-  <tabstop>usecwviacat_radioButton</tabstop>
   <tabstop>cwip_field</tabstop>
-  <tabstop>usecwdaemon_radioButton</tabstop>
   <tabstop>multicast_group</tabstop>
   <tabstop>multicast_port</tabstop>
   <tabstop>interface_ip</tabstop>
@@ -2606,7 +2872,13 @@
   </property>
  </designerdata>
  <buttongroups>
-  <buttongroup name="buttonGroup_2"/>
-  <buttongroup name="buttonGroup"/>
+  <buttongroup name="cwkeying_group"/>
+  <buttongroup name="cwserial_1_group"/>
+  <buttongroup name="cwserial_9_group"/>
+  <buttongroup name="cwserial_0_group"/>
+  <buttongroup name="cat_method_group"/>
+  <buttongroup name="lookup_method_group"/>
+  <buttongroup name="cwpaddingchar_group"/>
+  <buttongroup name="cwsentrst_group"/>
  </buttongroups>
 </ui>

--- a/not1mm/lib/settings.py
+++ b/not1mm/lib/settings.py
@@ -146,9 +146,27 @@ class Settings(QtWidgets.QDialog):
             self.set_winkeyer_port_hint()
         elif self.preference.get("cwtype") == 3:
             self.set_catforcw_port_hint()
-        self.cwpaddingchar_field.setText(self.preference.get("cwpaddingchar", "T"))
         self.cwpaddinglength_field.setValue(self.preference.get("cwpaddinglength", 3))
         self.cwstepping_field.setValue(self.preference.get("cwstepping", 1))
+        self.cwsentrst_599.setChecked(self.preference.get("cwsentrst", "599") == "599")
+        self.cwsentrst_5nn.setChecked(self.preference.get("cwsentrst", "599") == "5NN")
+        self.cwsentrst_enn.setChecked(self.preference.get("cwsentrst", "599") == "ENN")
+        self.cwpaddingchar_0.setChecked(
+            self.preference.get("cwpaddingchar", "T") == "0"
+        )
+        self.cwpaddingchar_o.setChecked(
+            self.preference.get("cwpaddingchar", "T") == "O"
+        )
+        self.cwpaddingchar_t.setChecked(
+            self.preference.get("cwpaddingchar", "T") == "T"
+        )
+        self.cwserial_0_as_0.setChecked(self.preference.get("cwserial_0", "0") == "0")
+        self.cwserial_0_as_o.setChecked(self.preference.get("cwserial_0", "0") == "O")
+        self.cwserial_0_as_t.setChecked(self.preference.get("cwserial_0", "0") == "T")
+        self.cwserial_1_as_1.setChecked(self.preference.get("cwserial_1", "1") == "1")
+        self.cwserial_1_as_a.setChecked(self.preference.get("cwserial_1", "1") == "A")
+        self.cwserial_9_as_9.setChecked(self.preference.get("cwserial_9", "9") == "9")
+        self.cwserial_9_as_n.setChecked(self.preference.get("cwserial_9", "9") == "N")
 
         self.connect_to_server.setChecked(bool(self.preference.get("useserver", False)))
         self.be_the_master.setChecked(bool(self.preference.get("im_the_master", False)))
@@ -295,7 +313,10 @@ class Settings(QtWidgets.QDialog):
         except ValueError:
             self.preference["cwport"] = None
             ...
-        self.preference["cwpaddingchar"] = self.cwpaddingchar_field.text()
+        cwpaddingchar_button = self.cwpaddingchar_group.checkedButton()
+        self.preference["cwpaddingchar"] = (
+            cwpaddingchar_button.text() if cwpaddingchar_button else "0"
+        )
         self.preference["cwpaddinglength"] = self.cwpaddinglength_field.value()
         self.preference["cwstepping"] = self.cwstepping_field.value()
         self.preference["cwtype"] = 0
@@ -305,6 +326,23 @@ class Settings(QtWidgets.QDialog):
             self.preference["cwtype"] = 2
         elif self.usecwviacat_radioButton.isChecked():
             self.preference["cwtype"] = 3
+        cwsentrst_button = self.cwsentrst_group.checkedButton()
+        self.preference["cwsentrst"] = (
+            cwsentrst_button.text() if cwsentrst_button else "5NN"
+        )
+        cwserial_1_button = self.cwserial_1_group.checkedButton()
+        self.preference["cwserial_1"] = (
+            cwserial_1_button.text() if cwserial_1_button else "1"
+        )
+        cwserial_9_button = self.cwserial_9_group.checkedButton()
+        self.preference["cwserial_9"] = (
+            cwserial_9_button.text() if cwserial_9_button else "9"
+        )
+        cwserial_0_button = self.cwserial_0_group.checkedButton()
+        self.preference["cwserial_0"] = (
+            cwserial_0_button.text() if cwserial_0_button else "0"
+        )
+
         self.preference["useserver"] = self.connect_to_server.isChecked()
         self.preference["im_the_master"] = self.be_the_master.isChecked()
         self.preference["multicast_group"] = self.multicast_group.text()


### PR DESCRIPTION
Support abbreviating 1, 9 and 0 in CW serial numbers as A, N and O/T. Sent RST is sent as 599, 5NN or ENN.

The {EXCH} macro is evaluated first so it can contain other macros like '#'.

The serial padding length now applies to all modes. (But I'll leave moving that to some other tab in the config window to some other cleanup.)

<img width="763" height="531" alt="Bildschirmfoto vom 2026-05-03 16-53-22" src="https://github.com/user-attachments/assets/abcb0be0-eba2-4ea2-9751-1fffbb184cd2" />
