### PR TITLE
Split CAT class into three separate for flrig, rigctld and fake

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -2719,10 +2719,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.cw.set_winkeyer_speed(self.cw.speed)
         if self.rig_control and self.rig_control.cat:
             if self.pref.get("cwtype") == 3:
-                if self.rig_control.interface == "flrig":
-                    self.rig_control.cat.set_flrig_cw_speed(self.cw.speed)
-                elif self.rig_control.interface == "rigctld":
-                    self.rig_control.cat.set_rigctl_cw_speed(self.cw.speed)
+                self.rig_control.set_cw_speed(self.cw.speed)
 
     def stop_cw(self) -> None:
         """"""
@@ -2739,11 +2736,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.rig_control and self.rig_control.cat:
             if self.rig_control.online:
                 if self.pref.get("cwtype") == 3:
-                    if self.rig_control.interface == "flrig":
-                        self.rig_control.cat.set_flrig_cw_send(False)
-                        self.rig_control.cat.set_flrig_cw_send(True)
-                    if self.rig_control.interface == "rigctld":
-                        self.rig_control.cat.stopcwrigctl()
+                    self.rig_control.stopcw()
 
     def stop_all(self) -> None:
         """Stop CW and rotator."""
@@ -4590,9 +4583,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 if self.rig_control.online:
                     self.rig_control.set_mode(self.rig_control.last_cw_mode)
                     if self.pref.get("cwtype") == 3 and self.rig_control is not None:
-                        if self.rig_control.interface == "flrig":
-                            self.cwspeed_spinbox_changed()
-                            self.rig_control.cat.set_flrig_cw_send(True)
+                        self.cwspeed_spinbox_changed()
+                        self.rig_control.set_cw_send(True)
             else:
                 self.setmode("CW")
                 self.radio_state["mode"] = "CW"

--- a/not1mm/lib/cat_fake.py
+++ b/not1mm/lib/cat_fake.py
@@ -5,6 +5,8 @@ GPL V3
 """
 
 import logging
+import os
+from not1mm.lib.cat_interface import CAT
 
 if __name__ == "__main__":
     print("I'm not the program you are looking for.")
@@ -12,13 +14,13 @@ if __name__ == "__main__":
 logger = logging.getLogger("cat_interface")
 
 
-class CAT:
-    """CAT control base class"""
+class FakeCAT(CAT):
+    """CAT control fake radio for testing without a real rig"""
 
     def __init__(self, host: str, port: int) -> None:
         """
         Computer Aided Transceiver abstraction class.
-        Offers a normalized interface; this is the base class.
+        Offers a normalized interface; this is the "fake" class.
 
         Takes 2 inputs to setup the class.
 
@@ -27,67 +29,70 @@ class CAT:
         An integer defining the network port used.
         Commonly 12345 for flrig, or 4532 for rigctld.
 
-        Exposed methods are:
-
-        reinit()
-        get_vfo() set_vfo()
-        get_mode() set_mode()
-        get_power() set_power()
-        get_ptt() ptt_on() ptt_off()
-        sendcw() stopcw() set_cw_speed() set_cw_send()
-
-        A variable 'online' is set to True if no error was encountered,
-        otherwise False.
+        A variable 'online' is always True.
         """
-        self.interface = ""
-        self.host = host
-        self.port = port
-        self.online = False
-
-    def reinit(self):
-        """reinitialise rigctl"""
-
-    def sendvoicememory(self, memoryspot=1):
-        """..."""
-
-    def sendcw(self, texttosend):
-        """..."""
-
-    def stopcw(self):
-        """..."""
-
-    def set_cw_send(self, send: bool) -> None:
-        """Enable or disable the radio's CW keyer send flag."""
+        super().__init__(host, port)
+        self.interface = "fake"
+        self.online = True
+        self.fake_radio = {
+            "vfo": "14032000",
+            "mode": "CW",
+            "bw": "500",
+            "power": "100",
+            "modes": ["CW", "USB", "LSB", "RTTY"],
+            "ptt": False,
+        }
+        logger.debug("Using Fake Rig")
 
     def get_vfo(self) -> str:
         """Poll the radio for current vfo using the interface"""
+        vfo = self.fake_radio.get("vfo", "")
+        return vfo
 
     def get_mode(self) -> str:
         """Returns the current mode filter width of the radio"""
+        mode = self.fake_radio.get("mode")
+        return mode
 
     def get_bw(self):
         """Get current vfo bandwidth"""
+        return self.fake_radio.get("bw")
 
     def get_power(self):
         """Get power level from rig"""
+        return self.fake_radio.get("power", "100")
 
     def get_ptt(self):
-        """Get PTT state"""
+        return self.fake_radio.get("ptt", False)
 
     def get_mode_list(self):
         "Get a list of modes supported by the radio"
+        return self.fake_radio.get("modes")
 
     def set_vfo(self, freq: str) -> bool:
