### PR TITLE
Move current operator to preferences and wire Ctrl+O to OPON

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -80,7 +80,6 @@ from not1mm.lib.about import About
 from not1mm.lib.cwinterface import CW
 from not1mm.lib.database import DataBase
 from not1mm.lib.edit_macro import EditMacro
-from not1mm.lib.edit_opon import OpOn
 from not1mm.lib.edit_rove import Rove
 from not1mm.lib.edit_station import EditStation
 from not1mm.lib.fldigi_sendstring import FlDigi_Comm
@@ -4285,7 +4284,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.change_mode(stripped_text)
                 return
             if stripped_text == "OPON":
-                self.get_opon()
+                not1mm.actions.OPON(self)
                 self.clearinputs()
                 return
             if stripped_text == "ROVE":
@@ -4651,49 +4650,6 @@ class MainWindow(QtWidgets.QMainWindow):
             self.RoverLocation = self.rover_dialog.NewLocation.text().upper()
             logger.debug("New RoverLocation: %s", self.RoverLocation)
         self.rover_dialog.close()
-
-    def get_opon(self) -> None:
-        """
-        Ctrl+O Open the OPON dialog.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        None
-        """
-
-        self.opon_dialog = OpOn(fsutils.APP_DATA_PATH)
-
-        if self.current_palette:
-            self.opon_dialog.setPalette(self.current_palette)
-
-        self.opon_dialog.accepted.connect(self.new_op)
-        self.opon_dialog.open()
-
-    def new_op(self) -> None:
-        """
-        Called when the user clicks the OK button on the OPON dialog.
-        Create the new directory and copy the phonetic files.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        None
-        """
-
-        if current_op := self.opon_dialog.NewOperator.text().upper():
-            self.pref["current_op"] = current_op
-            Preferences.save()
-            logger.debug("New Op: %s", current_op)
-            self.make_op_dir()
-            self.set_window_title()
-        self.opon_dialog.close()
 
     def make_op_dir(self) -> None:
         """

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -133,7 +133,6 @@ class MainWindow(QtWidgets.QMainWindow):
     pref: typing.ClassVar = {}
     station: typing.ClassVar = {}
     spaceweather = ""
-    current_op = ""
     current_mode = ""
     current_band = ""
     default_rst = "59"
@@ -712,7 +711,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.voice_thread.finished.connect(self.voice_process.deleteLater)
         self.voice_process.ptt_on.connect(self.ptt_on)
         self.voice_process.ptt_off.connect(self.ptt_off)
-        self.voice_process.current_op = self.current_op
         self.voice_process.data_path = fsutils.USER_DATA_PATH
         self.voice_process.sounddevice = self.pref.get("sounddevice", "default")
         self.voice_thread.start()
@@ -730,8 +728,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.previous_contact = (
             self.contact
         )  # Keep previous contact, if any, so we can spot it.
-        self.current_op = self.station.get("Call", "")
-        self.voice_process.current_op = self.current_op
         self.make_op_dir()
         self.cq_freq = None
 
@@ -760,7 +756,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.bandmap_window.hide()
         self.bandmap_window.cluster_expire.connect(self.cluster_expire_updated)
         self.bandmap_window.message.connect(self.dockwidget_message)
-        self.bandmap_window.callsignField.setText(self.current_op)
+        self.bandmap_window.callsignField.setText(self.pref.get("current_op", ""))
         self.bandmap_window.bandmapwindow_closed.connect(self.launch_bandmap_window)
 
         self.show_splash_msg("Setting up CheckWindow.")
@@ -803,7 +799,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, self.chat_window)
         self.chat_window.hide()
         self.chat_window.message.connect(self.dockwidget_message)
-        self.chat_window.mycall = self.current_op
         self.chat_window.chatwindow_closed.connect(self.launch_chat_window)
 
         self.show_splash_msg("Setting up DXCCWindow.")
@@ -1077,7 +1072,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     )
                     cmd["expire"] = stale.isoformat()
                     cmd["NetBiosName"] = socket.gethostname()
-                    cmd["Operator"] = self.current_op
+                    cmd["Operator"] = self.pref.get("current_op", "")
                     cmd["ID"] = uuid.uuid4().hex
                     cmd["Station"] = self.station
                     try:
@@ -1367,20 +1362,6 @@ class MainWindow(QtWidgets.QMainWindow):
                     self.bandmap_window.msg_from_main(cmd)
                 return
 
-            if msg.get("cmd", "") == "GETCONTESTSTATUS":
-                cmd = {
-                    "cmd": "CONTESTSTATUS",
-                    "contest": self.contest_settings,
-                    "operator": self.current_op,
-                }
-                if self.bandmap_window:
-                    self.bandmap_window.msg_from_main(cmd)
-                    self.bandmap_window.callsignField.setText(self.current_op)
-                if self.chat_window:
-                    self.chat_window.msg_from_main(cmd)
-                    self.chat_window.mycall = self.current_op
-                return
-
             if msg.get("cmd", "") == "CHANGECALL":
                 self.activateWindow()
                 self.callsign.setText(msg.get("call", ""))
@@ -1426,7 +1407,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 msg.get("cmd", "") == "CHAT"
                 and self.pref.get("useserver", False) is True
             ):
-                msg["sender"] = self.current_op
+                msg["sender"] = self.pref.get("current_op", "")
                 try:
                     self.server_channel.send_as_json(msg)
                 except OSError as err:
@@ -1857,8 +1838,6 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.station = {}
             if self.rotator_window is not None:
                 self.rotator_window.set_mygrid(self.station.get("GridSquare", ""))
-            self.current_op = self.station.get("Call", "")
-            self.voice_process.current_op = self.current_op
             self.make_op_dir()
             cmd = {}
             cmd["cmd"] = "NEWDB"
@@ -1872,8 +1851,6 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.dxcc_window.msg_from_main(cmd)
             if self.zone_window:
                 self.zone_window.msg_from_main(cmd)
-            if self.chat_window:
-                self.chat_window.mycall = self.current_op
 
             self.clearinputs()
             self.edit_station_settings()
@@ -1908,8 +1885,6 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.rotator_window.set_mygrid(self.station.get("GridSquare", ""))
             if self.station.get("Call", "") == "":
                 self.edit_station_settings()
-            self.current_op = self.station.get("Call", "")
-            self.voice_process.current_op = self.current_op
             self.make_op_dir()
             cmd = {}
             cmd["cmd"] = "NEWDB"
@@ -1923,8 +1898,6 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.dxcc_window.msg_from_main(cmd)
             if self.zone_window:
                 self.zone_window.msg_from_main(cmd)
-            if self.chat_window:
-                self.chat_window.mycall = self.current_op
 
             self.clearinputs()
             self.open_contest()
@@ -2245,7 +2218,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     )
                     cmd["expire"] = stale.isoformat()
                     cmd["NetBiosName"] = socket.gethostname()
-                    cmd["Operator"] = self.current_op
+                    cmd["Operator"] = self.pref.get("current_op", "")
                     cmd["ID"] = uuid.uuid4().hex
                     cmd["Station"] = self.station
                     # self.server_commands.append(cmd)
@@ -2784,7 +2757,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.current_sn = "REQUESTED"
                 cmd = {}
                 cmd["cmd"] = "GET_SN"
-                cmd["Operator"] = self.current_op
+                cmd["Operator"] = self.pref.get("current_op", "")
                 cmd["NetBiosName"] = socket.gethostname()
                 try:
                     self.server_channel.send_as_json(cmd)
@@ -3001,7 +2974,7 @@ class MainWindow(QtWidgets.QMainWindow):
         line = (
             f"vfoa:{round(vfoa, 2)} "
             f"mode:{self.radio_state.get('mode', '')} "
-            f"OP:{self.current_op} {contest_name} "
+            f"OP:{self.pref.get("current_op", "")} {contest_name} "
             f"{self.spaceweather} "
             f"- Not1MM v{__version__}"
         )
@@ -3170,7 +3143,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.contact["StationPrefix"] = self.station.get("Call", "")
         self.contact["WPXPrefix"] = calculate_wpx_prefix(self.callsign.text())
         self.contact["IsRunQSO"] = self.radioButton_run.isChecked()
-        self.contact["Operator"] = self.current_op
+        self.contact["Operator"] = self.pref.get("current_op", "")
 
         if self.RoverLocation:
             self.contact["RoverLocation"] = self.RoverLocation
@@ -3376,6 +3349,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.settings_dialog.accepted.connect(self.save_settings)
         self.settings_dialog.Call.setText(self.station.get("Call", ""))
+        self.settings_dialog.Operator.setText(
+            self.pref.get("current_op", "") or self.station.get("Call", "")
+        )
         self.settings_dialog.Name.setText(self.station.get("Name", ""))
         self.settings_dialog.Address1.setText(self.station.get("Street1", ""))
         self.settings_dialog.Address2.setText(self.station.get("Street2", ""))
@@ -3413,9 +3389,9 @@ class MainWindow(QtWidgets.QMainWindow):
         None
         """
 
