### PR TITLE
Move preferences handling into a single place

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -95,6 +95,7 @@ from not1mm.lib.ham_utility import (
 from not1mm.lib.multicast import Multicast
 from not1mm.lib.n1mm import N1MM
 from not1mm.lib.new_contest import NewContest
+from not1mm.lib.preferences import Preferences
 from not1mm.lib.select_contest import SelectContest
 from not1mm.lib.settings import Settings
 from not1mm.lib.super_check_partial import SCP
@@ -120,60 +121,6 @@ class MainWindow(QtWidgets.QMainWindow):
     """
 
     ctyfile = {}
-    pref_ref = {
-        "sounddevice": "default",
-        "useqrz": False,
-        "lookupusername": "username",
-        "lookuppassword": "password",
-        "run_state": True,
-        "command_buttons": False,
-        "cw_macros": True,
-        "bands_modes": True,
-        "bands": ["160", "80", "40", "20", "15", "10"],
-        "current_database": "ham.db",
-        "contest": "",
-        "multicast_group": "239.1.1.1",
-        "multicast_port": 2239,
-        "interface_ip": "0.0.0.0",
-        "send_rtc_scores": False,
-        "rtc_url": "",
-        "rtc_user": "",
-        "rtc_pass": "",
-        "rtc_interval": 2,
-        "send_n1mm_packets": False,
-        "n1mm_station_name": "20M CW Tent",
-        "n1mm_operator": "Bernie",
-        "n1mm_radioport": "127.0.0.1:12060",
-        "n1mm_contactport": "127.0.0.1:12060",
-        "n1mm_lookupport": "127.0.0.1:12060",
-        "n1mm_scoreport": "127.0.0.1:12060",
-        "usehamdb": False,
-        "usehamqth": False,
-        "cloudlog": False,
-        "cloudlogapi": "",
-        "cloudlogurl": "",
-        "CAT_ip": "127.0.0.1",
-        "userigctld": False,
-        "useflrig": False,
-        "cwip": "127.0.0.1",
-        "cwport": 6789,
-        "cwtype": 0,
-        "useserver": False,
-        "im_the_master": False,
-        "CAT_port": 4532,
-        "cluster_server": "dxc.nc7j.com",
-        "cluster_port": 7373,
-        "cluster_filter": "Set DX Filter SpotterCont=NA",
-        "cluster_mode": "OPEN",
-        "cluster_expire": 1,
-        "logwindow": False,
-        "bandmapwindow": False,
-        "checkwindow": False,
-        "vfowindow": False,
-        "ratewindow": False,
-        "statisticswindow": False,
-        "darkmode": True,
-    }
     appstarted = False
     contact = {}
     contest = None
@@ -734,16 +681,16 @@ class MainWindow(QtWidgets.QMainWindow):
                 "There ws an error parsing the BigCity file.", blocking=False
             )
 
-        self.show_splash_msg("Starting LookUp Service.")
+        self.show_splash_msg("Reading preferences.")
+        self.pref = Preferences.load()
+        self.apply_preferences()
 
+        self.show_splash_msg("Starting LookUp Service.")
         self.lookup_service = LookupService()
         self.lookup_service.message.connect(self.dockwidget_message)
         self.lookup_service.hide()
 
         self.server_seen = datetime.datetime.now()
-
-        self.show_splash_msg("Reading preferences.")
-        self.readpreferences()
 
         self.show_splash_msg("Starting voice thread.")
         self.voice_process = Voice()
@@ -1477,7 +1424,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def cluster_expire_updated(self, number: str) -> None:
         """signal from bandmap"""
         self.pref["cluster_expire"] = int(number)
-        self.write_preference()
+        Preferences.save()
 
     def fldigi_qso(self, result: str) -> None:
         """
@@ -1712,7 +1659,7 @@ class MainWindow(QtWidgets.QMainWindow):
         -------
         None
         """
-        self.write_preference()
+        Preferences.save()
         cmd = {}
         cmd["cmd"] = "HALT"
         if self.lookup_service:
@@ -1851,9 +1798,9 @@ class MainWindow(QtWidgets.QMainWindow):
         """
 
         self.configuration_dialog.save_changes()
-        self.write_preference()
+        Preferences.save()
         # logger.debug("%s", f"{self.pref}")
-        self.readpreferences()
+        self.apply_preferences()
         self.voice_process.sounddevice = self.pref.get("sounddevice", "default")
 
     def new_database(self) -> None:
@@ -1874,7 +1821,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if filename[-3:] != ".db":
                 filename += ".db"
             self.pref["current_database"] = os.path.basename(filename)
-            self.write_preference()
+            Preferences.save()
             self.dbname = fsutils.USER_DATA_PATH / self.pref.get(
                 "current_database", "ham.db"
             )
@@ -1923,7 +1870,7 @@ class MainWindow(QtWidgets.QMainWindow):
         filename = self.filepicker("open")
         if filename:
             self.pref["current_database"] = os.path.basename(filename)
-            self.write_preference()
+            Preferences.save()
             self.dbname = fsutils.USER_DATA_PATH / self.pref.get(
                 "current_database", "ham.db"
             )
@@ -2036,7 +1983,7 @@ class MainWindow(QtWidgets.QMainWindow):
         selected_row = self.contest_dialog.contest_list.currentRow()
         contest = self.contest_dialog.contest_list.item(selected_row, 0).text()
         self.pref["contest"] = contest
-        self.write_preference()
+        Preferences.save()
         logger.debug("Selected contest: %s", f"{contest}")
         self.load_contest()
         self.worked_list = self.database.get_calls_and_bands()
@@ -2161,7 +2108,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         logger.debug("%s", f"{contest}")
         self.database.update_contest(contest)
-        self.write_preference()
+        Preferences.save()
         self.load_contest()
 
     def load_contest(self) -> None:
@@ -2483,7 +2430,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def launch_log_window(self) -> None:
         """Launch or close the log window"""
         self.pref["logwindow"] = self.actionLog_Window.isChecked()
-        self.write_preference()
+        Preferences.save()
         if self.actionLog_Window.isChecked():
             self.log_window.show()
         else:
@@ -2492,7 +2439,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def launch_bandmap_window(self) -> None:
         """Launch or close the bandmap window"""
         self.pref["bandmapwindow"] = self.actionBandmap.isChecked()
-        self.write_preference()
+        Preferences.save()
         if self.actionBandmap.isChecked():
             self.bandmap_window.show()
             self.bandmap_window.setActive(True)
@@ -2503,7 +2450,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def launch_check_window(self) -> None:
         """Launch or close the check window"""
         self.pref["checkwindow"] = self.actionCheck_Window.isChecked()
-        self.write_preference()
+        Preferences.save()
         if self.actionCheck_Window.isChecked():
             self.check_window.show()
             self.check_window.setActive(True)
@@ -2514,7 +2461,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def launch_rate_window(self) -> None:
         """Launch or close the rate window"""
         self.pref["ratewindow"] = self.actionRate_Window.isChecked()
-        self.write_preference()
+        Preferences.save()
         if self.actionRate_Window.isChecked():
             self.rate_window.show()
             self.rate_window.setActive(True)
@@ -2525,7 +2472,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def launch_stats_window(self) -> None:
         """Launch or close the stats window"""
         self.pref["statisticswindow"] = self.actionStatistics.isChecked()
-        self.write_preference()
+        Preferences.save()
         if self.actionStatistics.isChecked():
             self.statistics_window.show()
             self.statistics_window.setActive(True)
@@ -2537,7 +2484,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def launch_dxcc_window(self) -> None:
         """Launch or close the dxcc window"""
         self.pref["dxccwindow"] = self.actionDXCC.isChecked()
-        self.write_preference()
+        Preferences.save()
         if self.actionDXCC.isChecked():
             self.dxcc_window.show()
             self.dxcc_window.setActive(True)
@@ -2549,7 +2496,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def launch_zone_window(self) -> None:
         """Launch or close the zone window"""
         self.pref["zonewindow"] = self.actionZone.isChecked()
-        self.write_preference()
+        Preferences.save()
         if self.actionZone.isChecked():
             self.zone_window.show()
             self.zone_window.setActive(True)
@@ -2561,7 +2508,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def launch_rotator_window(self) -> None:
         """Launch or close the rotator window"""
         self.pref["rotatorwindow"] = self.actionRotator.isChecked()
-        self.write_preference()
+        Preferences.save()
         if self.actionRotator.isChecked():
             self.rotator_window.show()
             self.rotator_window.setActive(True)
@@ -2572,7 +2519,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def launch_vfo(self) -> None:
         """Launch or close the VFO window"""
         self.pref["vfowindow"] = self.actionVFO.isChecked()
-        self.write_preference()
+        Preferences.save()
         if self.actionVFO.isChecked():
             self.vfo_window.show()
         else:
@@ -2581,7 +2528,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def launch_chat_window(self) -> None:
         """Launch or close the chat window"""
         self.pref["chatwindow"] = self.actionGroup_Chat.isChecked()
-        self.write_preference()
+        Preferences.save()
         if self.actionGroup_Chat.isChecked():
             self.chat_window.show()
             self.chat_window.setActive(True)
@@ -2664,7 +2611,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.log_window.msg_from_main(cmd)
         if self.lookup_service:
             self.lookup_service.msg_from_main(cmd)
-        self.write_preference()
+        Preferences.save()
 
     def cty_lookup(self, callsign: str) -> dict:
         """Lookup callsign in cty.dat file.
@@ -3479,7 +3426,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # contest['TimeCategory'] = self.contest_dialog.
         logger.debug("%s", f"{contest}")
         self.database.add_contest(contest)
-        self.write_preference()
+        Preferences.save()
         self.load_contest()
 
     def edit_station_settings(self) -> None:
@@ -3921,73 +3868,19 @@ class MainWindow(QtWidgets.QMainWindow):
         None
         """
         self.pref["run_state"] = self.radioButton_run.isChecked()
-        self.write_preference()
+        Preferences.save()
         self.read_macros()
         self.check_esm()
 
-    def write_preference(self) -> None:
+    def apply_preferences(self) -> None:
         """
-        Write preferences to file.
+        Apply current preferences to subsystems (database, radio, CW, RTC, N1MM, ...).
 
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        None
+        Called once at startup and again after the Settings dialog closes.
+        Preferences.load() must have been called first.
         """
 
-        logger.debug("writepreferences")
-        try:
-            with open(fsutils.CONFIG_FILE, "wt", encoding="utf-8") as file_descriptor:
-                file_descriptor.write(dumps(self.pref, indent=4))
-                # logger.info("writing: %s", self.pref)
-        except (IOError, TypeError, ValueError) as exception:
-            logger.critical("writepreferences: %s", exception)
-            self.show_message_box(f"writepreferences: {exception}", blocking=False)
-
-    def readpreferences(self) -> None:
-        """
-        Restore preferences if they exist, otherwise create some sane defaults.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        None
-        """
-
-        logger.debug("readpreferences")
-        try:
-            if os.path.exists(fsutils.CONFIG_FILE):
-                with open(
-                    fsutils.CONFIG_FILE, "rt", encoding="utf-8"
-                ) as file_descriptor:
-                    try:
-                        self.pref = loads(file_descriptor.read())
-                    except (JSONDecodeError, TypeError):
-                        logging.CRITICAL(
-                            "There was an error parsing the preference file."
-                        )
-                        self.show_message_box(
-                            "There was an error parsing the preference file.",
-                            blocking=False,
-                        )
-                    logger.info("%s", self.pref)
-            else:
-                logger.info("No preference file. Writing preference.")
-                with open(
-                    fsutils.CONFIG_FILE, "wt", encoding="utf-8"
-                ) as file_descriptor:
-                    self.pref = self.pref_ref.copy()
-                    file_descriptor.write(dumps(self.pref, indent=4))
-                    logger.info("%s", self.pref)
-        except (IOError, TypeError, ValueError) as exception:
-            logger.critical("Error: %s", exception)
-            self.show_message_box(f"readpreferences error: {exception}", blocking=False)
+        logger.debug("apply_preferences")
 
         # open database as the first thing we do so other threads can use it
         self.dbname = fsutils.USER_DATA_PATH / self.pref.get(
@@ -4230,7 +4123,7 @@ class MainWindow(QtWidgets.QMainWindow):
         """
 
         self.pref["cw_macros"] = self.actionCW_Macros.isChecked()
-        self.write_preference()
+        Preferences.save()
         self.show_CW_macros()
 
     def show_CW_macros(self) -> None:
@@ -4298,7 +4191,7 @@ class MainWindow(QtWidgets.QMainWindow):
         """
 
         self.pref["command_buttons"] = self.actionCommand_Buttons_2.isChecked()
-        self.write_preference()
+        Preferences.save()
         self.show_command_buttons()
 
     def show_command_buttons(self) -> None:

--- a/not1mm/bandmap.py
+++ b/not1mm/bandmap.py
@@ -397,7 +397,17 @@ class BandMapScene(QtWidgets.QGraphicsScene):
 class BandMapWindow(QDockWidget):
     """The BandMapWindow class."""
 
-    zoom = 5
+    default_zoom = 5
+    zoom_levels = [  # kHz per tick, decimal digits
+        (0.04, 1),
+        (0.1, 1),
+        (0.2, 0),
+        (0.4, 0),
+        (1, 0),
+        (2, 0),  # default level (index 5)
+        (4, 0),
+        (10, 0),
+    ]
     currentBand = Band("20m")
     txMark = []
     rxMark = []
@@ -443,8 +453,8 @@ class BandMapWindow(QDockWidget):
         self.clearButton.setIcon(icon)
         self.clearmarkedButton.clicked.connect(self.clear_marked)
         self.clearmarkedButton.setIcon(icon)
-        self.zoominButton.clicked.connect(self.dec_zoom)
-        self.zoomoutButton.clicked.connect(self.inc_zoom)
+        self.zoominButton.clicked.connect(self.zoom_in)
+        self.zoomoutButton.clicked.connect(self.zoom_out)
         self.connectButton.clicked.connect(self.connect)
         self.spots = Database()
         self.socket = QtNetwork.QTcpSocket()
@@ -480,9 +490,9 @@ class BandMapWindow(QDockWidget):
             target_band_name = packet.get("band", "")
             if len(target_band_name):
                 if target_band_name[-1:] == "m":
-                    self.set_band(target_band_name, False)
+                    self.set_band(target_band_name)
                 else:
-                    self.set_band(packet.get("band") + "m", False)
+                    self.set_band(packet.get("band") + "m")
             try:
                 if self.rx_freq != float(packet.get("vfoa")) / 1000:
                     self.rx_freq = float(packet.get("vfoa")) / 1000
@@ -697,17 +707,19 @@ class BandMapWindow(QDockWidget):
         self.drawTXRXMarks(step)
         self.update_stations()
 
-    def inc_zoom(self):
-        """doc"""
-        self.zoom += 1
-        self.zoom = min(self.zoom, 7)
+    def zoom_out(self):
+        """The zoom out button was clicked"""
+        zoom = self.settings.get("bandmap_zoom", self.default_zoom) + 1
+        zoom = min(zoom, len(self.zoom_levels) - 1)  # clamp to valid values
+        self.settings["bandmap_zoom"] = zoom
         self.update()
         self.center_on_rxfreq()
 
-    def dec_zoom(self):
-        """doc"""
-        self.zoom -= 1
-        self.zoom = max(self.zoom, 0)
+    def zoom_in(self):
+        """The zoom in button was clicked"""
+        zoom = self.settings.get("bandmap_zoom", self.default_zoom) - 1
+        zoom = max(zoom, 0)  # clamp to valid values
+        self.settings["bandmap_zoom"] = zoom
         self.update()
         self.center_on_rxfreq()
 
@@ -865,33 +877,24 @@ class BandMapWindow(QDockWidget):
 
     def determine_step_digits(self):
         """doc"""
-        return_zoom = {
-            0: (0.04, 1),
-            1: (0.1, 1),
-            2: (0.2, 0),
-            3: (0.4, 0),
-            4: (1, 0),
-            5: (2, 0),
-            6: (4, 0),
-            7: (10, 0),
-        }
-        step, digits = return_zoom.get(self.zoom, (0.1, 1))
+        zoom = self.settings.get("bandmap_zoom", self.default_zoom)
+        zoom = max(0, min(zoom, len(self.zoom_levels) - 1))
+        step, digits = self.zoom_levels[zoom]
 
         if self.currentBand.start >= 50_000.0 and self.currentBand.start < 420_000.0:
             step = step * 10
             digits = 0
-        elif self.currentBand.start >= 420_000.0 and self.currentBand.start < 2300_000.0:
+        elif (
+            self.currentBand.start >= 420_000.0 and self.currentBand.start < 2300_000.0
+        ):
             step = step * 100
             digits = 0
 
         return (step, digits)
 
-    def set_band(self, band: str, savePrevBandZoom: bool) -> None:
+    def set_band(self, band: str) -> None:
         """Change band being shown."""
-        logger.debug("%s", f"{band} {savePrevBandZoom}")
         if band != self.currentBand.name:
-            if savePrevBandZoom:
-                self.saveCurrentZoom()
             self.currentBand = Band(band)
             self.update()
 

--- a/not1mm/bandmap.py
+++ b/not1mm/bandmap.py
@@ -14,7 +14,6 @@ import re
 import sqlite3
 from datetime import datetime, timezone
 from decimal import Decimal
-from json import loads
 
 from PyQt6 import QtCore, QtGui, QtNetwork, QtWidgets, uic
 from PyQt6.QtCore import Qt, pyqtSignal
@@ -22,6 +21,7 @@ from PyQt6.QtGui import QColor, QColorConstants, QFont
 from PyQt6.QtWidgets import QDockWidget, QStyle
 
 import not1mm.fsutils as fsutils
+from not1mm.lib.preferences import Preferences
 
 # from not1mm.lib.multicast import Multicast
 
@@ -431,7 +431,7 @@ class BandMapWindow(QDockWidget):
         uic.loadUi(fsutils.APP_DATA_PATH / "bandmap.ui", self)
         # self.thefont = QFont("JetBrains Mono", 10, QFont.Weight.Thin)
         self.thefont = QFont("JetBrains Mono", 10)
-        self.settings = self.get_settings()
+        self.settings = Preferences.data()
         self.clear_spot_olderSpinBox.setValue(
             int(self.settings.get("cluster_expire", 1))
         )
@@ -471,12 +471,6 @@ class BandMapWindow(QDockWidget):
     def setActive(self, mode: bool):
         self.active = bool(mode)
         self.request_workedlist()
-
-    def get_settings(self) -> dict:
-        """Get the settings."""
-        if os.path.exists(fsutils.CONFIG_FILE):
-            with open(fsutils.CONFIG_FILE, "rt", encoding="utf-8") as file_descriptor:
-                return loads(file_descriptor.read())
 
     def msg_from_main(self, packet):
         """"""
@@ -615,7 +609,6 @@ class BandMapWindow(QDockWidget):
         if self.connected is True:
             self.close_cluster()
             return
-        self.settings = self.get_settings()
         server = self.settings.get("cluster_server", "dxc.nc7j.com")
         port = self.settings.get("cluster_port", 7373)
         logger.info(f"connecting to dx cluster {server} {port}")

--- a/not1mm/chat.py
+++ b/not1mm/chat.py
@@ -1,14 +1,12 @@
 import datetime
 import logging
-import os
-from json import loads
-from json.decoder import JSONDecodeError
 
 from PyQt6 import QtGui, uic
 from PyQt6.QtCore import pyqtSignal
 from PyQt6.QtWidgets import QDockWidget
 
 import not1mm.fsutils as fsutils
+from not1mm.lib.preferences import Preferences
 
 logger = logging.getLogger(__name__)
 
@@ -71,18 +69,7 @@ class ChatWindow(QDockWidget):
         -------
         None
         """
-        try:
-            if os.path.exists(fsutils.CONFIG_FILE):
-                with open(
-                    fsutils.CONFIG_FILE, "rt", encoding="utf-8"
-                ) as file_descriptor:
-                    self.pref = loads(file_descriptor.read())
-                    logger.info(f"loaded config file from {fsutils.CONFIG_FILE}")
-            else:
-                self.pref["current_database"] = "ham.db"
-
-        except (IOError, JSONDecodeError) as exception:
-            logger.critical("Error: %s", exception)
+        self.pref = Preferences.data()
 
     def closeEvent(self, event) -> None:
         self.action.setChecked(False)

--- a/not1mm/checkwindow.py
+++ b/not1mm/checkwindow.py
@@ -8,10 +8,8 @@ Purpose: Onscreen widget to show possible matches to callsigns entered in the ma
 """
 
 import logging
-import os
 import queue
 from dataclasses import dataclass
-from json import loads
 from typing import Optional
 
 from PyQt6 import uic
@@ -22,6 +20,7 @@ from rapidfuzz.distance import Levenshtein
 
 import not1mm.fsutils as fsutils
 from not1mm.lib.database import DataBase
+from not1mm.lib.preferences import Preferences
 from not1mm.lib.super_check_partial import SCP
 
 logger = logging.getLogger(__name__)
@@ -121,18 +120,7 @@ class CheckWindow(QDockWidget):
         -------
         None
         """
-        try:
-            if os.path.exists(fsutils.CONFIG_FILE):
-                with open(
-                    fsutils.CONFIG_FILE, "rt", encoding="utf-8"
-                ) as file_descriptor:
-                    self.pref = loads(file_descriptor.read())
-                    logger.info(f"loaded config file from {fsutils.CONFIG_FILE}")
-            else:
-                self.pref["current_database"] = "ham.db"
-
-        except IOError as exception:
-            logger.critical("Error: %s", exception)
+        self.pref = Preferences.data()
 
     def clear_lists(self) -> None:
         """

--- a/not1mm/dxcc_tracker.py
+++ b/not1mm/dxcc_tracker.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from json import loads
 from json.decoder import JSONDecodeError
 
@@ -10,6 +9,7 @@ from PyQt6.QtWidgets import QDockWidget
 
 import not1mm.fsutils as fsutils
 from not1mm.lib.database import DataBase
+from not1mm.lib.preferences import Preferences
 
 logger = logging.getLogger(__name__)
 
@@ -141,18 +141,7 @@ class DXCCWindow(QDockWidget):
         -------
         None
         """
-        try:
-            if os.path.exists(fsutils.CONFIG_FILE):
-                with open(
-                    fsutils.CONFIG_FILE, "rt", encoding="utf-8"
-                ) as file_descriptor:
-                    self.pref = loads(file_descriptor.read())
-                    logger.info("%s", self.pref)
-            else:
-                self.pref["current_database"] = "ham.db"
-
-        except IOError as exception:
-            logger.critical("Error: %s", exception)
+        self.pref = Preferences.data()
 
     def load_new_db(self) -> None:
         """

--- a/not1mm/lib/preferences.py
+++ b/not1mm/lib/preferences.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Single source of truth for reading and writing not1mm.json.
+
+Exposes a Preferences class:
+    Preferences.load() -> reads file, merges over _defaults, populates _data
+    Preferences.data() -> live reference to the in-memory dict
+    Preferences.save() -> atomic write of _data
+"""
+
+import logging
+import os
+from json import dumps, loads
+from json.decoder import JSONDecodeError
+from pathlib import Path
+
+import not1mm.fsutils as fsutils
+
+logger = logging.getLogger("preferences")
+
+
+class Preferences:
+    _path: Path = fsutils.CONFIG_FILE
+    _data: dict = {}
+    _defaults: dict = {
+        "sounddevice": "default",
+        "useqrz": False,
+        "lookupusername": "username",
+        "lookuppassword": "password",
+        "run_state": True,
+        "command_buttons": False,
+        "cw_macros": True,
+        "bands_modes": True,
+        "bands": ["160", "80", "40", "20", "15", "10"],
+        "current_database": "ham.db",
+        "contest": "",
+        "multicast_group": "239.1.1.1",
+        "multicast_port": 2239,
+        "interface_ip": "0.0.0.0",
+        "send_rtc_scores": False,
+        "rtc_url": "",
+        "rtc_user": "",
+        "rtc_pass": "",
+        "rtc_interval": 2,
+        "send_n1mm_packets": False,
+        "n1mm_station_name": "20M CW Tent",
+        "n1mm_operator": "Bernie",
+        "n1mm_radioport": "127.0.0.1:12060",
+        "n1mm_contactport": "127.0.0.1:12060",
+        "n1mm_lookupport": "127.0.0.1:12060",
+        "n1mm_scoreport": "127.0.0.1:12060",
+        "usehamdb": False,
+        "usehamqth": False,
+        "cloudlog": False,
+        "cloudlogapi": "",
+        "cloudlogurl": "",
+        "CAT_ip": "127.0.0.1",
+        "userigctld": False,
+        "useflrig": False,
+        "cwip": "127.0.0.1",
+        "cwport": 6789,
+        "cwtype": 0,
+        "useserver": False,
+        "im_the_master": False,
+        "CAT_port": 4532,
+        "cluster_server": "dxc.nc7j.com",
+        "cluster_port": 7373,
+        "cluster_filter": "Set DX Filter SpotterCont=NA",
+        "cluster_mode": "OPEN",
+        "cluster_expire": 1,
+        "logwindow": False,
+        "bandmapwindow": False,
+        "checkwindow": False,
+        "vfowindow": False,
+        "ratewindow": False,
+        "statisticswindow": False,
+        "darkmode": True,
+    }
+
+    @classmethod
+    def load(cls) -> dict:
+        """Read the prefs file, merge over defaults, populate _data.
+
+        Pure stdlib + logger. Never touches Qt.
+        Missing file -> write defaults, return them.
+        Parse error  -> log critical, return defaults.
+        """
+        if os.path.exists(cls._path):
+            try:
+                with open(cls._path, "rt", encoding="utf-8") as file_descriptor:
+                    raw = loads(file_descriptor.read())
+                    cls._data = {**cls._defaults, **raw}
+            except (JSONDecodeError, ValueError, TypeError) as exc:
+                logger.critical("Error parsing %s: %s", cls._path, exc)
+                cls._data = cls._defaults.copy()
+        else:
+            logger.info("No preference file. Writing a new one to %s.", cls._path)
+            cls._data = cls._defaults.copy()
+            cls.save()
+        return cls._data
+
+    @classmethod
+    def data(cls) -> dict:
+        """Live reference to the in-memory dict. Mutations are visible to all callers."""
+        return cls._data
+
+    @classmethod
+    def save(cls) -> None:
+        """Atomic write: tmp file then os.replace()."""
+        path = Path(cls._path)
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        try:
+            with open(tmp_path, "wt", encoding="utf-8") as file_descriptor:
+                file_descriptor.write(dumps(cls._data, indent=4))
+            os.replace(tmp_path, path)
+        except (IOError, TypeError, ValueError) as exc:
+            logger.critical("writepreferences: %s", exc)

--- a/not1mm/lib/settings.py
+++ b/not1mm/lib/settings.py
@@ -3,6 +3,8 @@
 import logging
 from PyQt6 import QtWidgets, uic
 
+from not1mm.lib.preferences import Preferences
+
 try:
     import sounddevice as sd
 except OSError:
@@ -407,3 +409,4 @@ class Settings(QtWidgets.QDialog):
         if self.activate_23cm.isChecked():
             bandlist.append("23cm")
         self.preference["bands"] = bandlist
+        Preferences.save()

--- a/not1mm/logwindow.py
+++ b/not1mm/logwindow.py
@@ -9,9 +9,7 @@ Purpose: Onscreen widget to show and edit logged contacts.
 
 import logging
 import math
-import os
 import queue
-from json import loads
 
 from PyQt6 import QtCore, QtGui, QtWidgets, uic
 from PyQt6.QtCore import QItemSelectionModel, Qt, pyqtSignal
@@ -21,6 +19,7 @@ import not1mm.fsutils as fsutils
 from not1mm.lib.database import DataBase
 from not1mm.lib.edit_contact import EditContact
 from not1mm.lib.n1mm import N1MM
+from not1mm.lib.preferences import Preferences
 
 logger = logging.getLogger(__name__)
 
@@ -232,18 +231,7 @@ class LogWindow(QDockWidget):
         -------
         None
         """
-        try:
-            if os.path.exists(fsutils.CONFIG_FILE):
-                with open(
-                    fsutils.CONFIG_FILE, "rt", encoding="utf-8"
-                ) as file_descriptor:
-                    self.pref = loads(file_descriptor.read())
-                    logger.info("%s", self.pref)
-            else:
-                self.pref["current_database"] = "ham.db"
-
-        except IOError as exception:
-            logger.critical("Error: %s", exception)
+        self.pref = Preferences.data()
 
         try:
             self.n1mm = N1MM(

--- a/not1mm/lookupservice.py
+++ b/not1mm/lookupservice.py
@@ -27,22 +27,21 @@ class LookupService(QDockWidget):
         super().__init__()
         self._udpwatch = None
         self.look_up = None
-        self.settings = self.get_settings()
-        if self.settings:
-            if self.settings.get("useqrz"):
-                self.look_up = QRZlookup(
-                    self.settings.get("lookupusername", ""),
-                    self.settings.get("lookuppassword", ""),
-                )
-            if self.settings.get("usehamqth"):
-                self.look_up = HamQTH(
-                    self.settings.get("lookupusername", ""),
-                    self.settings.get("lookuppassword", ""),
-                )
+        self.settings = Preferences.data()
+        self.setup()
 
-    def get_settings(self) -> dict:
-        """Get the settings."""
-        return Preferences.data()
+    def setup(self):
+        self.look_up = None
+        if self.settings.get("useqrz"):
+            self.look_up = QRZlookup(
+                self.settings.get("lookupusername", ""),
+                self.settings.get("lookuppassword", ""),
+            )
+        elif self.settings.get("usehamqth"):
+            self.look_up = HamQTH(
+                self.settings.get("lookupusername", ""),
+                self.settings.get("lookuppassword", ""),
+            )
 
     def msg_from_main(self, packet):
         """"""
@@ -58,15 +57,4 @@ class LookupService(QDockWidget):
             return
 
         if packet.get("cmd", "") == "REFRESH_LOOKUP":
-            self.settings = self.get_settings()
-            self.look_up = None
-            if self.settings.get("useqrz"):
-                self.look_up = QRZlookup(
-                    self.settings.get("lookupusername", ""),
-                    self.settings.get("lookuppassword", ""),
-                )
-            if self.settings.get("usehamqth"):
-                self.look_up = HamQTH(
-                    self.settings.get("lookupusername", ""),
-                    self.settings.get("lookuppassword", ""),
-                )
+            self.setup()

--- a/not1mm/lookupservice.py
+++ b/not1mm/lookupservice.py
@@ -8,14 +8,12 @@ Purpose: Lookup callsigns with online services.
 """
 
 import logging
-import os
-from json import loads
 
 from PyQt6.QtCore import pyqtSignal
 from PyQt6.QtWidgets import QDockWidget
 
-import not1mm.fsutils as fsutils
 from not1mm.lib.lookup import HamQTH, QRZlookup
+from not1mm.lib.preferences import Preferences
 
 logger = logging.getLogger(__name__)
 
@@ -44,10 +42,7 @@ class LookupService(QDockWidget):
 
     def get_settings(self) -> dict:
         """Get the settings."""
-        if os.path.exists(fsutils.CONFIG_FILE):
-            with open(fsutils.CONFIG_FILE, "rt", encoding="utf-8") as file_descriptor:
-                return loads(file_descriptor.read())
-        return {}
+        return Preferences.data()
 
     def msg_from_main(self, packet):
         """"""

--- a/not1mm/ratewindow.py
+++ b/not1mm/ratewindow.py
@@ -9,9 +9,6 @@ Purpose: not sure yet
 
 import datetime
 import logging
-import os
-from json import loads
-from json.decoder import JSONDecodeError
 
 from PyQt6 import uic
 from PyQt6.QtCore import QTimer, pyqtSignal
@@ -19,6 +16,7 @@ from PyQt6.QtWidgets import QDockWidget
 
 import not1mm.fsutils as fsutils
 from not1mm.lib.database import DataBase
+from not1mm.lib.preferences import Preferences
 
 logger = logging.getLogger(__name__)
 
@@ -75,18 +73,7 @@ class RateWindow(QDockWidget):
         -------
         None
         """
-        try:
-            if os.path.exists(fsutils.CONFIG_FILE):
-                with open(
-                    fsutils.CONFIG_FILE, "rt", encoding="utf-8"
-                ) as file_descriptor:
-                    self.pref = loads(file_descriptor.read())
-                    logger.info(f"loaded config file from {fsutils.CONFIG_FILE}")
-            else:
-                self.pref["current_database"] = "ham.db"
-
-        except (IOError, JSONDecodeError) as exception:
-            logger.critical("Error: %s", exception)
+        self.pref = Preferences.data()
 
     def get_run_and_total_qs(self):
         """get numbers"""

--- a/not1mm/rtc_service.py
+++ b/not1mm/rtc_service.py
@@ -9,14 +9,12 @@ Purpose: Service to post 'real time' scores.
 
 import datetime
 import logging
-import os
-from json import loads
 
 import requests
 from PyQt6.QtCore import QEventLoop, QObject, QThread, pyqtSignal
 from requests.auth import HTTPBasicAuth
 
-import not1mm.fsutils as fsutils
+from not1mm.lib.preferences import Preferences
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +72,4 @@ class RTCService(QObject):
 
     def get_settings(self) -> dict:
         """Get the settings."""
-        if os.path.exists(fsutils.CONFIG_FILE):
-            with open(fsutils.CONFIG_FILE, "rt", encoding="utf-8") as file_descriptor:
-                return loads(file_descriptor.read())
+        return Preferences.data()

--- a/not1mm/statistics.py
+++ b/not1mm/statistics.py
@@ -1,8 +1,5 @@
 import datetime
 import logging
-import os
-from json import loads
-from json.decoder import JSONDecodeError
 
 from PyQt6 import QtWidgets, uic
 from PyQt6.QtCore import Qt, pyqtSignal
@@ -10,6 +7,7 @@ from PyQt6.QtWidgets import QDockWidget, QTableWidgetItem
 
 import not1mm.fsutils as fsutils
 from not1mm.lib.database import DataBase
+from not1mm.lib.preferences import Preferences
 
 logger = logging.getLogger(__name__)
 
@@ -73,18 +71,7 @@ class StatsWindow(QDockWidget):
         -------
         None
         """
-        try:
-            if os.path.exists(fsutils.CONFIG_FILE):
-                with open(
-                    fsutils.CONFIG_FILE, "rt", encoding="utf-8"
-                ) as file_descriptor:
-                    self.pref = loads(file_descriptor.read())
-                    logger.info(f"loaded config file from {fsutils.CONFIG_FILE}")
-            else:
-                self.pref["current_database"] = "ham.db"
-
-        except (IOError, JSONDecodeError) as exception:
-            logger.critical("Error: %s", exception)
+        self.pref = Preferences.data()
 
     def get_run_and_total_qs(self):
         """get numbers"""

--- a/not1mm/vfo.py
+++ b/not1mm/vfo.py
@@ -15,7 +15,6 @@ import datetime
 import logging
 import os
 import sys
-from json import loads
 
 import serial
 from PyQt6 import QtWidgets, uic
@@ -26,6 +25,7 @@ from PyQt6.QtWidgets import QDockWidget
 import not1mm.fsutils as fsutils
 from not1mm.lib.cat_flrig import FlrigCAT
 from not1mm.lib.cat_rigctld import RigctldCAT
+from not1mm.lib.preferences import Preferences
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -65,16 +65,7 @@ class VfoWindow(QDockWidget):
         Load preference file.
         Get CAT interface.
         """
-        try:
-            if os.path.exists(fsutils.CONFIG_FILE):
-                with open(
-                    fsutils.CONFIG_FILE, "rt", encoding="utf-8"
-                ) as file_descriptor:
-                    self.pref: dict = loads(file_descriptor.read())
-                    logger.info("%s", self.pref)
-
-        except IOError as exception:
-            logger.critical("Error: %s", exception)
+        self.pref: dict = Preferences.data()
 
         if self.pref.get("useflrig", False):
             logger.debug(

--- a/not1mm/zone_tracker.py
+++ b/not1mm/zone_tracker.py
@@ -1,6 +1,4 @@
 import logging
-import os
-from json import loads
 
 from PyQt6 import QtWidgets, uic
 from PyQt6.QtCore import Qt, pyqtSignal
@@ -9,6 +7,7 @@ from PyQt6.QtWidgets import QDockWidget
 
 import not1mm.fsutils as fsutils
 from not1mm.lib.database import DataBase
+from not1mm.lib.preferences import Preferences
 
 logger = logging.getLogger(__name__)
 
@@ -112,18 +111,7 @@ class ZoneWindow(QDockWidget):
         -------
         None
         """
-        try:
-            if os.path.exists(fsutils.CONFIG_FILE):
-                with open(
-                    fsutils.CONFIG_FILE, "rt", encoding="utf-8"
-                ) as file_descriptor:
-                    self.pref = loads(file_descriptor.read())
-                    logger.info("%s", self.pref)
-            else:
-                self.pref["current_database"] = "ham.db"
-
-        except IOError as exception:
-            logger.critical("Error: %s", exception)
+        self.pref = Preferences.data()
 
     def load_new_db(self) -> None:
         """


### PR DESCRIPTION
All sub-windows had copies of the same preferences loading code. Move
    everything to not1mm/lib/preferences.py. Everything now uses the same
    global dict returned by Preferences.load().

One benefit is that we can now also introduce settings saved by other
    parts of the code. (Like saving the state of the "Scroll to" checkboxes
    in the dxcc/zone tracker windows or the bandmap zoom level.)

Refactor lookupservice setup

Save bandmap zoom level in preferences