### PR TITLE
Allow more time for rig connection

### DIFF
--- a/not1mm/lib/cat_interface.py
+++ b/not1mm/lib/cat_interface.py
@@ -127,7 +127,7 @@ class CAT:
         try:
             logger.debug("Connecting to rigctrld")
             self.rigctrlsocket = socket.socket()
-            self.rigctrlsocket.settimeout(0.1)
+            self.rigctrlsocket.settimeout(1.0)
             self.rigctrlsocket.connect((self.host, self.port))
             logger.debug("Connected to rigctrld")
             self.online = True


### PR DESCRIPTION
100ms are not enough to connect to a remote rig across the Atlantic. (Tested from VE7 connecting to my home station in DL.)