-        cs = self.settings_dialog.Call.text()
+        mycall = self.settings_dialog.Call.text().upper()
         self.station = {}
-        self.station["Call"] = cs.upper()
+        self.station["Call"] = mycall
         self.station["Name"] = self.settings_dialog.Name.text().title()
         self.station["Street1"] = self.settings_dialog.Address1.text().title()
         self.station["Street2"] = self.settings_dialog.Address2.text().title()
@@ -3442,10 +3418,11 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.rotator_window is not None:
             self.rotator_window.set_mygrid(self.settings_dialog.GridSquare.text())
         self.settings_dialog.close()
-        if self.current_op == "":
-            self.current_op = self.station.get("Call", "")
-            self.voice_process.current_op = self.current_op
-            self.make_op_dir()
+
+        self.pref["current_op"] = self.settings_dialog.Operator.text().upper() or mycall
+        Preferences.save()
+        self.make_op_dir()
+
         contest_count = self.database.fetch_all_contests()
         if len(contest_count) == 0:
             self.new_contest_dialog()
@@ -4575,7 +4552,7 @@ class MainWindow(QtWidgets.QMainWindow):
         ):
             cmd = {}
             cmd["cmd"] = "ISDUPE"
-            cmd["Operator"] = self.current_op
+            cmd["Operator"] = self.pref.get("current_op", "")
             cmd["NetBiosName"] = socket.gethostname()
             cmd["Call"] = call
             cmd["Band"] = band
