### PR TITLE
Fixup: Simplify database queries

### DIFF
--- a/not1mm/lib/database.py
+++ b/not1mm/lib/database.py
@@ -387,7 +387,7 @@ class DataBase:
 
     def get_contest_list(self):
         """get the list of contests"""
-        return self.exec_sql(
+        return self.exec_sql_mult(
             "select Name, DisplayName from Contest order by DisplayName;"
         )
 
@@ -561,7 +561,7 @@ class DataBase:
         Fetch count of unique countries
         {exch1_count: count}
         """
-        return self.exec_sql_mult(
+        return self.exec_sql(
             "select count(DISTINCT(Exchange1)) as exch1_count from dxlog where Exchange1 != '' and ContestNR = ?;",
             (self.current_contest,),
         )

--- a/not1mm/plugins/es_field_day.py
+++ b/not1mm/plugins/es_field_day.py
@@ -286,7 +286,7 @@ def show_mults(self, rtc=None):
     # apply params
     params = estonian_regions
     # run query
-    result = self.database.exec_sql_mult(query, params)
+    result = self.database.exec_sql(query, params)
     if result:
         mult_count = result.get("mults", 0)
         return mult_count


### PR DESCRIPTION
get_contest_list and fetch_exchange1_unique_count were simply converted wrongly by me, but for es_field_day.py, I blame the original function to be named exec_sql_params_mult when it was really only fetching a single row.

Fixup for PR #598.

Sorry, I should really have fed this through AI for a review before, but the provider was down.