### PR TITLE
Bypass installing dbus-python on non linux platform

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "rapidfuzz",
     "appdata",
     "adif_io",
-    "dbus-python",
+    "dbus-python ; platform_system != 'Windows'",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
this package is used for notification on linux platform only. other platforms don't need and it would help to resolve installing failure.