-        """Sets the radios vfo"""
+        try:
+            self.fake_radio["vfo"] = str(freq)
+            return True
+        except ValueError:
+            ...
+        return False
 
     def set_mode(self, mode: str) -> bool:
         """Sets the radios mode"""
+        self.fake_radio["mode"] = mode
+        return True
 
     def set_power(self, power):
         """Sets the radios power"""
+        self.fake_radio["power"] = str(power)
+        return True
 
     def ptt_on(self):
         """turn ptt on/off"""
+        self.fake_radio["ptt"] = True
+        return True
 
     def ptt_off(self):
         """turn ptt on/off"""
+        self.fake_radio["ptt"] = False
+        return True

--- a/not1mm/lib/cat_flrig.py
+++ b/not1mm/lib/cat_flrig.py
@@ -1,0 +1,428 @@
+"""
+K6GTE, CAT interface abstraction
+Email: michael.bridak@gmail.com
+GPL V3
+
+rig.cwio_set_wpm          n:i  set cwio WPM
+rig.cwio_text             i:s  send text via cwio interface
+rig.cwio_send             n:i  cwio transmit 1/0 (on/off)
+command lines to test the CW API via XMLRPC
+
+Setting WPM
+curl -d "<?xml version='1.0'?><methodCall><methodName>rig.cwio_set_wpm</methodName><params><param><value><i4>28</i4></value></param></params></methodCall>" http://localhost:12345
+
+Setting the text to send
+curl -d "<?xml version='1.0'?><methodCall><methodName>rig.cwio_text</methodName><params><param><value><string>test test test</string></value></param></params></methodCall>" http://localhost:12345
+
+Enable send
+curl -d "<?xml version='1.0'?><methodCall><methodName>rig.cwio_send</methodName><params><param><value><i4>1</i4></value></param></params></methodCall>" http://localhost:12345
+"""
+
+import logging
+import socket
+import xmlrpc.client
+import http
+import os
+from not1mm.lib.cat_interface import CAT
+
+if __name__ == "__main__":
+    print("I'm not the program you are looking for.")
+
+logger = logging.getLogger("cat_interface")
+
+
+class FlrigCAT(CAT):
+    """CAT control via flrig"""
+
+    def __init__(self, host: str, port: int) -> None:
+        """
+        Computer Aided Transceiver abstraction class.
+        Offers a normalized interface; this is the flrig class.
+
+        Takes 2 inputs to setup the class.
+
+        A string defining the host, example: 'localhost' or '127.0.0.1'
+
+        An integer defining the network port used.
+        Commonly 12345 for flrig.
+
+        A variable 'online' is set to True if no error was encountered,
+        otherwise False.
+        """
+        super().__init__(host, port)
+        self.server = None
+        self.interface = "flrig"
+
+        target = f"http://{self.host}:{self.port}"
+        logger.debug("%s", target)
+        self.server = xmlrpc.client.ServerProxy(target)
+        self.online = True
+        try:
+            _ = self.server.main.get_version()
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            socket.error,
+            socket.gaierror,
+            TimeoutError,
+            OSError,
+        ):
+            self.online = False
+
+    def sendcw(self, texttosend):
+        """..."""
+        logger.debug(f"{texttosend=} {self.interface=}")
+        self.sendcwxmlrpc(texttosend)
+
+    def sendcwxmlrpc(self, texttosend):
+        """Add text to flrig's cw send buffer."""
+        logger.debug(f"{texttosend=}")
+        try:
+            self.online = True
+            self.server.rig.cwio_text(texttosend)
+            return
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            http.client.CannotSendRequest,
+            http.client.ResponseNotReady,
+            TimeoutError,
+            OSError,
+        ) as exception:
+            self.online = False
+            logger.debug("%s", f"{exception}")
+        return False
+
+    def stopcw(self):
+        self.set_cw_send(False)
+        self.set_cw_send(True)
+
+    def set_cw_send(self, send: bool) -> None:
+        """Turn on flrig cw keyer send flag."""
+        try:
+            self.online = True
+            self.server.rig.cwio_send(int(send))
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            http.client.CannotSendRequest,
+            http.client.ResponseNotReady,
+            ValueError,
+            TimeoutError,
+            OSError,
+        ) as exception:
+            self.online = False
+            logger.debug("%s", f"{exception}")
+
+    def set_cw_speed(self, speed):
+        """Set flrig's CW send speed"""
+        try:
+            self.online = True
+            self.server.rig.cwio_set_wpm(int(speed))
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            http.client.CannotSendRequest,
+            http.client.ResponseNotReady,
+            ValueError,
+            TimeoutError,
+            OSError,
+        ) as exception:
+            self.online = False
+            logger.debug("%s", f"{exception}")
+
+    def get_vfo(self) -> str:
+        """Poll the radio for current vfo using the interface"""
+        try:
+            self.online = True
+            vfo_value = self.server.rig.get_vfo()
+            logger.debug(f"{vfo_value=}")
+            return vfo_value
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            http.client.CannotSendRequest,
+            http.client.ResponseNotReady,
+            AttributeError,
+            TimeoutError,
+            OSError,
+        ) as exception:
+            self.online = False
+            logger.debug(f"{exception=}")
+        return ""
+
+    def get_mode(self) -> str:
+        """Returns the current mode filter width of the radio"""
+        # QMX ['CW-U', 'CW-L', 'DIGI-U', 'DIGI-L']
+        # 7300 ['LSB', 'USB', 'AM', 'FM', 'CW', 'CW-R', 'RTTY', 'RTTY-R', 'LSB-D', 'USB-D', 'AM-D', 'FM-D']
+        try:
+            self.online = True
+            mode_value = self.server.rig.get_mode()
+            logger.debug(f"{mode_value=}")
+            return mode_value
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            http.client.CannotSendRequest,
+            http.client.ResponseNotReady,
+            AttributeError,
+            TimeoutError,
+            OSError,
+        ) as exception:
+            self.online = False
+            logger.debug("%s", f"{exception}")
+        return ""
+
+    def get_bw(self):
+        """Get current vfo bandwidth"""
+        try:
+            self.online = True
+            bandwidth = self.server.rig.get_bw()
+            logger.debug(f"{bandwidth=}")
+            return bandwidth[0]
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            http.client.CannotSendRequest,
+            http.client.ResponseNotReady,
+            AttributeError,
+            TimeoutError,
+            OSError,
+        ) as exception:
+            self.online = False
+            logger.debug("getbw_flrig: %s", f"{exception}")
+            return ""
+
+    def get_power(self):
+        """Get power level from rig"""
+        try:
+            self.online = True
+            return self.server.rig.get_power()
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            http.client.CannotSendRequest,
+            http.client.ResponseNotReady,
+            TimeoutError,
+            OSError,
+        ) as exception:
+            self.online = False
+            logger.debug("getpower_flrig: %s", f"{exception}")
+            return ""
+
+    def get_ptt(self):
+        """Get PTT state"""
+        try:
+            self.online = True
+            return self.server.rig.get_ptt()
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            http.client.CannotSendRequest,
+            http.client.ResponseNotReady,
+            TimeoutError,
+            OSError,
+        ) as exception:
+            self.online = False
+            logger.debug("%s", f"{exception}")
+        return "0"
+
+    def get_mode_list(self):
+        "Get a list of modes supported by the radio"
+        try:
+            self.online = True
+            mode_list = self.server.rig.get_modes()
+            logger.debug(f"{mode_list=}")
+            return mode_list
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            http.client.CannotSendRequest,
+            http.client.ResponseNotReady,
+            AttributeError,
+            TimeoutError,
+            OSError,
+        ) as exception:
+            self.online = False
+            logger.debug("%s", f"{exception}")
+        return ""
+
+    def set_vfo(self, freq: str) -> bool:
+        """Sets the radios vfo"""
+        try:
+            return self.__setvfo_flrig(freq)
+        except ValueError:
+            ...
+        return False
+
+    def __setvfo_flrig(self, freq: str) -> bool:
+        """Sets the radios vfo"""
+        try:
+            self.online = True
+            return self.server.rig.set_frequency(float(freq))
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            http.client.CannotSendRequest,
+            http.client.ResponseNotReady,
+            AttributeError,
+            TimeoutError,
+            OSError,
+        ) as exception:
+            self.online = False
+            logger.debug("setvfo_flrig: %s", f"{exception}")
+        return False
+
+    def set_mode(self, mode: str) -> bool:
+        """Sets the radios mode"""
+        try:
+            self.online = True
+            logger.debug(f"{mode=}")
+            set_mode_result = self.server.rig.set_mode(mode)
+            logger.debug(f"self.server.rig.setmode(mode) = {set_mode_result}")
+            return set_mode_result
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            http.client.CannotSendRequest,
+            http.client.ResponseNotReady,
+            AttributeError,
+            TimeoutError,
+            OSError,
+        ) as exception:
+            self.online = False
+            logger.debug(f"{exception=}")
+        return False
+
+    def set_power(self, power):
+        """Sets the radios power"""
+        try:
+            self.online = True
+            return self.server.rig.set_power(power)
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            http.client.CannotSendRequest,
+            http.client.ResponseNotReady,
+            AttributeError,
+            TimeoutError,
+            OSError,
+        ) as exception:
+            self.online = False
+            logger.debug("setpower_flrig: %s", f"{exception}")
+            return False
+
+    def ptt_on(self):
+        """turn ptt on/off"""
+        try:
+            self.online = True
+            return self.server.rig.set_ptt(1)
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            http.client.CannotSendRequest,
+            http.client.ResponseNotReady,
+            AttributeError,
+            TimeoutError,
+            OSError,
+        ) as exception:
+            self.online = False
+            logger.debug("%s", f"{exception}")
+        return "0"
+
+    def ptt_off(self):
+        """turn ptt on/off"""
+        try:
+            self.online = True
+            return self.server.rig.set_ptt(0)
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            http.client.CannotSendRequest,
+            http.client.ResponseNotReady,
+            AttributeError,
+            TimeoutError,
+            OSError,
+        ) as exception:
+            self.online = False
+            logger.debug("%s", f"{exception}")
+        return "0"
+
+    def send_cat_string(self, cmdstr=""):
+        """send a raw cat string to radio"""
+        cmdstr = cmdstr.strip()
+        test1 = cmdstr.replace(" ", "")
+        if test1 == "":
+            return True
+        working = cmdstr
+        test2 = [" ", " x", " X", "\\"]
+        test3 = "0123456789ABCDEF "  # trailing space
+        ishex = False
+        # does this look like hex?
+        for c2 in test2:
+            if c2 in working:
+                ishex = True
+        if ishex:
+            working = working.replace("x", "")
+            working = working.replace("X", "")
+            working = working.replace("\\", "")
+            working = working.upper()
+            # should be space-delimited now
+            # any illegal chars?
+            for c3 in working:
+                if c3 not in test3:
+                    logger.debug(f"Bad char in command string: [{cmdstr}]")
+                    return True
+            # hex checks out so far
+            spacesok = True
+            for i in range(len(working)):
+                if (i + 1) % 3 == 0:  # every 3rd char
+                    if working[i] != " ":
+                        spacesok = False
+            if not spacesok:
+                logger.debug(f"Bad delimiters in cmd string: [{cmdstr}]")
+                return True
+        else:
+            """not hex, but plain ascii text - do nothing"""
+
+        return self.__send_cat_string_flrig(working, ishex)
+
+    def __send_cat_string_flrig(self, cmd, thisishex):
+        """convert string to flrig format, send to flrig"""
+        if thisishex:
+            # make string " x" delimited (again) for flrig
+            cmd = "x" + cmd
+            cmd = cmd.replace(" ", " x")
+        else:
+            """ascii - do nothing"""
+        logger.debug("%s", f"Sending rig command: [{cmd}]")
+        try:
+            return self.server.rig.cat_string(cmd)
+        except (
+            ConnectionRefusedError,
+            xmlrpc.client.Fault,
+            http.client.BadStatusLine,
+            http.client.CannotSendRequest,
+            http.client.ResponseNotReady,
+            AttributeError,
+            TimeoutError,
+            OSError,
+        ) as exception:
+            self.online = False
+            logger.debug("%s", f"{exception}")
+        return "0"

