### PR TITLE
Fixed telnet spots check in the checkwindow.

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -1360,6 +1360,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
             if msg.get("cmd", "") == "CHECKSPOTS":
                 if self.check_window:
+                    msg["call"] = self.callsign.text()
                     self.check_window.msg_from_main(msg)
 
             # '{"cmd": "LOOKUP_RESPONSE", "station": "fredo", "result": {"call": "K6GTE", "aliases": "KM6HQI", "dxcc": "291", "nickname": "Mike", "fname": "Michael C", "name": "Bridak", "addr1": "2854 W Bridgeport Ave", "addr2": "Anaheim", "state": "CA", "zip": "92804", "country": "United States", "lat": "33.825460", "lon": "-117.987510", "grid": "DM13at", "county": "Orange", "ccode": "271", "fips": "06059", "land": "United States", "efdate": "2021-01-13", "expdate": "2027-11-07", "class": "G", "codes": "HVIE", "email": "michael.bridak@gmail.com", "u_views": "3049", "bio": "7232", "biodate": "2023-04-10 17:56:55", "image": "https://cdn-xml.qrz.com/e/k6gte/qsl.png", "imageinfo": "285:545:99376", "moddate": "2021-04-08 21:41:07", "MSA": "5945", "AreaCode": "714", "TimeZone": "Pacific", "GMTOffset": "-8", "DST": "Y", "eqsl": "0", "mqsl": "1", "cqzone": "3", "ituzone": "6", "born": "1967", "lotw": "1", "user": "K6GTE", "geoloc": "geocode", "name_fmt": "Michael C \\"Mike\\" Bridak"}}'

--- a/not1mm/checkwindow.py
+++ b/not1mm/checkwindow.py
@@ -6,6 +6,7 @@ GPL V3
 Class: CheckWindow
 Purpose: Onscreen widget to show possible matches to callsigns entered in the main window.
 """
+
 # pylint: disable=no-name-in-module, unused-import, no-member, invalid-name, c-extension-no-member
 # pylint: disable=logging-fstring-interpolation, line-too-long
 
@@ -92,6 +93,8 @@ class CheckWindow(QDockWidget):
             self.log_list(call)
             return
         if packet.get("cmd", "") == "CHECKSPOTS":
+            call = packet.get("call", "")
+            self.call = call
             self.populate_layout(self.dxcLayout, [])
             spots = packet.get("spots", [])
             self.telnet_list(spots)


### PR DESCRIPTION
For some reason the spots check was happening before the call was changed.
Fixed by just passing the current call with the request to check the spots.

Close #530 