### PR TITLE
ES Field Day: points and ADIF metadata update

### DIFF
--- a/not1mm/fsutils.py
+++ b/not1mm/fsutils.py
@@ -27,14 +27,8 @@ LOG_FILE = USER_DATA_PATH / "not1mm_debug.log"
 
 # Create directories if they do not exist on Linux systems
 if platform.system() not in ["Windows", "Darwin"]:
-    try:
-        os.mkdir(CONFIG_PATH)
-    except FileExistsError:
-        ...
-    try:
-        os.mkdir(USER_DATA_PATH)
-    except FileExistsError:
-        ...
+    Path(CONFIG_PATH).mkdir(parents=True, exist_ok=True)
+    Path(USER_DATA_PATH).mkdir(parents=True, exist_ok=True)
 
 # Define and create directories if they do not exist on Windows or Mac systems
 if platform.system() in ["Windows", "Darwin"]:


### PR DESCRIPTION
﻿This PR updates filesystem startup behavior..

Included changes:

- `not1mm/not1mm/fsutils.py`:
  - Use `Path.mkdir(parents=True, exist_ok=True)` for `CONFIG_PATH` and `USER_DATA_PATH` to avoid startup failures when `~/.config` or `~/.local/share` are missing.