--- a/not1mm/lib/cat_rigctld.py
+++ b/not1mm/lib/cat_rigctld.py
@@ -1,0 +1,483 @@
+"""
+K6GTE, CAT interface abstraction
+Email: michael.bridak@gmail.com
+GPL V3
+"""
+
+import logging
+import socket
+import os
+from not1mm.lib.cat_interface import CAT
+
+if __name__ == "__main__":
+    print("I'm not the program you are looking for.")
+
+logger = logging.getLogger("cat_interface")
+
+
+class RigctldCAT(CAT):
+    """CAT control via rigctld"""
+
+    def __init__(self, host: str, port: int) -> None:
+        """
+        Computer Aided Transceiver abstraction class.
+        Offers a normalized interface; this is the rigctld class.
+
+        Takes 2 inputs to setup the class.
+
+        A string defining the host, example: 'localhost' or '127.0.0.1'
+
+        An integer defining the network port used.
+        Commonly 4532 for rigctld.
+
+        A variable 'online' is set to True if no error was encountered,
+        otherwise False.
+        """
+        super().__init__(host, port)
+        self.rigctrlsocket = None
+        self.rigctld_bw = "0"
+        self.interface = "rigctld"
+        self.__initialize_rigctrld()
+
+    def __initialize_rigctrld(self):
+        try:
+            logger.debug("Connecting to rigctrld %s %d", self.host, self.port)
+            self.rigctrlsocket = socket.socket()
+            self.rigctrlsocket.settimeout(1.0)
+            self.rigctrlsocket.connect((self.host, self.port))
+            logger.debug("Connected to rigctrld")
+            self.online = True
+        except (
+            ConnectionRefusedError,
+            TimeoutError,
+            OSError,
+            socket.error,
+            socket.gaierror,
+        ) as exception:
+            self.rigctrlsocket = None
+            self.online = False
+            logger.debug("%s", f"{exception}")
+
+    def reinit(self):
+        """reinitialise rigctl"""
+        self.__initialize_rigctrld()
+
+    def __get_serial_string(self):
+        """Gets any serial data waiting"""
+        dump = ""
+        thegrab = ""
+        if self.rigctrlsocket is None:
+            return ""
+        if hasattr(self.rigctrlsocket, "settimeout"):
+            self.rigctrlsocket.settimeout(0.1)
+            try:
+                while True and hasattr(self.rigctrlsocket, "recv"):
+                    thegrab = self.rigctrlsocket.recv(1024).decode()
+                    dump += thegrab
+                    if thegrab == "":
+                        break
+            except (socket.error, UnicodeDecodeError):
+                ...
+            # self.rigctrlsocket.settimeout(0.1)
+        # logger.debug("%s", dump)
+        if os.environ.get("SEERIGCTLD", False):
+            print(repr(dump))
+        return dump
+
+    def sendvoicememory(self, memoryspot=1):
+        """..."""
+        return self.__sendvoicememory_rigctld(memoryspot)
+
+    def __sendvoicememory_rigctld(self, memoryspot=1):
+        """..."""
+        try:
+            self.online = True
+            self.rigctrlsocket.send(bytes(f"+\\send_voice_mem {memoryspot}\n", "utf-8"))
+            info = self.__get_serial_string()
+            logger.debug("%s", info)
+            return
+        except socket.error as exception:
+            self.online = False
+            logger.debug("%s", f"{exception}")
+            self.rigctrlsocket = None
+            return
+
+    def sendcw(self, texttosend):
+        """..."""
+        logger.debug(f"{texttosend=} {self.interface=}")
+        self.sendcwrigctl(texttosend)
+
+    def sendcwrigctl(self, texttosend):
+        """Send text via rigctld"""
+        if self.rigctrlsocket is not None:
+            try:
+                self.online = True
+                if hasattr(self.rigctrlsocket, "send"):
+                    self.rigctrlsocket.send(bytes(f"b {texttosend}\n", "utf-8"))
+                else:
+                    self.rigctrlsocket = None
+                    self.online = False
+                    return False
+                info = self.__get_serial_string()
+                logger.debug("%s", info)
+                return True
+            except socket.error as exception:
+                self.online = False
+                logger.debug("setvfo_rigctld: %s", f"{exception}")
+                self.rigctrlsocket = None
+                return False
+        self.__initialize_rigctrld()
+        return False
+
+    def stopcw(self):
+        """Stop CW via rigctld"""
+        if self.rigctrlsocket is not None:
+            try:
+                self.online = True
+                if hasattr(self.rigctrlsocket, "send"):
+                    self.rigctrlsocket.send(bytes("\\stop_morse\n", "utf-8"))
+                else:
+                    self.rigctrlsocket = None
+                    self.online = False
+                    return False
+                _ = self.__get_serial_string()
+                return True
+            except socket.error as exception:
+                self.online = False
+                logger.debug("setvfo_rigctld: %s", f"{exception}")
+                self.rigctrlsocket = None
+                return False
+        self.__initialize_rigctrld()
+        return False
+
+    def set_cw_speed(self, speed):
+        """Set CW speed via rigctld"""
+        if self.rigctrlsocket is not None:
+            try:
+                self.online = True
+                if hasattr(self.rigctrlsocket, "send"):
+                    self.rigctrlsocket.send(bytes(f"L KEYSPD {speed}\n", "utf-8"))
+                else:
+                    self.rigctrlsocket = None
+                    self.online = False
+                    return
+                info = self.__get_serial_string()
+                logger.debug("%s", info)
+                return
+            except socket.error as exception:
+                self.online = False
+                logger.debug("set_level_rigctld: %s", f"{exception}")
+                self.rigctrlsocket = None
+                return
+        self.__initialize_rigctrld()
+
+    def get_vfo(self) -> str:
+        """Poll the radio for current vfo using the interface"""
+        vfo = self.__getvfo_rigctld()
+        if "RPRT -" in vfo:
+            vfo = ""
+        return vfo
+
+    def __getvfo_rigctld(self) -> str:
+        """Returns VFO freq returned from rigctld"""
+        if self.rigctrlsocket is not None:
+            try:
+                self.online = True
+                if hasattr(self.rigctrlsocket, "send"):
+                    self.rigctrlsocket.send(b"|f\n")
+                else:
+                    self.rigctrlsocket = None
+                    self.online = False
+                    return ""
+                report = self.__get_serial_string().strip()
+                logger.debug("%s", report)
+                if report.startswith("get_freq:|") and "RPRT 0" in report:
+                    seg_rpt = report.split("|")
+                    return seg_rpt[1].split(" ")[1]
+            except (socket.error, IndexError) as exception:
+                self.online = False
+                logger.debug(f"{exception=}")
+                self.rigctrlsocket = None
+            return ""
+
+        self.__initialize_rigctrld()
+        return ""
+
+    def get_mode(self) -> str:
+        """Returns the current mode filter width of the radio"""
+        # QMX 'DIGI-U DIGI-L CW-U CW-L' or 'LSB', 'USB', 'CW', 'FM', 'AM', 'FSK'
+        # 7300 'AM CW USB LSB RTTY FM CWR RTTYR PKTLSB PKTUSB FM-D AM-D'
+        if self.rigctrlsocket is not None:
+            try:
+                self.online = True
+                if hasattr(self.rigctrlsocket, "send"):
+                    self.rigctrlsocket.send(b"|m\n")
+                else:
+                    self.rigctrlsocket = None
+                    self.online = False
+                    return ""
+                # get_mode:|Mode: CW|Passband: 500|RPRT 0
+                report = self.__get_serial_string().strip()
+                logger.debug("%s", report)
+                if report.startswith("get_mode:|") and "RPRT 0" in report:
+                    seg_rpt = report.split("|")
+                    self.rigctld_bw = seg_rpt[2].split(" ")[1]
+                    return seg_rpt[1].split(" ")[1]
+            except IndexError as exception:
+                logger.debug("%s", f"{exception}")
+            except socket.error as exception:
+                self.online = False
+                logger.debug("%s", f"{exception}")
+                self.rigctrlsocket = None
+            return ""
+        self.__initialize_rigctrld()
+        return ""
+
+    def get_bw(self):
+        """Get current vfo bandwidth"""
+        return self.rigctld_bw
+
+    def get_power(self):
+        """Get power level from rig"""
+        if self.rigctrlsocket is not None:
+            try:
+                self.online = True
+                if hasattr(self.rigctrlsocket, "send"):
+                    self.rigctrlsocket.send(b"|l RFPOWER\n")
+                else:
+                    self.rigctrlsocket = None
+                    self.online = False
+                    return ""
+                # get_level: RFPOWER|0.000000|RPRT 0
+                report = self.__get_serial_string().strip()
+                logger.debug("%s", report)
+                if "get_level: RFPOWER|" in report and "RPRT 0" in report:
+                    seg_rpt = report.split("|")
+                    return int(float(seg_rpt[1]) * 100)
+            except socket.error as exception:
+                self.online = False
+                logger.debug("getpower_rigctld: %s", f"{exception}")
+                self.rigctrlsocket = None
+            return ""
+
+    def get_ptt(self):
+        """Get PTT state"""
+        if self.rigctrlsocket is not None:
+            try:
+                self.online = True
+                if hasattr(self.rigctrlsocket, "send"):
+                    self.rigctrlsocket.send(b"t\n")
+                else:
+                    self.rigctrlsocket = None
+                    self.online = False
+                    return "0"
+                ptt = self.__get_serial_string()
+                logger.debug("%s", ptt)
+                ptt = ptt.strip()
+                return ptt
+            except socket.error as exception:
+                self.online = False
+                logger.debug("%s", f"{exception}")
+                self.rigctrlsocket = None
+        return "0"
+
+    def get_mode_list(self):
+        "Get a list of modes supported by the radio"
+        # Mode list: AM CW USB LSB RTTY FM CWR RTTYR
+        if self.rigctrlsocket:
+            try:
+                self.online = True
+                if hasattr(self.rigctrlsocket, "send"):
+                    self.rigctrlsocket.send(b"1\n")
+                else:
+                    self.rigctrlsocket = None
+                    self.online = False
+                    return ""
+                dump = self.__get_serial_string()
+                for line in dump.splitlines():
+                    if "Mode list:" in line:
+                        modes = line.split(":")[1].strip()
+                        return modes
+                return ""
+            except socket.error as exception:
+                self.online = False
+                logger.debug("%s", f"{exception}")
+                self.rigctrlsocket = None
+        return ""
+
+    def set_vfo(self, freq: str) -> bool:
+        """Sets the radios vfo"""
+        try:
+            return self.__setvfo_rigctld(freq)
+        except ValueError:
+            ...
+        return False
+
+    def __setvfo_rigctld(self, freq: str) -> bool:
+        """sets the radios vfo"""
+        if self.rigctrlsocket is not None:
+            try:
+                self.online = True
+                if hasattr(self.rigctrlsocket, "send"):
+                    self.rigctrlsocket.send(bytes(f"|F {freq}\n", "utf-8"))
+                else:
+                    self.rigctrlsocket = None
+                    self.online = False
+                    return False
+                info = self.__get_serial_string()
+                logger.debug("%s", info)
+                return True
+            except socket.error as exception:
+                self.online = False
+                logger.debug("setvfo_rigctld: %s", f"{exception}")
+                self.rigctrlsocket = None
+                return False
+        self.__initialize_rigctrld()
+        return False
+
+    def set_mode(self, mode: str) -> bool:
+        """Sets the radios mode"""
+        if self.rigctrlsocket:
+            try:
+                self.online = True
+                # logger.debug(f"\nM {mode} 0\n")
+                if hasattr(self.rigctrlsocket, "send"):
+                    self.rigctrlsocket.send(bytes(f"\n|M {mode} 0\n", "utf-8"))
+                else:
+                    self.rigctrlsocket = None
+                    self.online = False
+                    return False
+                info = self.__get_serial_string()
+                logger.debug("%s", info)
+                return True
+            except socket.error as exception:
+                self.online = False
+                logger.debug("setmode_rigctld: %s", f"{exception}")
+                self.rigctrlsocket = None
+                return False
+        self.__initialize_rigctrld()
+        return False
+
+    def set_power(self, power):
+        """Sets the radios power"""
+        if power.isnumeric() and int(power) >= 1 and int(power) <= 100:
+            rig_cmd = bytes(f"|L RFPOWER {str(float(power) / 100)}\n", "utf-8")
+            try:
+                self.online = True
+                if hasattr(self.rigctrlsocket, "send"):
+                    self.rigctrlsocket.send(rig_cmd)
+                else:
+                    self.rigctrlsocket = None
+                    self.online = False
+                    return
+                info = self.__get_serial_string()
+                logger.debug("%s", info)
+            except socket.error:
+                self.online = False
+                self.rigctrlsocket = None
+
+    def ptt_on(self):
+        """turn ptt on/off"""
+
+        # T, set_ptt 'PTT'
+        # Set 'PTT'.
+        # PTT is a value: ‘0’ (RX), ‘1’ (TX), ‘2’ (TX mic), or ‘3’ (TX data).
+
+        # t, get_ptt
+        # Get 'PTT' status.
+        # Returns PTT as a value in set_ptt above.
+
+        rig_cmd = bytes("|T 1\n", "utf-8")
+        logger.debug("%s", f"{rig_cmd}")
+        try:
+            self.online = True
+            if hasattr(self.rigctrlsocket, "send"):
+                self.rigctrlsocket.send(rig_cmd)
+            else:
+                self.rigctrlsocket = None
+                self.online = False
+                return
+            info = self.__get_serial_string()
+            logger.debug("%s", info)
+        except socket.error:
+            self.online = False
+            self.rigctrlsocket = None
+
+    def ptt_off(self):
+        """turn ptt on/off"""
+        rig_cmd = bytes("|T 0\n", "utf-8")
+        logger.debug("%s", f"{rig_cmd}")
+        try:
+            self.online = True
+            if hasattr(self.rigctrlsocket, "send"):
+                self.rigctrlsocket.send(rig_cmd)
+            else:
+                self.rigctrlsocket = None
+                self.online = False
+                return
+            into = self.__get_serial_string()
+            logger.debug("%s", into)
+        except socket.error:
+            self.online = False
+            self.rigctrlsocket = None
+
+    def send_cat_string(self, cmdstr=""):
+        """send a raw cat string to radio"""
+        cmdstr = cmdstr.strip()
+        test1 = cmdstr.replace(" ", "")
+        if test1 == "":
+            return True
+        working = cmdstr
+        test2 = [" ", " x", " X", "\\"]
+        test3 = "0123456789ABCDEF "  # trailing space
+        ishex = False
+        # does this look like hex?
+        for c2 in test2:
+            if c2 in working:
+                ishex = True
+        if ishex:
+            working = working.replace("x", "")
+            working = working.replace("X", "")
+            working = working.replace("\\", "")
+            working = working.upper()
+            # should be space-delimited now
+            # any illegal chars?
+            for c3 in working:
+                if c3 not in test3:
+                    logger.debug(f"Bad char in command string: [{cmdstr}]")
+                    return True
+            # hex checks out so far
+            spacesok = True
+            for i in range(len(working)):
+                if (i + 1) % 3 == 0:  # every 3rd char
+                    if working[i] != " ":
+                        spacesok = False
+            if not spacesok:
+                logger.debug(f"Bad delimiters in cmd string: [{cmdstr}]")
+                return True
+        else:
+            """not hex, but plain ascii text - do nothing"""
+
+        return self.__send_cat_string_rigctld(working, ishex)
+
+    def __send_cat_string_rigctld(self, cmd, thisishex):
+        """convert string to rigctld format, send to rigctld"""
+        if not self.rigctrlsocket:
+            return 0
+        if thisishex:
+            # make string "\0x" delimited for rigctld
+            cmd = cmd.replace(" ", "\\0x")
+            cmd = "|w \\0x" + cmd
+        else:
+            cmd = "|w " + cmd
+        bcmd = bytes(cmd, "utf-8")
+        logger.debug("%s", f"Sending rig command: [{bcmd}]")
+
+        try:
+            if hasattr(self.rigctrlsocket, "send"):
+                self.rigctrlsocket.send(bcmd)
+        except socket.error:
+            logger.debug("Socket error!")
+            self.online = False
+            self.rigctrlsocket = None
+            return 0

