### PR TITLE
Configure key bindings in a new Edit Keys dialog

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -43,6 +43,7 @@ from PyQt6.QtCore import (
     QT_VERSION_STR,
     QCoreApplication,
     QDir,
+    QEvent,
     QSettings,
     Qt,
     QThread,
@@ -55,6 +56,7 @@ from PyQt6.QtGui import (
     QFontDatabase,
     QIcon,
     QKeyEvent,
+    QKeySequence,
     QPalette,
     QPixmap,
 )
@@ -67,6 +69,7 @@ from PyQt6.QtWidgets import (
     QSystemTrayIcon,
 )
 
+import not1mm.actions
 import not1mm.fsutils as fsutils
 from not1mm.bandmap import BandMapWindow
 from not1mm.chat import ChatWindow
@@ -141,6 +144,7 @@ class MainWindow(QtWidgets.QMainWindow):
     qrz_dialog = None
     settings_dialog = None
     edit_macro_dialog = None
+    edit_keys_dialog = None
     contest_dialog = None
     configuration_dialog = None
     opon_dialog = None
@@ -321,6 +325,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.cw_entry.textChanged.connect(self.handle_text_change)
         self.cw_entry.returnPressed.connect(self.toggle_cw_entry)
+        self.cw_entry.installEventFilter(self)
 
         self.actionCW_Macros.triggered.connect(self.cw_macros_state_changed)
         self.actionCommand_Buttons_2.triggered.connect(
@@ -366,6 +371,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.actionAbout.triggered.connect(self.show_about_dialog)
         self.actionHotKeys.triggered.connect(self.show_key_help)
+        self.actionEdit_Keys.triggered.connect(lambda x: not1mm.actions.EDIT_KEYS(self))
         self.actionHelp.triggered.connect(self.show_help_dialog)
         self.actionUpdate_CTY.triggered.connect(self.check_for_new_cty)
         self.actionUpdate_MASTER_SCP.triggered.connect(self.update_masterscp)
@@ -377,18 +383,23 @@ class MainWindow(QtWidgets.QMainWindow):
         self.callsign.textEdited.connect(self.callsign_changed)
         self.callsign.returnPressed.connect(self.check_esm_with_enter)
         self.callsign.cursorPositionChanged.connect(self.check_esm)
+        self.callsign.installEventFilter(self)
         self.sent.returnPressed.connect(self.check_esm_with_enter)
         self.sent.textEdited.connect(self.sent_changed)
         self.sent.cursorPositionChanged.connect(self.check_esm)
+        self.sent.installEventFilter(self)
         self.receive.returnPressed.connect(self.check_esm_with_enter)
         self.receive.textEdited.connect(self.receive_changed)
         self.receive.cursorPositionChanged.connect(self.check_esm)
+        self.receive.installEventFilter(self)
         self.other_1.returnPressed.connect(self.check_esm_with_enter)
         self.other_1.textEdited.connect(self.other_1_changed)
         self.other_1.cursorPositionChanged.connect(self.check_esm)
+        self.other_1.installEventFilter(self)
         self.other_2.returnPressed.connect(self.check_esm_with_enter)
         self.other_2.textEdited.connect(self.other_2_changed)
         self.other_2.cursorPositionChanged.connect(self.check_esm)
+        self.other_2.installEventFilter(self)
 
         self.sent.setText("59")
         self.receive.setText("59")
@@ -2763,173 +2774,62 @@ class MainWindow(QtWidgets.QMainWindow):
             if self.current_sn == "None":
                 self.current_sn = "1"
 
+    def process_key_bindings(self, event: QKeyEvent, obj=None) -> bool:
+        """
+        Common key intercept code for eventFilter and keyPressEvent.
+        """
+        key_bindings = self.pref.get(
+            "key_bindings", not1mm.actions.default_key_bindings
+        )
+        key_name = QKeySequence(event.key() | event.modifiers().value).toString()
+
+        action = None
+        if obj == self.callsign:
+            action = key_bindings.get(f"Callsign:{key_name}", None)
+        elif obj in (self.sent, self.receive):
+            action = key_bindings.get(f"Report:{key_name}", None)
+        elif obj == self.other_1:
+            action = key_bindings.get(f"Other 1:{key_name}", None)
+        elif obj == self.other_2:
+            action = key_bindings.get(f"Other 2:{key_name}", None)
+        elif obj == self.cw_entry:
+            action = key_bindings.get(f"CW entry:{key_name}", None)
+        # Exchange is Other 1 + 2
+        if action is None and obj in (self.other_1, self.other_2):
+            action = key_bindings.get(f"Exchange:{key_name}", None)
+        # generic binding
+        if action is None:
+            action = key_bindings.get(key_name, None)
+
+        if action:
+            if action_function := getattr(not1mm.actions, action, None):
+                action_function(self)
+                return True
+        return False  # key not handled here
+
+    def eventFilter(self, obj, event) -> bool:
+        """
+        This intercepts key events on the input widgets.
+        True: event processing stops here.
+        False: further processing in the input widget (bindings like Ctrl+A),
+        then forwarded to MainWindow.keyPressEvent.
+        """
+
+        if event.type() != QEvent.Type.KeyPress:
+            return False
+        if self.process_key_bindings(event, obj=obj):
+            return True
+        return False
+
     def keyPressEvent(self, event: QKeyEvent) -> None:  # pylint: disable=invalid-name
         """
-        This overrides Qt key event.
-
-        Parameters:
-        ----------
-        event: QKeyEvent
-        Qt key event
-
-        Returns:
-        -------
-        None
-
-        Control
-        QWRTYIOPSFGHJLBNM,./;'[]//-
-
-
-        shift control
-        ABCDEFGHIJKLMNOPQRSTUVWXY
+        This overrides Qt key event to catch keys not yet handled in the input widgets.
         """
+
+        if self.process_key_bindings(event):
+            return
+
         modifier = event.modifiers()
-
-        if (
-            event.key() in [Qt.Key.Key_Equal, Qt.Key.Key_L]
-            and modifier == Qt.KeyboardModifier.ControlModifier
-        ):
-            self.save_contact()
-            return
-        if event.key() == Qt.Key.Key_K:
-            self.toggle_cw_entry()
-            return
-        if (
-            event.key() == Qt.Key.Key_S
-            and modifier == Qt.KeyboardModifier.ControlModifier
-        ):
-            freq = self.radio_state.get("vfoa")
-            dx = self.callsign.text()
-            if freq and dx:
-                cmd = {}
-                cmd["cmd"] = "SPOTDX"
-                cmd["dx"] = dx
-                cmd["freq"] = float(int(freq) / 1000)
-                if self.bandmap_window:
-                    self.bandmap_window.msg_from_main(cmd)
-            return
-        if (
-            event.key() == Qt.Key.Key_M
-            and modifier == Qt.KeyboardModifier.ControlModifier
-        ):
-            self.mark_spot(comment=f"{self.current_mode} MARKED")
-            return
-        if (
-            event.key() == Qt.Key.Key_G
-            and modifier == Qt.KeyboardModifier.ControlModifier
-        ):
-            dx = self.callsign.text()
-            if dx:
-                cmd = {}
-                cmd["cmd"] = "FINDDX"
-                cmd["dx"] = dx
-                if self.bandmap_window:
-                    self.bandmap_window.msg_from_main(cmd)
-            return
-        if (
-            event.key() == Qt.Key.Key_Q
-            and modifier == Qt.KeyboardModifier.ControlModifier
-        ):  # pylint: disable=no-member
-            if self.cq_freq:
-                self.radio_state["vfoa"] = self.cq_freq
-                if self.rig_control:
-                    self.rig_control.set_vfo(self.cq_freq)
-                self.set_running(True)
-                self.clearinputs()
-            return
-        if (
-            event.key() == Qt.Key.Key_R
-            and modifier == Qt.KeyboardModifier.ControlModifier
-        ):  # pylint: disable=no-member
-            self.toggle_run_sp()
-            return
-        if (
-            event.key() == Qt.Key.Key_T
-            and modifier == Qt.KeyboardModifier.ControlModifier
-        ):  # pylint: disable=no-member
-            if hasattr(self.contest, "add_test_data"):
-                self.contest.add_test_data(self)
-            return
-
-        if (
-            event.key() == Qt.Key.Key_W
-            and modifier == Qt.KeyboardModifier.ControlModifier
-        ):  # pylint: disable=no-member
-            self.clearinputs()
-            return
-        if (
-            event.key() == Qt.Key.Key_Escape
-            and modifier != Qt.KeyboardModifier.ControlModifier
-        ):
-            self.stop_all()
-        if event.key() == Qt.Key.Key_Up:
-            cmd = {}
-            cmd["cmd"] = "PREVSPOT"
-            if self.bandmap_window:
-                self.bandmap_window.msg_from_main(cmd)
-            return
-        if event.key() == Qt.Key.Key_Down:
-            cmd = {}
-            cmd["cmd"] = "NEXTSPOT"
-            if self.bandmap_window:
-                self.bandmap_window.msg_from_main(cmd)
-            return
-        if (
-            event.key() == Qt.Key.Key_PageUp
-            and modifier != Qt.KeyboardModifier.ControlModifier
-        ):
-            if self.cw is not None:
-                self.cw.speed += self.pref.get("cwstepping", 1)
-                self.cw_speed.setValue(self.cw.speed)
-                if self.cw.servertype == 1:
-                    self.cw.sendcw(f"\x1b2{self.cw.speed}")
-                if self.cw.servertype == 2:
-                    self.cw.set_winkeyer_speed(self.cw_speed.value())
-            return
-        if (
-            event.key() == Qt.Key.Key_PageDown
-            and modifier != Qt.KeyboardModifier.ControlModifier
-        ):
-            if self.cw is not None:
-                self.cw.speed -= self.pref.get("cwstepping", 1)
-                self.cw_speed.setValue(self.cw.speed)
-                if self.cw.servertype == 1:
-                    self.cw.sendcw(f"\x1b2{self.cw.speed}")
-                if self.cw.servertype == 2:
-                    self.cw.set_winkeyer_speed(self.cw_speed.value())
-            return
-        if (
-            event.key() == Qt.Key.Key_Period
-            and modifier == Qt.KeyboardModifier.ControlModifier
-        ):
-            freq = self.radio_state.get("vfoa")
-            selected_mode = self.radio_state.get("mode")
-            if selected_mode == "CW":
-                deltaf = 20
-            elif selected_mode in ["LSB", "USB", "SSB"]:
-                deltaf = 100
-            else:
-                deltaf = 0
-            vfo = int(freq) + deltaf
-            if self.rig_control:
-                self.rig_control.set_vfo(vfo)
-                return
-        if (
-            event.key() == Qt.Key.Key_Comma
-            and modifier == Qt.KeyboardModifier.ControlModifier
-        ):
-            freq = self.radio_state.get("vfoa")
-            selected_mode = self.radio_state.get("mode")
-            if selected_mode == "CW":
-                deltaf = 20
-            elif selected_mode in ["LSB", "USB", "SSB"]:
-                deltaf = 100
-            else:
-                deltaf = 0
-            vfo = int(freq) - deltaf
-            if self.rig_control:
-                self.rig_control.set_vfo(vfo)
-                return
         if event.key() == Qt.Key.Key_Tab or event.key() == Qt.Key.Key_Backtab:
             if self.sent.hasFocus():
                 logger.debug("From sent")

--- a/not1mm/actions.py
+++ b/not1mm/actions.py
@@ -1,0 +1,192 @@
+"""
+Functions called from key events
+
+Parameters: self (MainWindow)
+
+All functions from this file (except when prefixed with _) appear in the Action
+dropdown list, in the order they are defined in this file.
+
+The function doc string is used as action description in the Edit Keys dialog.
+"""
+
+# pylint: disable=invalid-name
+
+from not1mm.lib.edit_keys import EditKeys
+
+default_key_bindings = {
+    "Ctrl+R": "TOGGLE_RUN",
+    "Ctrl+L": "LOG_NOW",
+    "Ctrl+=": "LOG_NOW",
+    "Ctrl+Shift+K": "TOGGLE_CW_INPUT",
+    "Up": "PREV_SPOT",
+    "Down": "NEXT_SPOT",
+    "Ctrl+G": "FIND_DX",
+    "Ctrl+M": "MARK_SPOT",
+    "Ctrl+Q": "JUMP_TO_CQ",
+    "Ctrl+S": "SPOT_DX",
+    "Ctrl+,": "VFO_DOWN",
+    "Ctrl+.": "VFO_UP",
+    "PgDown": "CW_SPEED_DOWN",
+    "PgUp": "CW_SPEED_UP",
+    "Ctrl+W": "CLEAR_INPUTS",
+    "Esc": "STOP_ALL",
+    "Ctrl+T": "ADD_TEST_DATA",
+}
+
+
+def NO_ACTION(self) -> None:  # pylint: disable=unused-argument
+    """Select key combination and action to bind"""
+
+
+def TOGGLE_RUN(self) -> None:
+    """Toggle between RUN and S&P"""
+    self.set_running(not self.pref["run_state"])
+
+
+def LOG_NOW(self) -> None:
+    """Log the current contact"""
+    self.save_contact()
+
+
+def TOGGLE_CW_INPUT(self) -> None:
+    """Toggle CW text entry field"""
+    self.toggle_cw_entry()
+
+
+def PREV_SPOT(self) -> None:
+    """Jump to the previous spot in the bandmap"""
+    cmd = {}
+    cmd["cmd"] = "PREVSPOT"
+    if self.bandmap_window:
+        self.bandmap_window.msg_from_main(cmd)
+
+
+def NEXT_SPOT(self) -> None:
+    """Jump to the next spot in the bandmap"""
+    cmd = {}
+    cmd["cmd"] = "NEXTSPOT"
+    if self.bandmap_window:
+        self.bandmap_window.msg_from_main(cmd)
+
+
+def FIND_DX(self) -> None:
+    """Tune to a spot matching the partial callsign"""
+    dx = self.callsign.text()
+    if dx:
+        cmd = {}
+        cmd["cmd"] = "FINDDX"
+        cmd["dx"] = dx
+        if self.bandmap_window:
+            self.bandmap_window.msg_from_main(cmd)
+
+
+def SPOT_DX(self) -> None:
+    """Spot the callsign to the cluster"""
+    freq = self.radio_state.get("vfoa")
+    dx = self.callsign.text()
+    if freq and dx:
+        cmd = {}
+        cmd["cmd"] = "SPOTDX"
+        cmd["dx"] = dx
+        cmd["freq"] = float(int(freq) / 1000)
+        if self.bandmap_window:
+            self.bandmap_window.msg_from_main(cmd)
+
+
+def MARK_SPOT(self) -> None:
+    """Mark callsign to work later"""
+    self.mark_spot(comment=f"{self.current_mode} MARKED")
+
+
+def JUMP_TO_CQ(self) -> None:
+    """Jump to the last CQ frequency"""
+    if self.cq_freq:
+        self.radio_state["vfoa"] = self.cq_freq
+        if self.rig_control:
+            self.rig_control.set_vfo(self.cq_freq)
+        self.set_running(True)
+        self.clearinputs()
+
+
+def VFO_DOWN(self) -> None:
+    """Step the VFO frequency down"""
+    freq = self.radio_state.get("vfoa")
+    selected_mode = self.radio_state.get("mode")
+    if selected_mode == "CW":
+        deltaf = 20
+    elif selected_mode in ["LSB", "USB", "SSB"]:
+        deltaf = 100
+    else:
+        deltaf = 0
+    vfo = int(freq) - deltaf
+    if self.rig_control:
+        self.rig_control.set_vfo(vfo)
+
+
+def VFO_UP(self) -> None:
+    """Step the VFO frequency up"""
+    freq = self.radio_state.get("vfoa")
+    selected_mode = self.radio_state.get("mode")
+    if selected_mode == "CW":
+        deltaf = 20
+    elif selected_mode in ["LSB", "USB", "SSB"]:
+        deltaf = 100
+    else:
+        deltaf = 0
+    vfo = int(freq) + deltaf
+    if self.rig_control:
+        self.rig_control.set_vfo(vfo)
+
+
+def CW_SPEED_UP(self) -> None:
+    """Increase CW sending speed"""
+    if self.cw is not None:
+        self.cw.speed += self.pref.get("cwstepping", 1)
+        self.cw_speed.setValue(self.cw.speed)
+        if self.cw.servertype == 1:
+            self.cw.sendcw(f"\x1b2{self.cw.speed}")
+        if self.cw.servertype == 2:
+            self.cw.set_winkeyer_speed(self.cw_speed.value())
+
+
+def CW_SPEED_DOWN(self) -> None:
+    """Decrease CW sending speed"""
+    if self.cw is not None:
+        self.cw.speed -= self.pref.get("cwstepping", 1)
+        self.cw_speed.setValue(self.cw.speed)
+        if self.cw.servertype == 1:
+            self.cw.sendcw(f"\x1b2{self.cw.speed}")
+        if self.cw.servertype == 2:
+            self.cw.set_winkeyer_speed(self.cw_speed.value())
+
+
+def CLEAR_INPUTS(self) -> None:
+    """Clear the input fields"""
+    self.clearinputs()
+
+
+def STOP_ALL(self) -> None:
+    """Stop CW sending and antenna rotation"""
+    self.stop_all()
+
+
+def ADD_TEST_DATA(self) -> None:
+    """Add test data to the log"""
+    if hasattr(self.contest, "add_test_data"):
+        self.contest.add_test_data(self)
+
+
+def EDIT_KEYS(self) -> None:
+    """Open the Edit Keys dialog"""
+
+    def finished():
+        self.edit_keys_dialog = None
+
+    if self.edit_keys_dialog is None:
+        key_bindings = self.pref.get("key_bindings", default_key_bindings)
+        self.edit_keys_dialog = EditKeys(key_bindings=key_bindings, parent=self)
+        if self.current_palette:
+            self.edit_keys_dialog.setPalette(self.current_palette)
+        self.edit_keys_dialog.accepted.connect(self.edit_keys_dialog.save_keys)
+        self.edit_keys_dialog.finished.connect(finished)
+        self.edit_keys_dialog.show()

--- a/not1mm/data/edit_keys.ui
+++ b/not1mm/data/edit_keys.ui
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>720</width>
+    <height>804</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>720</width>
+    <height>400</height>
+   </size>
+  </property>
+  <property name="font">
+   <font>
+    <family>JetBrains Mono</family>
+   </font>
+  </property>
+  <property name="windowTitle">
+   <string>Edit Keys</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableWidget" name="table">
+     <property name="columnCount">
+      <number>4</number>
+     </property>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Context</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Key</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Action</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Description</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonRow">
+     <item>
+      <widget class="QPushButton" name="add_button">
+       <property name="text">
+        <string>Add</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="remove_button">
+       <property name="text">
+        <string>Remove</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="reset_all_button">
+       <property name="text">
+        <string>Reset all</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Policy::Expanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="button_box">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/not1mm/data/main.ui
+++ b/not1mm/data/main.ui
@@ -1554,6 +1554,7 @@
     <addaction name="actionImport_ADIF"/>
     <addaction name="separator"/>
     <addaction name="actionEdit_Macros"/>
+    <addaction name="actionEdit_Keys"/>
     <addaction name="separator"/>
     <addaction name="actionLoad_Call_History_File"/>
     <addaction name="actionUpdate_CTY"/>
@@ -2040,6 +2041,17 @@
   <action name="actionEdit_Current_Contest">
    <property name="text">
     <string>Edit Current Contest</string>
+   </property>
+   <property name="font">
+    <font>
+     <family>JetBrains Mono</family>
+     <weight>100</weight>
+    </font>
+   </property>
+  </action>
+  <action name="actionEdit_Keys">
+   <property name="text">
+    <string>Edit Keys</string>
    </property>
    <property name="font">
     <font>

--- a/not1mm/lib/edit_keys.py
+++ b/not1mm/lib/edit_keys.py
@@ -1,0 +1,244 @@
+"""Edit key bindings dialog."""
+
+from PyQt6 import QtCore, QtGui, QtWidgets, uic
+
+import not1mm.actions
+import not1mm.fsutils as fsutils
+from not1mm.lib.preferences import Preferences
+
+_KNOWN_CONTEXTS = [
+    "*",
+    "Callsign",
+    "Report",
+    "Exchange",
+    "Other 1",
+    "Other 2",
+    "CW entry",
+]
+
+
+class EditKeys(QtWidgets.QDialog):
+    """Dialog to view, add, edit, and remove key bindings."""
+
+    _READONLY_FLAGS = (
+        QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsEnabled
+    )
+
+    def __init__(self, key_bindings, parent=None):
+        """Open Edit Keys dialog window and populate it"""
+
+        super().__init__(parent)
+        uic.loadUi(fsutils.APP_DATA_PATH / "edit_keys.ui", self)
+
+        # load known actions by inspecting the not1mm.actions module
+        self.actions = []
+        self.action_docs = {}
+        for action in vars(not1mm.actions):
+            action_function = getattr(not1mm.actions, action)
+            # skip everything starting with _ and check if this is a function
+            if not action.startswith("_") and callable(action_function):
+                self.actions.append(action)
+                self.action_docs[action] = action_function.__doc__
+
+        self._suppress_widget_signals = False
+        self._context_combos = {}
+        self._action_combos = {}
+        self._key_edits = {}
+
+        self.table.setSelectionBehavior(
+            QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        self.table.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
+        )
+        self.table.setEditTriggers(
+            QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers
+        )
+        header = self.table.horizontalHeader()
+        header.setSectionResizeMode(
+            0, QtWidgets.QHeaderView.ResizeMode.ResizeToContents
+        )
+        header.setSectionResizeMode(
+            1, QtWidgets.QHeaderView.ResizeMode.ResizeToContents
+        )
+        header.setSectionResizeMode(
+            2, QtWidgets.QHeaderView.ResizeMode.ResizeToContents
+        )
+        header.setSectionResizeMode(3, QtWidgets.QHeaderView.ResizeMode.Stretch)
+
+        self.add_button.clicked.connect(self._on_add)
+        self.remove_button.clicked.connect(self._on_remove)
+        self.reset_all_button.clicked.connect(self._on_reset_all)
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+
+        self._load(key_bindings)
+        self._refresh()
+
+    def _load(self, key_bindings):
+        # populate dialog window with existing key bindings
+        self._bindings = []
+        for context_key, action in key_bindings.items():
+            if ":" in context_key:
+                context, _, key = context_key.partition(":")
+            else:
+                context, key = "*", context_key
+            self._bindings.append(
+                {
+                    "context": context,
+                    "key": key,
+                    "action": action,
+                }
+            )
+
+    def _refresh(self) -> None:
+        self._suppress_widget_signals = True
+        try:
+            old_count = self.table.rowCount()
+            self.table.setRowCount(len(self._bindings))
+
+            new_context_combos = {}
+            new_key_edits = {}
+            new_action_combos = {}
+            for row, entry in enumerate(self._bindings):
+                existing = self.table.cellWidget(row, 0)
+                if isinstance(existing, QtWidgets.QComboBox):
+                    context_combo = existing
+                    if context_combo.currentText() != entry["context"]:
+                        context_combo.setCurrentText(entry["context"])
+                else:
+                    context_combo = QtWidgets.QComboBox()
+                    context_combo.addItems(_KNOWN_CONTEXTS)
+                    context_combo.setCurrentText(entry["context"])
+                    context_combo.currentTextChanged.connect(
+                        lambda text, r=row: self._on_context_changed(r, text)
+                    )
+                    self.table.setCellWidget(row, 0, context_combo)
+                new_context_combos[row] = context_combo
+
+                existing_edit = self.table.cellWidget(row, 1)
+                if isinstance(existing_edit, QtWidgets.QKeySequenceEdit):
+                    key_edit = existing_edit
+                    if key_edit.keySequence().toString() != entry["key"]:
+                        key_edit.setKeySequence(QtGui.QKeySequence(entry["key"]))
+                else:
+                    key_edit = QtWidgets.QKeySequenceEdit(
+                        QtGui.QKeySequence(entry["key"])
+                    )
+                    key_edit.keySequenceChanged.connect(
+                        lambda seq, r=row: self._on_key_sequence_changed(r, seq)
+                    )
+                    self.table.setCellWidget(row, 1, key_edit)
+                new_key_edits[row] = key_edit
+
+                existing_combo = self.table.cellWidget(row, 2)
+                if isinstance(existing_combo, QtWidgets.QComboBox):
+                    combo = existing_combo
+                    if combo.currentText() != entry["action"]:
+                        combo.setCurrentText(entry["action"])
+                else:
+                    combo = QtWidgets.QComboBox()
+                    combo.setEditable(True)
+                    combo.addItems(self.actions)
+                    combo.setCurrentText(entry["action"])
+                    combo.currentTextChanged.connect(
+                        lambda text, r=row: self._on_action_changed(r, text)
+                    )
+                    self.table.setCellWidget(row, 2, combo)
+                new_action_combos[row] = combo
+
+                description_item = QtWidgets.QTableWidgetItem(
+                    self.action_docs.get(entry["action"], "")
+                )
+                description_item.setFlags(self._READONLY_FLAGS)
+                self.table.setItem(row, 3, description_item)
+
+            for removed_row in range(len(self._bindings), old_count):
+                for col in (0, 1, 2):
+                    old = self.table.cellWidget(removed_row, col)
+                    if old is not None:
+                        old.deleteLater()
+
+            self._context_combos = new_context_combos
+            self._key_edits = new_key_edits
+            self._action_combos = new_action_combos
+            for col in range(3):
+                self.table.resizeColumnToContents(col)
+        finally:
+            self._suppress_widget_signals = False
+
+    def _selected_row(self) -> int:
+        rows = self.table.selectionModel().selectedRows()
+        if not rows:
+            return -1
+        return rows[0].row()
+
+    def _on_add(self) -> None:
+        self._bindings.append({"context": "*", "key": "", "action": "NO_ACTION"})
+        self._refresh()
+        new_row = len(self._bindings) - 1
+        self.table.selectRow(new_row)
+        combo = self._action_combos.get(new_row)
+        if combo is not None:
+            self.table.setCurrentCell(new_row, 2)
+            combo.setFocus()
+            line_edit = combo.lineEdit()
+            if line_edit is not None:
+                line_edit.selectAll()
+
+    def _on_remove(self) -> None:
+        row = self._selected_row()
+        if row < 0:
+            return
+        del self._bindings[row]
+        self._refresh()
+        if self._bindings:
+            self.table.selectRow(min(row, len(self._bindings) - 1))
+
+    def _on_reset_all(self) -> None:
+        self._load(not1mm.actions.default_key_bindings)
+        self._refresh()
+
+    def _on_context_changed(self, row: int, context: str) -> None:
+        if self._suppress_widget_signals:
+            return
+        if 0 <= row < len(self._bindings):
+            self._bindings[row]["context"] = context
+
+    def _on_action_changed(self, row: int, action: str) -> None:
+        if self._suppress_widget_signals:
+            return
+        if not (0 <= row < len(self._bindings)):
+            return
+        self._bindings[row]["action"] = action
+        desc_item = self.table.item(row, 3)
+        desc_item.setText(self.action_docs.get(action, ""))
+
+    def _on_key_sequence_changed(self, row: int, sequence: QtGui.QKeySequence) -> None:
+        if self._suppress_widget_signals:
+            return
+        if 0 <= row < len(self._bindings):
+            self._bindings[row]["key"] = sequence.toString()
+
+    def save_keys(self) -> None:
+        """
+        Save keys configured in the dialog window to the preferences file.
+
+        Format is dict mapping <context>:<key> (e.g. Callsign:Ctrl-Shift-A) to
+        action names.
+        """
+
+        key_bindings = {}
+        for entry in self._bindings:
+            # skip incomplete entries
+            if entry["key"] == "" or entry["action"] == "":
+                continue
+            # key_bindings key is "Ctrl+R" or "context:Ctrl+R"
+            if entry["context"] == "*":
+                context_key = entry["key"]
+            else:
+                context_key = entry["context"] + ":" + entry["key"]
+            key_bindings[context_key] = entry["action"]
+        pref = Preferences.data()
+        pref["key_bindings"] = key_bindings
+        Preferences.save()


### PR DESCRIPTION
Anything that QKeySequenceEdit recognizes can be remapped, from a simple "Up" key to complex things like Ctrl+Alt+Shift+Backspace. Bindings are either valid everywhere, or can depend on the input widget currently focused, so Up could do something else in the callsign and the exchange input fields. Keys can now also be intercepted before they reach the input widgets, so remapping combinations like Ctrl+K is now possible (otherwise handled by the input widget).

Possible key actions are defined in not1mm/actions.py. The current actions have been extracted from the old keyPressEvent() implementation. Any function (not prefixed with _) defined in that file will automatically appear in the Edit Keys dialog dropdown.

One new action has been added: EDIT_KEYS opens the new dialog, if anyone wants to bind that to a key.

Default keybindings are also defined in not1mm/actions.py. They currently match the previous keybindings.

I have not touched the Tab and F-Keys handling yet, though there are probably some nice refactoring opportunities now.