### PR TITLE
fix: check for audio interface availability on startup - guard the ui

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -266,20 +266,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setCorner(Qt.Corner.BottomLeftCorner, Qt.DockWidgetArea.LeftDockWidgetArea)
         self.fontfamily = self.load_fonts_from_dir(os.fspath(fsutils.APP_DATA_PATH))
         uic.loadUi(fsutils.APP_DATA_PATH / "main.ui", self)
-        self.function_keys = (
-            self.F1,
-            self.F2,
-            self.F3,
-            self.F4,
-            self.F5,
-            self.F6,
-            self.F7,
-            self.F8,
-            self.F9,
-            self.F10,
-            self.F11,
-            self.F12,
-        )
         self.tray_icon = None
         if not QSystemTrayIcon.isSystemTrayAvailable():
             print("System tray not available for this system")
@@ -4271,7 +4257,20 @@ class MainWindow(QtWidgets.QMainWindow):
         is_phone_mode = self._is_phone_mode()
         hide_for_missing_audio = is_phone_mode and not self.voice_output_available
 
-        for function_key in self.function_keys:
+        for function_key in (
+            self.F1,
+            self.F2,
+            self.F3,
+            self.F4,
+            self.F5,
+            self.F6,
+            self.F7,
+            self.F8,
+            self.F9,
+            self.F10,
+            self.F11,
+            self.F12,
+        ):
             function_key.setEnabled(not hide_for_missing_audio)
 
         if self.pref.get("cw_macros") and not hide_for_missing_audio:

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -108,7 +108,7 @@ from not1mm.rotator import RotatorWindow
 from not1mm.rtc_service import RTCService
 from not1mm.statistics import StatsWindow
 from not1mm.vfo import VfoWindow
-from not1mm.voice_keying import Voice
+from not1mm.voice_keying import Voice, has_output_device
 from not1mm.zone_tracker import ZoneWindow
 
 poll_time = datetime.datetime.now()
@@ -211,6 +211,8 @@ class MainWindow(QtWidgets.QMainWindow):
     esm_dict = {}
     sandpfreq = 0
     current_sn = None
+    # Starts false and is set true when runtime output-device checks succeed.
+    voice_output_available = False
 
     radio_thread = QThread()
     voice_thread = QThread()
@@ -264,6 +266,20 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setCorner(Qt.Corner.BottomLeftCorner, Qt.DockWidgetArea.LeftDockWidgetArea)
         self.fontfamily = self.load_fonts_from_dir(os.fspath(fsutils.APP_DATA_PATH))
         uic.loadUi(fsutils.APP_DATA_PATH / "main.ui", self)
+        self.function_keys = (
+            self.F1,
+            self.F2,
+            self.F3,
+            self.F4,
+            self.F5,
+            self.F6,
+            self.F7,
+            self.F8,
+            self.F9,
+            self.F10,
+            self.F11,
+            self.F12,
+        )
         self.tray_icon = None
         if not QSystemTrayIcon.isSystemTrayAvailable():
             print("System tray not available for this system")
@@ -1856,6 +1872,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.write_preference()
         # logger.debug("%s", f"{self.pref}")
         self.readpreferences()
+        self.voice_process.sounddevice = self.pref.get("sounddevice", "default")
 
     def new_database(self) -> None:
         """
@@ -3862,12 +3879,20 @@ class MainWindow(QtWidgets.QMainWindow):
         """
 
         logger.debug("Function Key: %s", function_key.text())
+        if self._is_phone_mode():
+            self.voice_output_available = has_output_device(
+                self.pref.get("sounddevice", "default")
+            )
+            if not self.voice_output_available:
+                self.show_CW_macros()
+                logger.warning("No available output sound device for voice keying.")
+                return
         if function_key.toolTip()[0:3] == "RI:":
             self.rig_control.cat.send_cat_string(function_key.toolTip()[3:])
             return
         if self.n1mm:
             self.n1mm.radio_info["FunctionKeyCaption"] = function_key.text()
-        if self.radio_state.get("mode") in ["LSB", "USB", "SSB", "FM", "AM"]:
+        if self._is_phone_mode():
             self.voice_process.voice_string(self.process_macro(function_key.toolTip()))
             # self.voice_string(self.process_macro(function_key.toolTip()))
             return