--- a/not1mm/lib/cat_rigctld.py
+++ b/not1mm/lib/cat_rigctld.py
@@ -193,8 +193,9 @@ class RigctldCAT(CAT):
                 logger.debug("%s", report)
                 if report.startswith("get_freq:|") and "RPRT 0" in report:
                     seg_rpt = report.split("|")
-                    return seg_rpt[1].split(" ")[1]
-            except (socket.error, IndexError) as exception:
+                    freq_str = seg_rpt[1].split(" ")[1]
+                    return str(int(float(freq_str)))
+            except (socket.error, IndexError, ValueError) as exception:
                 self.online = False
                 logger.debug(f"{exception=}")
                 self.rigctrlsocket = None

--- a/not1mm/radio.py
+++ b/not1mm/radio.py
@@ -11,7 +11,9 @@ import logging
 
 from PyQt6.QtCore import QEventLoop, QObject, QThread, pyqtSignal
 
-from not1mm.lib.cat_interface import CAT
+from not1mm.lib.cat_flrig import FlrigCAT
+from not1mm.lib.cat_rigctld import RigctldCAT
+from not1mm.lib.cat_fake import FakeCAT
 
 logger = logging.getLogger("radio")
 
@@ -49,10 +51,16 @@ class Radio(QObject):
         self.interface = interface
         self.host = host
         self.port = port
