### PR TITLE
Fix: Handle float format frequency responses in certain rigctld emulators.

### DIFF
--- a/not1mm/lib/cat_interface.py
+++ b/not1mm/lib/cat_interface.py
@@ -369,8 +369,9 @@ class CAT:
                 logger.debug("%s", report)
                 if report.startswith("get_freq:|") and "RPRT 0" in report:
                     seg_rpt = report.split("|")
-                    return seg_rpt[1].split(" ")[1]
-            except (socket.error, IndexError) as exception:
+                    freq_str = seg_rpt[1].split(" ")[1]
+                    return str(int(float(freq_str)))
+            except (socket.error, IndexError, ValueError) as exception:
                 self.online = False
                 logger.debug(f"{exception=}")
                 self.rigctrlsocket = None


### PR DESCRIPTION
Some rigctld emulators have specific quirks. In this case, the issue lies with how the f command is handled.

While the original rigctld returns an integer string like 14123000 when operating at 14.123 MHz, certain emulators return a float string format like 14123000.000000. Currently, not1mm fails to process this float format, causing unexpected behavior.