### PR TITLE
Synchronize VFOs

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -343,6 +343,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.actionRotator.triggered.connect(self.launch_rotator_window)
         self.actionRecalculate_Mults.triggered.connect(self.recalculate_mults)
         self.actionMark_Contacts_Dirty.triggered.connect(self.mark_all_dirty)
+        self.actionSynchronize_VFOs.triggered.connect(self.synchronize_vfos_triggered)
         self.actionLoad_Call_History_File.triggered.connect(self.load_call_history)
 
         self.actionGenerate_Cabrillo_ASCII.triggered.connect(
@@ -2438,6 +2439,13 @@ class MainWindow(QtWidgets.QMainWindow):
         self.database.make_all_dirty()
         self.resolve_dirty_records()
 
+    def synchronize_vfos_triggered(self) -> None:
+        """When ticked, set both VFO A and B on supported rigs when set_vfo is called."""
+        self.pref["synchronize_vfos"] = self.actionSynchronize_VFOs.isChecked()
+        Preferences.save()
+        if self.rig_control is not None:
+            self.rig_control.cat.set_sync_vfos(self.pref["synchronize_vfos"])
+
     def launch_log_window(self) -> None:
         """Launch or close the log window"""
         self.pref["logwindow"] = self.actionLog_Window.isChecked()
@@ -4005,6 +4013,12 @@ class MainWindow(QtWidgets.QMainWindow):
                 ),
                 port=self.pref.get("rotctld_port", 4533),
             )
+
+        # widgets outside the settings window
+        sync_vfos = self.pref.get("synchronize_vfos", False)
+        self.actionSynchronize_VFOs.setChecked(sync_vfos)
+        if self.rig_control is not None:
+            self.rig_control.cat.set_sync_vfos(sync_vfos)
 
     def rtc_response(self, response: dict) -> None:
         print(f"{response=}")

--- a/not1mm/actions.py
+++ b/not1mm/actions.py
@@ -138,6 +138,12 @@ def VFO_UP(self) -> None:
         self.rig_control.set_vfo(vfo)
 
 
+def TOGGLE_VFO_SYNC(self) -> None:
+    """Toggle the Synchronize VFOs mode"""
+    self.actionSynchronize_VFOs.setChecked(not self.actionSynchronize_VFOs.isChecked())
+    self.synchronize_vfos_triggered()
+
+
 def CW_SPEED_UP(self) -> None:
     """Increase CW sending speed"""
     if self.cw is not None:

--- a/not1mm/data/main.ui
+++ b/not1mm/data/main.ui
@@ -1601,6 +1601,8 @@
     </property>
     <addaction name="actionRecalculate_Mults"/>
     <addaction name="actionMark_Contacts_Dirty"/>
+    <addaction name="separator"/>
+    <addaction name="actionSynchronize_VFOs"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuView"/>
@@ -2299,6 +2301,14 @@
    </property>
    <property name="shortcut">
     <string>Alt+Z</string>
+   </property>
+  </action>
+  <action name="actionSynchronize_VFOs">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Synchronize VFOs</string>
    </property>
   </action>
  </widget>

--- a/not1mm/lib/cat_interface.py
+++ b/not1mm/lib/cat_interface.py
@@ -77,8 +77,11 @@ class CAT:
     def get_mode_list(self):
         "Get a list of modes supported by the radio"
 
-    def set_vfo(self, freq: str) -> bool:
-        """Sets the radios vfo"""
+    def set_vfo(self, freq: str):
+        """Sets the radios VFO. Defaults to VFOA."""
+
+    def set_sync_vfos(self, sync_vfos: bool) -> bool:
+        """Turn Sync VFOs on/off"""
 
     def set_mode(self, mode: str) -> bool:
         """Sets the radios mode"""

--- a/not1mm/lib/cat_rigctld.py
+++ b/not1mm/lib/cat_rigctld.py
@@ -37,6 +37,7 @@ class RigctldCAT(CAT):
         self.rigctrlsocket = None
         self.rigctld_bw = "0"
         self.interface = "rigctld"
+        self.sync_vfos = False
         self.reinit()
 
     def reinit(self):
@@ -193,7 +194,27 @@ class RigctldCAT(CAT):
     def set_vfo(self, freq: str) -> bool:
         """Sets the radios vfo"""
         self.rigctld_command(f"F VFOA {freq}")
+        if self.sync_vfos:
+            self.rigctld_command(f"F VFOB {freq}")
         return True
+
+    def set_sync_vfos(self, sync_vfos: bool):
+        """
+        Turn on/off the Sync VFOs feature. Syncs frequencies once when turned
+        on and then with every set_vfo().
+
+        It also turns on VFO Tracking mode on supported rigs. On ICOM, setting
+        VFOA using CAT doesn't automatically update VFOB even when tracking is
+        active, so we still need to set VFOB explicitly.
+        """
+        self.sync_vfos = sync_vfos
+        # turn on SY/Tracking on supported rigs
+        self.rigctld_command(
+            f"\\set_func VFOA SYNC {int(self.sync_vfos)}"
+        )
+        # sync now when activating
+        if self.sync_vfos and (freq := self.get_vfo()):
+            self.rigctld_command(f"F VFOB {freq}")
 
     def set_mode(self, mode: str) -> bool:
         """Sets the radios mode"""


### PR DESCRIPTION
Rigs with dual receivers can synchronize tuning on both VFOs for diversity reception. (Hamlib calls this SYNC, Yaesu SY and ICOM Tracking.) Enabling this on the radio isn't enough when using CAT to jump to the next spot - at least on ICOM, it still sets VFOA only (and then the tracking is out of sync.)

Fix by adding a checkable "Synchronize VFOs" menu item in the Misc menu (so it's readily available without going through the settings dialog). Also add a TOGGLE_VFO_SYNC action.

Currently only supported for rigctld, and in there, it still depends on Hamlib support for "\set_func SYNC" which is only implemented for Yaesu FTDX101, but I sent a pull request to add IC-7610 support.