+        logger.debug("Using %s: %s %d", interface, host, port)
 
     def run(self):
         try:
-            self.cat = CAT(self.interface, self.host, self.port)
+            if self.interface == "flrig":
+                self.cat = FlrigCAT(self.host, self.port)
+            elif self.interface == "rigctld":
+                self.cat = RigctldCAT(self.host, self.port)
+            else:
+                self.cat = FakeCAT(self.host, self.port)
             self.online = self.cat.online
             self.modes = self.cat.get_mode_list()
             for pos_cw in self.cw_list:
@@ -136,6 +144,21 @@ class Radio(QObject):
         logger.debug(f"Send CW: {texttosend}")
         if self.cat:
             self.cat.sendcw(texttosend)
+
+    def stopcw(self):
+        logger.debug("Stopping CW")
+        if self.cat:
+            self.cat.stopcw()
+
+    def set_cw_speed(self, speed):
+        logger.debug("Setting CW speed %d", speed)
+        if self.cat:
+            self.cat.set_cw_speed(speed)
+
+    def set_cw_send(self, send: bool) -> None:
+        logger.debug("Setting CW send %s", send)
+        if self.cat:
+            self.cat.set_cw_send(send)
 
     def set_vfo(self, vfo):
         self.vfoa = vfo

--- a/not1mm/vfo.py
+++ b/not1mm/vfo.py
@@ -24,7 +24,8 @@ from PyQt6.QtGui import QPalette
 from PyQt6.QtWidgets import QDockWidget
 
 import not1mm.fsutils as fsutils
