### PR TITLE
Refactor CW mode handling in Cabrillo format for multiple plugins

### DIFF
--- a/not1mm/plugins/10_10_fall_cw.py
+++ b/not1mm/plugins/10_10_fall_cw.py
@@ -344,6 +344,8 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]

--- a/not1mm/plugins/10_10_spring_cw.py
+++ b/not1mm/plugins/10_10_spring_cw.py
@@ -343,6 +343,8 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]

--- a/not1mm/plugins/10_10_summer_phone.py
+++ b/not1mm/plugins/10_10_summer_phone.py
@@ -347,6 +347,8 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]

--- a/not1mm/plugins/10_10_winter_phone.py
+++ b/not1mm/plugins/10_10_winter_phone.py
@@ -345,6 +345,8 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]

--- a/not1mm/plugins/agcw_qrp.py
+++ b/not1mm/plugins/agcw_qrp.py
@@ -593,6 +593,8 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]

--- a/not1mm/plugins/ari_40_80.py
+++ b/not1mm/plugins/ari_40_80.py
@@ -342,6 +342,8 @@ def cabrillo(self, file_encoding):
                     themode = "PH"
                 if themode == "RTTY":
                     themode = "RY"
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]

--- a/not1mm/plugins/ari_dx.py
+++ b/not1mm/plugins/ari_dx.py
@@ -424,6 +424,8 @@ def cabrillo(self, file_encoding):
                     themode = "PH"
                 if themode == "RTTY":
                     themode = "RY"
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]

--- a/not1mm/plugins/arrl_10m.py
+++ b/not1mm/plugins/arrl_10m.py
@@ -434,6 +434,8 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]

--- a/not1mm/plugins/arrl_160m.py
+++ b/not1mm/plugins/arrl_160m.py
@@ -437,6 +437,8 @@ def cabrillo(self, file_encoding):
                 themode = contact.get("Mode", "")
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)
 
                 loggeddate = the_date_and_time[:10]

--- a/not1mm/plugins/arrl_dx_cw.py
+++ b/not1mm/plugins/arrl_dx_cw.py
@@ -371,6 +371,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/arrl_dx_ssb.py
+++ b/not1mm/plugins/arrl_dx_ssb.py
@@ -371,6 +371,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/arrl_field_day.py
+++ b/not1mm/plugins/arrl_field_day.py
@@ -326,6 +326,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode in ("LSB", "USB", "FM"):
                     themode = "PH"
                 if themode in ("FT8", "FT4", "RTTY"):

