### PR TITLE
Fix corruption of current_contest after changing settings

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -3325,8 +3325,7 @@ class MainWindow(QtWidgets.QMainWindow):
         contest["Operators"] = self.contest_dialog.operators.text()
         contest["Soapbox"] = self.contest_dialog.soapbox.toPlainText()
         contest["SentExchange"] = self.contest_dialog.exchange.text()
-        contest["ContestNR"] = next_number.get("count", 1)
-        self.pref["contest"] = next_number.get("count", 1)
+        contest["ContestNR"] = next_number.get("nr", 1)
         # contest['SubType'] = self.contest_dialog.
         contest["StationCategory"] = self.contest_dialog.station.currentText()
         contest["AssistedCategory"] = self.contest_dialog.assisted.currentText()
@@ -3334,7 +3333,10 @@ class MainWindow(QtWidgets.QMainWindow):
         # contest['TimeCategory'] = self.contest_dialog.
         logger.debug("%s", f"{contest}")
         self.database.add_contest(contest)
+
+        self.pref["contest"] = next_number.get("nr", 1)
         Preferences.save()
+
         self.load_contest()
 
     def edit_station_settings(self) -> None:
@@ -3794,7 +3796,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self.dbname = fsutils.USER_DATA_PATH / self.pref.get(
             "current_database", "ham.db"
         )
-        self.database = DataBase(self.dbname, fsutils.APP_DATA_PATH)
+        self.database = DataBase(
+            self.dbname,
+            fsutils.APP_DATA_PATH,
+            current_contest=self.pref.get("contest", None),
+        )
 
         if self.pref.get("run_state", False) is True:
             self.radioButton_run.setChecked(True)

--- a/not1mm/lib/database.py
+++ b/not1mm/lib/database.py
@@ -21,12 +21,11 @@ logger = logging.getLogger("database")
 class DataBase:
     """Database class for our database."""
 
-    current_contest = 1
-
-    def __init__(self, database: str, app_data_dir: str):
+    def __init__(self, database: str, app_data_dir: str, current_contest=None):
         """initializes DataBase instance"""
         logger.debug("Database: %s", database)
         self.app_data_dir = app_data_dir
+        self.current_contest = current_contest
         self.empty_contact = {
             "TS": "",
             "Call": "",
@@ -133,7 +132,9 @@ class DataBase:
             logger.error("%s", exception)
             return ()
 
-    def exec_sql_commit(self, query: str, params=(), commit=True, error_logger=logger.error) -> None:
+    def exec_sql_commit(
+        self, query: str, params=(), commit=True, error_logger=logger.error
+    ) -> None:
         """Exec write query with database changes and commit"""
         try:
             logger.debug("%s", query)
@@ -369,7 +370,9 @@ class DataBase:
 
     def get_next_contest_nr(self):
         """Returns the next ContestNR to use."""
-        return self.exec_sql("select count(*) + 1 as count from ContestInstance;")
+        return self.exec_sql(
+            "select coalesce(max(ContestNR), 0) + 1 as nr from ContestInstance;"
+        )
 
     def fetch_contest_by_id(self, contest_nr: str) -> dict:
         """returns a dict of ContestInstance"""


### PR DESCRIPTION
apply_settings reconnects to the database for the main window, but didn't restore the current_contest class variable, so dupe computation and scores were based on contest number 1 afterwards. Make the variable an instance variable and set it from __init__. It now defaults to None so places not initializing it should fail more loudly now.

In passing, fix computation of the next contest number. It should be max+1 instead of count+1, the latter is wrong if the ContestInstance table is ever cleaned up.