@@ -4710,17 +4687,13 @@ class MainWindow(QtWidgets.QMainWindow):
         None
         """
 
-        if self.opon_dialog.NewOperator.text():
-            self.current_op = self.opon_dialog.NewOperator.text().upper()
-            self.voice_process.current_op = self.current_op
-            if self.bandmap_window:
-                self.bandmap_window.callsignField.setText(self.current_op)
-            if self.chat_window:
-                self.chat_window.mycall = self.current_op
+        if current_op := self.opon_dialog.NewOperator.text().upper():
+            self.pref["current_op"] = current_op
+            Preferences.save()
+            logger.debug("New Op: %s", current_op)
+            self.make_op_dir()
+            self.set_window_title()
         self.opon_dialog.close()
-        logger.debug("New Op: %s", self.current_op)
-        self.make_op_dir()
-        self.set_window_title()
 
     def make_op_dir(self) -> None:
         """
@@ -4736,8 +4709,8 @@ class MainWindow(QtWidgets.QMainWindow):
         None
         """
 
-        if self.current_op:
-            op_path = fsutils.USER_DATA_PATH / self.current_op.replace("/", "-")
+        if current_op := self.pref.get("current_op", ""):
+            op_path = fsutils.USER_DATA_PATH / current_op.replace("/", "-")
             logger.debug("op_path: %s", str(op_path))
             if op_path.is_dir() is False:
                 logger.debug("Creating Op Directory: %s", str(op_path))
@@ -4867,7 +4840,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     self.n1mm.radio_info["Freq"] = vfo[:-1]
                     self.n1mm.radio_info["TXFreq"] = vfo[:-1]
                     self.n1mm.radio_info["Mode"] = mode
-                    self.n1mm.radio_info["OpCall"] = self.current_op
+                    self.n1mm.radio_info["OpCall"] = self.pref.get("current_op", "")
                     self.n1mm.radio_info["IsRunning"] = str(
                         self.pref.get("run_state", False)
                     )
@@ -4879,7 +4852,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     cmd["Band"] = band
                     cmd["Mode"] = mode
                     cmd["NetBiosName"] = socket.gethostname()
-                    cmd["Operator"] = self.current_op
+                    cmd["Operator"] = self.pref.get("current_op", "")
                     try:
                         self.server_channel.send_as_json(cmd)
                     except OSError as err:

--- a/not1mm/actions.py
+++ b/not1mm/actions.py
@@ -11,7 +11,10 @@ The function doc string is used as action description in the Edit Keys dialog.
 
 # pylint: disable=invalid-name
 
+from not1mm import fsutils
 from not1mm.lib.edit_keys import EditKeys
+from not1mm.lib.edit_opon import OpOn
+from not1mm.lib.preferences import Preferences
 
 default_key_bindings = {
     "Ctrl+R": "TOGGLE_RUN",
@@ -30,6 +33,7 @@ default_key_bindings = {
     "PgUp": "CW_SPEED_UP",
     "Ctrl+W": "CLEAR_INPUTS",
     "Esc": "STOP_ALL",
+    "Ctrl+O": "OPON",
     "Ctrl+T": "ADD_TEST_DATA",
 }
 
@@ -174,6 +178,17 @@ def CLEAR_INPUTS(self) -> None:
 def STOP_ALL(self) -> None:
     """Stop CW sending and antenna rotation"""
     self.stop_all()
+
+
+def OPON(self) -> None:
+    """
+    Ctrl+O Open the OPON dialog.
+    """
+
+    self.opon_dialog = OpOn(fsutils.APP_DATA_PATH, self)
+    if self.current_palette:
+        self.opon_dialog.setPalette(self.current_palette)
+    self.opon_dialog.open()
 
 
 def ADD_TEST_DATA(self) -> None:

--- a/not1mm/bandmap.py
+++ b/not1mm/bandmap.py
@@ -476,7 +476,7 @@ class BandMapWindow(QDockWidget):
         self.setDarkMode()
         self.update()
         self.request_workedlist()
-        self.request_contest()
+        self.callsignField.setText(self.settings.get("current_op", ""))
 
     def setActive(self, mode: bool):
         self.active = bool(mode)
@@ -585,10 +585,6 @@ class BandMapWindow(QDockWidget):
             cmd["spots"] = []
             self.message.emit(cmd)
             return
-        if packet.get("cmd", "") == "CONTESTSTATUS":
-            if not self.callsignField.text():
-                self.callsignField.setText(packet.get("operator", "").upper())
-            return
         if packet.get("cmd", "") == "DARKMODE":
             self.setDarkMode()
 
@@ -642,12 +638,6 @@ class BandMapWindow(QDockWidget):
         """Request worked call list from logger"""
         cmd = {}
         cmd["cmd"] = "GETWORKEDLIST"
-        self.message.emit(cmd)
-
-    def request_contest(self):
-        """Request active contest from logger"""
-        cmd = {}
-        cmd["cmd"] = "GETCONTESTSTATUS"
         self.message.emit(cmd)
 
     def update_station_timer(self):

--- a/not1mm/chat.py
+++ b/not1mm/chat.py
@@ -16,7 +16,6 @@ class ChatWindow(QDockWidget):
 
     message = pyqtSignal(dict)
     chatwindow_closed = pyqtSignal()
-    mycall = ""
     poll_time = datetime.datetime.now() + datetime.timedelta(milliseconds=1000)
 
     def __init__(self, action):
@@ -25,6 +24,7 @@ class ChatWindow(QDockWidget):
         self.active: bool = False
         uic.loadUi(fsutils.APP_DATA_PATH / "chat.ui", self)
         self.chat_input.returnPressed.connect(self.send_chat)
+        self.pref = Preferences.data()
 
     def send_chat(self):
         """Sends UDP chat packet with text entered in chat_entry field."""
@@ -37,7 +37,7 @@ class ChatWindow(QDockWidget):
     def display_chat(self, sender, body):
         """Displays the chat history."""
 
-        if self.mycall in body.upper():
+        if (mycall := self.pref.get("current_op", "")) and mycall in body.upper():
             self.chat_history.setTextColor(QtGui.QColor(245, 121, 0))
         self.chat_history.insertPlainText(f"\n{sender}: {body}")
         self.chat_history.setTextColor(QtGui.QColor(211, 215, 207))
@@ -50,26 +50,9 @@ class ChatWindow(QDockWidget):
             # {"cmd": "CHAT", "sender": "N2CQR", "message": "I worked your mama on 80 meters."}
             self.display_chat(packet.get("sender", ""), packet.get("message", ""))
             return
-        if packet.get("cmd", "") == "CONTESTSTATUS":
-            self.mycall = packet.get("operator", "").upper()
-            return
 
     def setActive(self, mode: bool) -> None:
         self.active: bool = bool(mode)
-
-    def load_pref(self) -> None:
-        """
-        Load preference file to get current db filename and sets the initial darkmode state.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        None
-        """
-        self.pref = Preferences.data()
 
     def closeEvent(self, event) -> None:
         self.action.setChecked(False)

--- a/not1mm/data/settings.ui
+++ b/not1mm/data/settings.ui
@@ -1413,6 +1413,66 @@
      </item>
     </layout>
    </item>
+   <item row="2" column="4">
+    <widget class="QLineEdit" name="Operator">
+     <property name="palette">
+      <palette>
+       <active>
+        <colorrole role="PlaceholderText">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>229</red>
+           <green>163</green>
+           <blue>10</blue>
+          </color>
+         </brush>
+        </colorrole>
+       </active>
+       <inactive>
+        <colorrole role="PlaceholderText">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>145</red>
+           <green>145</green>
+           <blue>144</blue>
+          </color>
+         </brush>
+        </colorrole>
+       </inactive>
+       <disabled>
+        <colorrole role="PlaceholderText">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>145</red>
+           <green>145</green>
+           <blue>144</blue>
+          </color>
+         </brush>
+        </colorrole>
+       </disabled>
+      </palette>
+     </property>
+     <property name="accessibleName">
+      <string>Station operator</string>
+     </property>
+     <property name="accessibleDescription">
+      <string>Station operator. Leave blank when same as Call.</string>
+     </property>
+     <property name="placeholderText">
+      <string>K6GTE</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3">
+    <widget class="QLabel" name="label_24">
+     <property name="text">
+      <string>Operator</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>

--- a/not1mm/lib/edit_opon.py
+++ b/not1mm/lib/edit_opon.py
@@ -2,14 +2,26 @@
 
 from PyQt6 import QtWidgets, uic
 
+from not1mm.lib.preferences import Preferences
+
 
 class OpOn(QtWidgets.QDialog):
     """Change the current operator"""
 
-    def __init__(self, app_data_path, parent=None):
+    def __init__(self, app_data_path, parent):
         super().__init__(parent)
         uic.loadUi(app_data_path / "opon.ui", self)
-        self.buttonBox.clicked.connect(self.store)
+        self.parent = parent
+        self.accepted.connect(self.new_op)
 
-    def store(self):
-        """dialog magic"""
+    def new_op(self) -> None:
+        """
+        Called when the user clicks the OK button on the OPON dialog.
+        Create the new directory and copy the phonetic files.
+        """
+        if current_op := self.NewOperator.text().upper():
+            self.parent.pref["current_op"] = current_op
+            Preferences.save()
+            self.parent.make_op_dir()
+            self.parent.set_window_title()
+        self.close()

--- a/not1mm/voice_keying.py
+++ b/not1mm/voice_keying.py
@@ -21,6 +21,8 @@ except OSError as exception:
 import soundfile as sf
 from PyQt6.QtCore import QObject, QThread, pyqtSignal
 
+from not1mm.lib.preferences import Preferences
+
 logger = logging.getLogger("voice_keying")
 
 
@@ -41,7 +43,6 @@ class Voice(QObject):
     ptt_on = pyqtSignal()
     ptt_off = pyqtSignal()
     data_path = None
-    current_op = None
     sounddevice = None
     nonblocking = False
     voicings = []
@@ -49,6 +50,7 @@ class Voice(QObject):
     def __init__(self) -> None:
         super().__init__()
         """setup interface"""
+        self.pref = Preferences.data()
 
     def run(self):
         while True:
@@ -120,7 +122,7 @@ class Voice(QObject):
         if not has_output_device(self.sounddevice):
             logger.warning("No available output sound device for voice keying.")
             return
-        op_path = self.data_path / self.current_op.replace("/", "-")
+        op_path = self.data_path / self.pref.get("current_op", "").replace("/", "-")
         if "[" in the_string:
             sub_string = the_string.strip("[]").lower()
             filename = f"{str(op_path)}/{sub_string}.wav"


### PR DESCRIPTION
Move current operator to preferences

    This makes the operator setting survive restarts and simplifies many
    places in the code that had to track it.

    For the initial setting, add a new field to the Station Settings dialog.
    Unlike the other fields, this is not stored in the database, but it
    seems to make sense to put it there.

Make OPON an action and connect it to Ctrl+O

    There was already an old comment saying it was connected to Ctrl+O.