--- a/not1mm/plugins/arrl_rtty_ru.py
+++ b/not1mm/plugins/arrl_rtty_ru.py
@@ -396,6 +396,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/arrl_ss_cw.py
+++ b/not1mm/plugins/arrl_ss_cw.py
@@ -378,6 +378,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/arrl_ss_phone.py
+++ b/not1mm/plugins/arrl_ss_phone.py
@@ -359,6 +359,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/arrl_vhf_jan.py
+++ b/not1mm/plugins/arrl_vhf_jan.py
@@ -397,7 +397,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
-
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode in ("LSB", "USB", "AM"):
                     themode = "PH"
                 if themode in (

--- a/not1mm/plugins/arrl_vhf_jun.py
+++ b/not1mm/plugins/arrl_vhf_jun.py
@@ -365,6 +365,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode in ("LSB", "USB", "AM"):
                     themode = "PH"
                 if themode in (

--- a/not1mm/plugins/arrl_vhf_sep.py
+++ b/not1mm/plugins/arrl_vhf_sep.py
@@ -365,6 +365,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode in ("LSB", "USB", "AM"):
                     themode = "PH"
                 if themode in (

--- a/not1mm/plugins/canada_day.py
+++ b/not1mm/plugins/canada_day.py
@@ -393,6 +393,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/cq_160_cw.py
+++ b/not1mm/plugins/cq_160_cw.py
@@ -380,6 +380,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/cq_160_ssb.py
+++ b/not1mm/plugins/cq_160_ssb.py
@@ -380,6 +380,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/cq_wpx_cw.py
+++ b/not1mm/plugins/cq_wpx_cw.py
@@ -414,6 +414,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/cq_wpx_rtty.py
+++ b/not1mm/plugins/cq_wpx_rtty.py
@@ -413,6 +413,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/cq_wpx_ssb.py
+++ b/not1mm/plugins/cq_wpx_ssb.py
@@ -377,6 +377,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/cq_ww_cw.py
+++ b/not1mm/plugins/cq_ww_cw.py
@@ -395,6 +395,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/cq_ww_rtty.py
+++ b/not1mm/plugins/cq_ww_rtty.py
@@ -405,6 +405,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 if themode.strip() in (

--- a/not1mm/plugins/cq_ww_ssb.py
+++ b/not1mm/plugins/cq_ww_ssb.py
@@ -393,6 +393,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/cwo.py
+++ b/not1mm/plugins/cwo.py
@@ -368,6 +368,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/cwt.py
+++ b/not1mm/plugins/cwt.py
@@ -367,6 +367,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/darc_vhf.py
+++ b/not1mm/plugins/darc_vhf.py
@@ -692,6 +692,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/darc_xmas.py
+++ b/not1mm/plugins/darc_xmas.py
@@ -398,6 +398,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/ea_majistad_cw.py
+++ b/not1mm/plugins/ea_majistad_cw.py
@@ -460,6 +460,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 if themode == "RTTY":

--- a/not1mm/plugins/ea_majistad_ssb.py
+++ b/not1mm/plugins/ea_majistad_ssb.py
@@ -451,6 +451,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 if themode == "RTTY":

--- a/not1mm/plugins/ea_rtty.py
+++ b/not1mm/plugins/ea_rtty.py
@@ -464,6 +464,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 if themode == "RTTY":

--- a/not1mm/plugins/es_field_day.py
+++ b/not1mm/plugins/es_field_day.py
@@ -482,6 +482,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/es_ll_kv.py
+++ b/not1mm/plugins/es_ll_kv.py
@@ -452,6 +452,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/es_manual_key.py
+++ b/not1mm/plugins/es_manual_key.py
@@ -507,6 +507,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/es_open.py
+++ b/not1mm/plugins/es_open.py
@@ -451,6 +451,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/helvetia.py
+++ b/not1mm/plugins/helvetia.py
@@ -501,6 +501,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/iaru_fieldday_r1_cw.py
+++ b/not1mm/plugins/iaru_fieldday_r1_cw.py
@@ -404,6 +404,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/iaru_fieldday_r1_ssb.py
+++ b/not1mm/plugins/iaru_fieldday_r1_ssb.py
@@ -404,6 +404,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/iaru_hf.py
+++ b/not1mm/plugins/iaru_hf.py
@@ -377,6 +377,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/icwc_mst.py
+++ b/not1mm/plugins/icwc_mst.py
@@ -356,6 +356,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/jidx_cw.py
+++ b/not1mm/plugins/jidx_cw.py
@@ -378,6 +378,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/jidx_ph.py
+++ b/not1mm/plugins/jidx_ph.py
@@ -347,6 +347,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/k1usn_sst.py
+++ b/not1mm/plugins/k1usn_sst.py
@@ -347,6 +347,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/labre_rs_digi.py
+++ b/not1mm/plugins/labre_rs_digi.py
@@ -381,7 +381,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
-
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode in ("LSB", "USB", "AM"):
                     themode = "PH"
                 if themode in (

--- a/not1mm/plugins/lz-dx.py
+++ b/not1mm/plugins/lz-dx.py
@@ -405,6 +405,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/naqp_cw.py
+++ b/not1mm/plugins/naqp_cw.py
@@ -373,6 +373,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/naqp_rtty.py
+++ b/not1mm/plugins/naqp_rtty.py
@@ -374,6 +374,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 if themode == "LSB" or themode == "USB":

--- a/not1mm/plugins/naqp_ssb.py
+++ b/not1mm/plugins/naqp_ssb.py
@@ -343,6 +343,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/pacc.py
+++ b/not1mm/plugins/pacc.py
@@ -401,6 +401,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/phone_weekly_test.py
+++ b/not1mm/plugins/phone_weekly_test.py
@@ -363,6 +363,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/raem.py
+++ b/not1mm/plugins/raem.py
@@ -465,6 +465,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/ref_cw.py
+++ b/not1mm/plugins/ref_cw.py
@@ -506,6 +506,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/ref_ssb.py
+++ b/not1mm/plugins/ref_ssb.py
@@ -520,6 +520,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/rsgb_80m_cc.py
+++ b/not1mm/plugins/rsgb_80m_cc.py
@@ -332,6 +332,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 if themode == "RTTY":

--- a/not1mm/plugins/rsgb_iota.py
+++ b/not1mm/plugins/rsgb_iota.py
@@ -444,6 +444,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/sac_cw.py
+++ b/not1mm/plugins/sac_cw.py
@@ -435,6 +435,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/sac_ssb.py
+++ b/not1mm/plugins/sac_ssb.py
@@ -435,6 +435,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/spdx.py
+++ b/not1mm/plugins/spdx.py
@@ -377,6 +377,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/ssa_mt_cw.py
+++ b/not1mm/plugins/ssa_mt_cw.py
@@ -380,6 +380,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode in ("LSB", "USB", "AM"):
                     themode = "PH"
                 if themode in (

--- a/not1mm/plugins/ssa_mt_ssb.py
+++ b/not1mm/plugins/ssa_mt_ssb.py
@@ -380,6 +380,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode in ("LSB", "USB", "AM"):
                     themode = "PH"
                 if themode in (

--- a/not1mm/plugins/stew_perry_topband.py
+++ b/not1mm/plugins/stew_perry_topband.py
@@ -341,6 +341,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/ukeidx.py
+++ b/not1mm/plugins/ukeidx.py
@@ -436,6 +436,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/vhf_sprint.py
+++ b/not1mm/plugins/vhf_sprint.py
@@ -363,6 +363,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode in ("LSB", "USB", "AM"):
                     themode = "PH"
                 if themode in (

--- a/not1mm/plugins/wag.py
+++ b/not1mm/plugins/wag.py
@@ -463,6 +463,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "LSB" or themode == "USB":
                     themode = "PH"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/weekly_rtty.py
+++ b/not1mm/plugins/weekly_rtty.py
@@ -353,6 +353,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode == "RTTY":
                     themode = "RY"
                 frequency = str(round(contact.get("Freq", "0"))).rjust(5)

--- a/not1mm/plugins/winter_field_day.py
+++ b/not1mm/plugins/winter_field_day.py
@@ -335,6 +335,8 @@ def cabrillo(self, file_encoding):
             for contact in log:
                 the_date_and_time = contact.get("TS", "")
                 themode = contact.get("Mode", "")
+                if themode == "CW-U" | "CW-L" | "CW-R" | "CWR":
+                    themode = "CW"
                 if themode in ("LSB", "USB", "FM", "AM"):
                     themode = "PH"
                 if themode.upper() in (


### PR DESCRIPTION
- Consolidated various CW modes ("CW-U", "CW-L", "CW-R", "CWR") into a single "CW" mode across multiple plugins.
- Updated the cabrillo function in the following plugins:
  - arrl_field_day
  - arrl_rtty_ru
  - arrl_ss_cw
  - arrl_ss_phone
  - arrl_vhf_jan
  - arrl_vhf_jun
  - arrl_vhf_sep
  - canada_day
  - cq_160_cw
  - cq_160_ssb
  - cq_wpx_cw
  - cq_wpx_rtty
  - cq_wpx_ssb
  - cq_ww_cw
  - cq_ww_rtty
  - cq_ww_ssb
  - cwo
  - cwt
  - darc_vhf
  - darc_xmas
  - ea_majistad_cw
  - ea_majistad_ssb
  - ea_rtty
  - es_field_day
  - es_ll_kv
  - es_manual_key
  - es_open
  - helvetia
  - iaru_fieldday_r1_cw
  - iaru_fieldday_r1_ssb
  - iaru_hf
  - icwc_mst
  - jidx_cw
  - jidx_ph
  - k1usn_sst
  - labre_rs_digi
  - lz-dx
  - naqp_cw
  - naqp_rtty
  - naqp_ssb
  - pacc
  - phone_weekly_test
  - raem
  - ref_cw
  - ref_ssb
  - rsgb_80m_cc
  - rsgb_iota
  - sac_cw
  - sac_ssb
  - spdx
  - ssa_mt_cw
  - ssa_mt_ssb
  - stew_perry_topband
  - ukeidx
  - vhf_sprint
  - wag
  - weekly_rtty
  - winter_field_day

Closes #550 