### PR TITLE
Refactor RI macro CAT functions

### DIFF
--- a/not1mm/lib/cat_flrig.py
+++ b/not1mm/lib/cat_flrig.py
@@ -365,45 +365,9 @@ class FlrigCAT(CAT):
 
     def send_cat_string(self, cmdstr=""):
         """send a raw cat string to radio"""
-        cmdstr = cmdstr.strip()
-        test1 = cmdstr.replace(" ", "")
-        if test1 == "":
+        cmd, thisishex, ok = self._parse_cat_command(cmdstr)
+        if not ok or cmd == "":
             return True
-        working = cmdstr
-        test2 = [" ", " x", " X", "\\"]
-        test3 = "0123456789ABCDEF "  # trailing space
-        ishex = False
-        # does this look like hex?
-        for c2 in test2:
-            if c2 in working:
-                ishex = True
-        if ishex:
-            working = working.replace("x", "")
-            working = working.replace("X", "")
-            working = working.replace("\\", "")
-            working = working.upper()
-            # should be space-delimited now
-            # any illegal chars?
-            for c3 in working:
-                if c3 not in test3:
-                    logger.debug(f"Bad char in command string: [{cmdstr}]")
-                    return True
-            # hex checks out so far
-            spacesok = True
-            for i in range(len(working)):
-                if (i + 1) % 3 == 0:  # every 3rd char
-                    if working[i] != " ":
-                        spacesok = False
-            if not spacesok:
-                logger.debug(f"Bad delimiters in cmd string: [{cmdstr}]")
-                return True
-        else:
-            """not hex, but plain ascii text - do nothing"""
-
-        return self.__send_cat_string_flrig(working, ishex)
-
-    def __send_cat_string_flrig(self, cmd, thisishex):
-        """convert string to flrig format, send to flrig"""
         if thisishex:
             # make string " x" delimited (again) for flrig
             cmd = "x" + cmd

--- a/not1mm/lib/cat_interface.py
+++ b/not1mm/lib/cat_interface.py
@@ -97,3 +97,32 @@ class CAT:
 
     def ptt_off(self):
         """turn ptt on/off"""
+
+    @staticmethod
+    def _parse_cat_command(cmdstr: str) -> tuple[str, bool, bool]:
+        """Normalize an `RI:` macro payload into the form each CAT backend expects.
+
+        Returns (cmd, ishex, ok):
+        - cmd == "" and ok is True  -> whitespace input, nothing to send
+        - ok is False                   -> malformed; caller drops and logs
+        - ok is True, ishex is True     -> cmd holds hex bytes, space-delimited,
+                                           upper-case, every 3rd char is a space
+        - ok is True, ishex is False    -> cmd is ASCII text, returned as-is
+        """
+        cmdstr = cmdstr.strip()
+        if not cmdstr:
+            return "", False, True
+
+        ishex = any(tok in cmdstr for tok in (" ", " x", " X", "\\"))
+        if not ishex:
+            return cmdstr, False, True
+
+        cmd = cmdstr.replace("x", "").replace("X", "").replace("\\", "").upper()
+        if any(c not in "0123456789ABCDEF " for c in cmd):
+            logger.error("Bad char in RI: command string: [%s]", cmdstr)
+            return "", True, False
+        for i in range(2, len(cmd), 3):
+            if cmd[i] != " ":
+                logger.error("Bad delimiters in RI: cmd string: [%s]", cmdstr)
+                return "", True, False
+        return cmd, True, True

--- a/not1mm/lib/cat_rigctld.py
+++ b/not1mm/lib/cat_rigctld.py
@@ -272,61 +272,18 @@ class RigctldCAT(CAT):
 
     def send_cat_string(self, cmdstr=""):
         """send a raw cat string to radio"""
-        cmdstr = cmdstr.strip()
-        test1 = cmdstr.replace(" ", "")
-        if test1 == "":
+        cmd, thisishex, ok = self._parse_cat_command(cmdstr)
+        if not ok or cmd == "":
             return True
-        working = cmdstr
-        test2 = [" ", " x", " X", "\\"]
-        test3 = "0123456789ABCDEF "  # trailing space
-        ishex = False
-        # does this look like hex?
-        for c2 in test2:
-            if c2 in working:
-                ishex = True
-        if ishex:
-            working = working.replace("x", "")
-            working = working.replace("X", "")
-            working = working.replace("\\", "")
-            working = working.upper()
-            # should be space-delimited now
-            # any illegal chars?
-            for c3 in working:
-                if c3 not in test3:
-                    logger.debug(f"Bad char in command string: [{cmdstr}]")
-                    return True
-            # hex checks out so far
-            spacesok = True
-            for i in range(len(working)):
-                if (i + 1) % 3 == 0:  # every 3rd char
-                    if working[i] != " ":
-                        spacesok = False
-            if not spacesok:
-                logger.debug(f"Bad delimiters in cmd string: [{cmdstr}]")
-                return True
-        else:
-            """not hex, but plain ascii text - do nothing"""
-
-        return self.__send_cat_string_rigctld(working, ishex)
-
-    def __send_cat_string_rigctld(self, cmd, thisishex):
-        """convert string to rigctld format, send to rigctld"""
-        if not self.rigctrlsocket:
-            return 0
         if thisishex:
             # make string "\0x" delimited for rigctld
-            cmd = cmd.replace(" ", "\\0x")
-            cmd = "|w \\0x" + cmd
+            payload = "w \\0x" + cmd.replace(" ", "\\0x")
         else:
-            cmd = "|w " + cmd
-        bcmd = bytes(cmd, "utf-8")
-        logger.debug("%s", f"Sending rig command: [{bcmd}]")
+            payload = "w " + cmd
+        logger.debug("%s", f"Sending rig command: [{payload}]")
 
-        try:
-            if hasattr(self.rigctrlsocket, "send"):
-                self.rigctrlsocket.send(bcmd)
-        except socket.error:
-            logger.debug("Socket error!")
-            self.online = False
-            self.rigctrlsocket = None
-            return 0
+        report = self.rigctld_command(payload)
+        if "RPRT 0" not in report:
+            logger.info("rigctld rejected CAT cmd %r -> %s", payload, report.strip())
+            return False
+        return True


### PR DESCRIPTION
When I refactored the rigctld code, I didn't dare to touch this one. Now the common code is in a base class function called by the rigctld and flrig frontend classes.