### PR TITLE
@mbridak Fix ADIF filename generation to replace '/' with '-' in call…

### DIFF
--- a/not1mm/lib/plugin_common.py
+++ b/not1mm/lib/plugin_common.py
@@ -92,7 +92,7 @@ def gen_adif(self, cabrillo_name: str, contest_id=""):
     """
     now = datetime.datetime.now()
     date_time = now.strftime("%Y-%m-%d_%H-%M-%S")
-    station_callsign = self.station.get("Call", "").upper()
+    station_callsign = self.station.get("Call", "").upper().replace("/", "-")
     filename = (
         str(Path.home()) + "/" + f"{station_callsign}_{cabrillo_name}_{date_time}.adi"
     )

--- a/not1mm/plugins/es_field_day.py
+++ b/not1mm/plugins/es_field_day.py
@@ -20,6 +20,12 @@ from not1mm.lib.version import __version__
 
 logger = logging.getLogger(__name__)
 
+# this just removes unsused warning
+assert imp_adif
+assert get_points
+assert QtWidgets
+assert platform
+
 EXCHANGE_HINT = "#"
 
 name = "ES FIELD DAY"


### PR DESCRIPTION
Fix ADIF filename generation to replace '/' with '-' in callsign and remove unused warnings in ES FIELD DAY plugin