### PR TITLE
Initialize rig_control.cat earlier

### DIFF
--- a/not1mm/lib/cat_interface.py
+++ b/not1mm/lib/cat_interface.py
@@ -56,6 +56,9 @@ class CAT:
     def stopcw(self):
         """..."""
 
+    def set_cw_speed(self, speed: int) -> None:
+        """Set the CW speed in wpm"""
+
     def set_cw_send(self, send: bool) -> None:
         """Enable or disable the radio's CW keyer send flag."""
 

--- a/not1mm/radio.py
+++ b/not1mm/radio.py
@@ -22,7 +22,6 @@ class Radio(QObject):
     """Radio class"""
 
     poll_callback = pyqtSignal(dict)
-    cat = None
     vfoa = "14030000"
     mode = "CW"
     bw = "500"
@@ -53,7 +52,6 @@ class Radio(QObject):
         self.port = port
         logger.debug("Using %s: %s %d", interface, host, port)
 
-    def run(self):
         try:
             if self.interface == "flrig":
                 self.cat = FlrigCAT(self.host, self.port)
@@ -73,6 +71,8 @@ class Radio(QObject):
                     break
         except ConnectionResetError:
             ...
+
+    def run(self):
         while not self.time_to_quit:
             if datetime.datetime.now() > self.poll_time:
                 self.poll_time = datetime.datetime.now() + datetime.timedelta(


### PR DESCRIPTION
There was a race condition after Radio() was instantiated: the radio_thread started run() and initialized "cat", and the main window calling cat methods as part of config loading and the CW speed widget.

If rigctld is unreachable, there might now be a 1s delay on startup and loading settings, but we aren't crashing anymore.