### PR TITLE
Set MainWindow dock option AllowNestedDocks

### DIFF
--- a/not1mm/data/main.ui
+++ b/not1mm/data/main.ui
@@ -42,6 +42,9 @@
     <height>32</height>
    </size>
   </property>
+  <property name="dockOptions">
+   <set>QMainWindow::DockOption::AllowNestedDocks|QMainWindow::DockOption::AllowTabbedDocks|QMainWindow::DockOption::AnimatedDocks</set>
+  </property>
   <widget class="QWidget" name="centralwidget">
    <property name="enabled">
     <bool>true</bool>


### PR DESCRIPTION
The default is AllowTabbedDocks|AnimatedDocks, this adds AllowNestedDocks. This allows more complex window arrangements like vertically splitting the space on top of the main widget or having two columns of vertically arranged widgets at the right.