### PR TITLE
Fix bandmap zoom on 160m

### DIFF
--- a/not1mm/bandmap.py
+++ b/not1mm/bandmap.py
@@ -884,12 +884,12 @@ class BandMapWindow(QDockWidget):
         }
         step, digits = return_zoom.get(self.zoom, (0.1, 1))
 
-        if self.currentBand.start >= 28.0 and self.currentBand.start < 420.0:
+        if self.currentBand.start >= 50_000.0 and self.currentBand.start < 420_000.0:
             step = step * 10
-            return (step, digits)
-
-        if self.currentBand.start >= 420.0 and self.currentBand.start < 2300.0:
+            digits = 0
+        elif self.currentBand.start >= 420_000.0 and self.currentBand.start < 2300_000.0:
             step = step * 100
+            digits = 0
 
         return (step, digits)
 


### PR DESCRIPTION
When I converted the bandmap to work with kHz instead of MHz, I neglected to update the code that automatically zooms in on the VHF and UHF bands. Instead, the code thought the 160m band was on UHF and displayed it very compressed only.

After fixing that, I realized that the HF zoom levels are in fact necessary on 10m as well when the band is crowded, so the VHF cutoff is now 50 instead of 28 MHz. If rendering becomes too slow for higher zoom levels there, we should instead clamp the upper 10m frequency to 29000.