-from not1mm.lib.cat_interface import CAT
+from not1mm.lib.cat_flrig import FlrigCAT
+from not1mm.lib.cat_rigctld import RigctldCAT
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ class VfoWindow(QDockWidget):
         self.action = action
         uic.loadUi(fsutils.APP_DATA_PATH / "vfo.ui", self)
         self.setWindowTitle("VFO Window")
-        self.rig_control: CAT | None = None
+        self.rig_control: FlrigCAT | RigctldCAT | None = None
         self.timer: QTimer = QTimer()
         self.timer.timeout.connect(self.getwaiting)
         self.load_pref()
@@ -80,8 +81,7 @@ class VfoWindow(QDockWidget):
                 "Using flrig: %s",
                 f"{self.pref.get('CAT_ip')} {self.pref.get('CAT_port')}",
             )
-            self.rig_control: CAT | None = CAT(
-                "flrig",
+            self.rig_control: FlrigCAT | None = FlrigCAT(
                 self.pref.get("CAT_ip", "127.0.0.1"),
                 int(self.pref.get("CAT_port", 12345)),
             )
@@ -91,8 +91,7 @@ class VfoWindow(QDockWidget):
                 "Using rigctld: %s",
                 f"{self.pref.get('CAT_ip')} {self.pref.get('CAT_port')}",
             )
-            self.rig_control: CAT | None = CAT(
-                "rigctld",
+            self.rig_control: RigctldCAT | None = RigctldCAT(
                 self.pref.get("CAT_ip", "127.0.0.1"),
                 int(self.pref.get("CAT_port", 4532)),
             )


### PR DESCRIPTION
This separates the three different implementations into separate files,
    making the code easier to read because it doesn't have all the different
    branches for all implementations in every method.

Remove the "sane IP" check method. It accepted only IPs in places that
    could also accept hostnames (and v6 IPs), failing initialization. The
    code still worked with hostnames, though, because reinit didn't have the
    check.