@@ -4240,13 +4265,31 @@ class MainWindow(QtWidgets.QMainWindow):
         -------
         None
         """
+        self.voice_output_available = has_output_device(
+            self.pref.get("sounddevice", "default")
+        )
+        is_phone_mode = self._is_phone_mode()
+        hide_for_missing_audio = is_phone_mode and not self.voice_output_available
 
-        if self.pref.get("cw_macros"):
+        for function_key in self.function_keys:
+            function_key.setEnabled(not hide_for_missing_audio)
+
+        if self.pref.get("cw_macros") and not hide_for_missing_audio:
             self.Button_Row1.show()
             self.Button_Row2.show()
         else:
             self.Button_Row1.hide()
             self.Button_Row2.hide()
+
+    def _is_phone_mode(self) -> bool:
+        """Return True when the current operating mode is phone/voice."""
+        return self.current_mode == "SSB" or self.radio_state.get("mode") in (
+            "LSB",
+            "USB",
+            "SSB",
+            "FM",
+            "AM",
+        )
 
     def command_buttons_state_change(self) -> None:
         """
@@ -4753,6 +4796,7 @@ class MainWindow(QtWidgets.QMainWindow):
                         self.read_macros()
                         if self.contest.name == "ICWC Medium Speed Test":
                             self.contest.prefill(self)
+                self.show_CW_macros()
             return
 
         if mode in ("LSB", "USB", "SSB", "FM", "AM"):
@@ -4762,6 +4806,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     self.sent.setText("59")
                     self.receive.setText("59")
                 self.read_macros()
+                self.show_CW_macros()
             return
 
         if mode in (
@@ -4785,6 +4830,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     self.sent.setText("599")
                     self.receive.setText("599")
                 self.read_macros()
+                self.show_CW_macros()
 
     # TODO
     def get_rover(self) -> None:

--- a/not1mm/voice_keying.py
+++ b/not1mm/voice_keying.py
@@ -24,6 +24,17 @@ from PyQt6.QtCore import QObject, QThread, pyqtSignal
 logger = logging.getLogger("voice_keying")
 
 
+def has_output_device(sounddevice_name="default") -> bool:
+    """Return True when the selected output audio device is available."""
+    if sd is None:
+        return False
+    try:
+        sd.check_output_settings(device=sounddevice_name)
+    except (sd.PortAudioError, ValueError, TypeError):
+        return False
+    return True
+
+
 class Voice(QObject):
     """Voice class"""
 
@@ -43,6 +54,10 @@ class Voice(QObject):
         while True:
             keyed = False
             while len(self.voicings):
+                if not has_output_device(self.sounddevice):
+                    logger.warning("No available output sound device for voice keying.")
+                    self.voicings.clear()
+                    break
                 if not keyed:
                     self.ptt_on.emit()
                     keyed = True
@@ -101,6 +116,9 @@ class Voice(QObject):
         logger.debug("Voicing: %s", the_string)
         if sd is None:
             logger.warning("Sounddevice/portaudio not installed.")
+            return
+        if not has_output_device(self.sounddevice):
+            logger.warning("No available output sound device for voice keying.")
             return
         op_path = self.data_path / self.current_op
         if "[" in the_string:


### PR DESCRIPTION
first of all: thank you very much for amazing piece of software - makes ham life on linux way easier!! i use it exclusively now for all my logging!

This PR applies the same guard idea already used by CW ( if self.cw  / only send when backend is available) to SSB voice macros:

• Added output-device checks before playing voice audio.
• Added UI behavior in phone mode to hide macro buttons when voice output is unavailable.

Note: that UI hiding is an SSB-specific addition; CW currently does not hide its macro buttons when CW backend is unavailable, but the app does not crash like it does for SSB

original err:
```
(venv) ivica.matic@GNUK-LAPT803212s-MacBook-Pro not1mm fix-disable-audio-when-no-audio-device % python3 not1mm
Traceback (most recent call last):
  File "/Users/ivica.matic/not1mm/not1mm/voice_keying.py", line 57, in run
    sd.play(data, blocking=False)
  File "/Users/ivica.matic/not1mm/venv/lib/python3.12/site-packages/sounddevice.py", line 183, in play
    ctx.start_stream(OutputStream, samplerate, ctx.output_channels,
  File "/Users/ivica.matic/not1mm/venv/lib/python3.12/site-packages/sounddevice.py", line 2664, in start_stream
    self.stream = StreamClass(samplerate=samplerate,
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ivica.matic/not1mm/venv/lib/python3.12/site-packages/sounddevice.py", line 1532, in __init__
    _StreamBase.__init__(self, kind='output', wrap_callback='array',
  File "/Users/ivica.matic/not1mm/venv/lib/python3.12/site-packages/sounddevice.py", line 833, in __init__
    _get_stream_parameters(kind, device, channels, dtype, latency,
  File "/Users/ivica.matic/not1mm/venv/lib/python3.12/site-packages/sounddevice.py", line 2734, in _get_stream_parameters
    device = _get_device_id(device, kind, raise_on_error=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ivica.matic/not1mm/venv/lib/python3.12/site-packages/sounddevice.py", line 2900, in _get_device_id
    raise ValueError(
ValueError: No output device matching 'default'
zsh: abort      python3 not1mm
```