### PR TITLE
Add TCI rig control support (AetherSDR, ExpertSDR)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ design.md
 not1mm/pull_master_to_branch.md
 ui.xml
 not1mm/testing/temp.txt
+.superpowers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- [2026-08-01] Add TCI rig control support, for SDRs such as AetherSDR and ExpertSDR
+  - Select TCI in the settings rig control tab; the default port is 50001
+  - CW keying over TCI works by also selecting "CW via CAT" on the CW tab
+  - Frequency, mode, and filter bandwidth sync in both directions, plus PTT
 - [2026-07-31] @mbridak Remove extra European HF Championship contest entry from contests.sql
 - [2026-07-30] Merge pull request #636 from mbridak/add-hadx
   - @mbridak Add HADX contest support and update UI for new contest entry

--- a/docs/superpowers/plans/2026-08-01-tci-support.md
+++ b/docs/superpowers/plans/2026-08-01-tci-support.md
@@ -91,7 +91,7 @@ from PyQt6.QtWebSockets import QWebSocket
 
 def main() -> None:
     host = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
-    port = int(sys.argv[2]) if len(sys.argv) > 2 else 40001
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else 50001
 
     app = QCoreApplication([])
     socket = QWebSocket()
@@ -125,7 +125,7 @@ if __name__ == "__main__":
 Start AetherSDR with TCI enabled, then:
 
 ```bash
-.venv/bin/python -m not1mm.testing.tci_probe 127.0.0.1 40001 | tee /tmp/tci-handshake.txt
+.venv/bin/python -m not1mm.testing.tci_probe 127.0.0.1 50001 | tee /tmp/tci-handshake.txt
 ```
 
 While it runs, exercise the radio manually: turn the VFO dial, change mode to CW and back, change the filter width, and key/unkey PTT. This makes the server emit every frame the backend needs to parse.
@@ -473,7 +473,7 @@ def client():
     building one via __new__ leaves the C++ side uninitialized, which PyQt6
     rejects with "'__init__' method of object's base class not called".
     """
-    return TCIClient("127.0.0.1", 40001, autostart=False)
+    return TCIClient("127.0.0.1", 50001, autostart=False)
 
 
 def test_starts_offline_with_empty_state(client):
@@ -881,7 +881,7 @@ def cat():
     instance = TciCAT.__new__(TciCAT)
     instance.interface = "tci"
     instance.host = "127.0.0.1"
-    instance.port = 40001
+    instance.port = 50001
     instance.online = False
     instance.client = StubClient()
     return instance
@@ -1039,7 +1039,7 @@ class TciCAT(CAT):
 
         A string defining the host, example: 'localhost' or '127.0.0.1'
 
-        An integer defining the network port used. Commonly 40001 for TCI.
+        An integer defining the network port used. Commonly 50001 for TCI.
 
         A variable 'online' is set to True once the TCI server completes its
         handshake, otherwise False.
@@ -1275,7 +1275,8 @@ Update the port hint at `not1mm/lib/settings.py:32-34`:
 
 ```python
         self.rigcontrolport_field.setToolTip(
-            "Usually 4532 for rigctld, 12345 for flrig, and 40001 for TCI."
+            "Usually 4532 for rigctld, 12345 for flrig, "
+            "and 50001 or 40001 for TCI."
         )
 ```
 
@@ -1304,7 +1305,7 @@ In `not1mm/__main__.py`, after the `userigctld` branch ending at line 3844 and b
             self.rig_control = Radio(
                 "tci",
                 self.pref.get("CAT_ip", "127.0.0.1"),
-                int(self.pref.get("CAT_port", 40001)),
+                int(self.pref.get("CAT_port", 50001)),
             )
 ```
 
@@ -1417,7 +1418,7 @@ class FakeTCIServer:
 
 
 def main() -> None:
-    port = int(sys.argv[1]) if len(sys.argv) > 1 else 40001
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 50001
     app = QCoreApplication([])
     server = FakeTCIServer(port)
     QTimer.singleShot(600000, app.quit)
@@ -1434,7 +1435,7 @@ if __name__ == "__main__":
 In one terminal:
 
 ```bash
-.venv/bin/python -m not1mm.testing.faketci 40001
+.venv/bin/python -m not1mm.testing.faketci 50001
 ```
 
 In another:
@@ -1445,7 +1446,7 @@ from PyQt6.QtCore import QCoreApplication, QThread
 from not1mm.lib.cat_tci import TciCAT
 
 app = QCoreApplication([])
-cat = TciCAT('127.0.0.1', 40001)
+cat = TciCAT('127.0.0.1', 50001)
 print('online:', cat.online)
 print('modes:', cat.get_mode_list())
 print('vfo:', cat.get_vfo())
@@ -1485,7 +1486,7 @@ from PyQt6.QtCore import QCoreApplication, QThread
 from not1mm.lib.cat_tci import TciCAT
 
 app = QCoreApplication([])
-cat = TciCAT('127.0.0.1', 40001)
+cat = TciCAT('127.0.0.1', 50001)
 for _ in range(30):
     QThread.msleep(1000)
     print('online:', cat.online, 'vfo:', repr(cat.get_vfo()), flush=True)
@@ -1521,7 +1522,7 @@ uv build
 uv tool install --force ./dist/not1mm-*-py3-none-any.whl
 ```
 
-Start AetherSDR with TCI enabled, then launch not1mm, open Settings, select **TCI** on the rig-control tab, set the address to `127.0.0.1` and the port to `40001`, and save.
+Start AetherSDR with TCI enabled, then launch not1mm, open Settings, select **TCI** on the rig-control tab, set the address to `127.0.0.1` and the port to `50001`, and save.
 
 - [ ] **Step 2: Verify radio state sync**
 
@@ -1558,7 +1559,7 @@ Add an entry to `CHANGELOG.md` in the existing format at the top of the file:
 
 ```
 Added TCI rig control support, for SDRs such as AetherSDR and ExpertSDR.
-Select TCI in the settings rig control tab; the default port is 40001.
+Select TCI in the settings rig control tab; the default port is 50001.
 CW keying over TCI works by also selecting "CW via CAT" on the CW tab.
 ```
 

--- a/docs/superpowers/plans/2026-08-01-tci-support.md
+++ b/docs/superpowers/plans/2026-08-01-tci-support.md
@@ -989,7 +989,7 @@ def test_set_mode_translates_to_tci_naming(cat):
     go_online(cat)
     cat.set_mode("CW")
     cat.set_mode("RTTY")
-    assert cat.client.sent == ["modulation:0,cw;", "modulation:0,digl;"]
+    assert cat.client.sent == ["modulation:0,cw;", "modulation:0,rtty;"]
 
 
 def test_ptt_on_and_off(cat):

--- a/docs/superpowers/plans/2026-08-01-tci-support.md
+++ b/docs/superpowers/plans/2026-08-01-tci-support.md
@@ -66,8 +66,15 @@ uv pip install -e . pytest
 
 - [ ] **Step 2: Verify pytest runs**
 
-Run: `.venv/bin/python -m pytest test/ -q`
-Expected: the existing suite collects and passes (`test/plugin_wag_tests.py`, `test/plugin_euhfc_tests.py`).
+Run: `.venv/bin/python -m pytest test/*_tests.py -q`
+Expected: 30 passed (`test/plugin_wag_tests.py`, `test/plugin_euhfc_tests.py`).
+
+**Note the glob.** Plain `pytest test/` collects **0** tests: this repo names its
+test files `*_tests.py`, which pytest's default `test_*.py` / `*_test.py`
+discovery patterns do not match, and the repo has no pytest config to widen
+them. Every test command in this plan therefore uses explicit paths or the
+`test/*_tests.py` glob. Do not "fix" this by adding pytest config to
+`pyproject.toml` — that file is off limits per the Global Constraints.
 
 - [ ] **Step 3: Write the probe script**
 
@@ -238,16 +245,24 @@ def test_build_command_roundtrips_through_parse_frame():
     "tci, not1mm",
     [
         ("cw", "CW"),
+        ("cwr", "CWR"),
         ("lsb", "LSB"),
         ("usb", "USB"),
         ("digl", "DIGI-L"),
         ("digu", "DIGI-U"),
-        ("nfm", "FM"),
+        ("rtty", "RTTY"),
+        ("fm", "FM"),
+        ("nfm", "NFM"),
         ("CW", "CW"),  # case insensitive
     ],
 )
 def test_tci_mode_to_not1mm(tci, not1mm):
     assert tci_mode_to_not1mm(tci) == not1mm
+
+
+def test_fm_and_nfm_do_not_collide():
+    """AetherSDR offers both; folding them together loses one on the way back."""
+    assert tci_mode_to_not1mm("fm") != tci_mode_to_not1mm("nfm")
 
 
 def test_tci_mode_to_not1mm_passes_through_unknown_modes_uppercased():
@@ -258,11 +273,12 @@ def test_tci_mode_to_not1mm_passes_through_unknown_modes_uppercased():
     "not1mm, tci",
     [
         ("CW", "cw"),
+        ("CWR", "cwr"),
         ("USB", "usb"),
         ("DIGI-L", "digl"),
-        ("RTTY", "digl"),
-        ("RTTY-R", "digu"),
-        ("FM", "nfm"),
+        ("RTTY", "rtty"),  # native on AetherSDR, not remapped to digl
+        ("FM", "fm"),
+        ("NFM", "nfm"),
     ],
 )
 def test_not1mm_mode_to_tci(not1mm, tci):
@@ -329,26 +345,32 @@ logger = logging.getLogger("tci_protocol")
 # Radio.cw_list / Radio.rtty_list (not1mm/radio.py:36-42) match the output of
 # get_mode_list() by exact string, so everything is normalized to not1mm's
 # uppercase names on the way in.
+# Verified against a live AetherSDR handshake on 2026-08-01; see
+# docs/superpowers/specs/2026-08-01-tci-handshake.md. AetherSDR reports:
+#   modulations_list:usb,lsb,cw,cwr,am,sam,fm,nfm,digu,digl,rtty;
 TCI_TO_NOT1MM_MODE = {
-    "cw": "CW",
-    "lsb": "LSB",
     "usb": "USB",
-    "dsb": "DSB",
+    "lsb": "LSB",
+    "cw": "CW",  # in Radio.cw_list
+    "cwr": "CWR",  # in Radio.cw_list
     "am": "AM",
     "sam": "SAM",
-    "nfm": "FM",
-    "wfm": "WFM",
-    "digl": "DIGI-L",
+    "fm": "FM",
+    # AetherSDR offers fm AND nfm. Folding nfm into FM would collide, and the
+    # reverse map would then lose fm entirely.
+    "nfm": "NFM",
     "digu": "DIGI-U",
+    "digl": "DIGI-L",  # in Radio.rtty_list
+    "rtty": "RTTY",  # in Radio.rtty_list -- native, never remapped to digl
+    # Not offered by AetherSDR; harmless, and correct for other TCI servers.
+    "dsb": "DSB",
+    "wfm": "WFM",
     "drm": "DRM",
 }
 
+# Plain inversion, no special cases: AetherSDR has a native rtty mode, so
+# not1mm's RTTY maps straight through.
 NOT1MM_TO_TCI_MODE = {v: k for k, v in TCI_TO_NOT1MM_MODE.items()}
-# not1mm uses RTTY as its generic data mode; TCI has no RTTY, so it lands on
-# the digital sidebands. Without this, selecting RTTY would send "rtty" and the
-# SDR would reject it.
-NOT1MM_TO_TCI_MODE["RTTY"] = "digl"
-NOT1MM_TO_TCI_MODE["RTTY-R"] = "digu"
 
 
 def parse_frame(frame: str) -> tuple[str, list[str]] | None:
@@ -427,7 +449,12 @@ Expected: PASS, all cases.
 
 - [ ] **Step 5: Reconcile with the recorded handshake**
 
-Open `docs/superpowers/specs/2026-08-01-tci-handshake.md` from Task 1. Compare the recorded `modulation_list:` names against `TCI_TO_NOT1MM_MODE`. Add any AetherSDR mode not in the table and add a test case for it. Remove nothing — unknown modes already pass through uppercased.
+The mode table above has **already been corrected** against the live handshake recorded in `docs/superpowers/specs/2026-08-01-tci-handshake.md`. Read that document's "Corrected mode table" section and confirm your `TCI_TO_NOT1MM_MODE` matches it exactly — all 14 entries.
+
+Three corrections it contains, so you recognize them as deliberate rather than mistakes:
+- The command is `modulations_list` (**plural**), not the singular form.
+- `fm` and `nfm` are **distinct** modes on AetherSDR and must not both map to `FM`.
+- AetherSDR has a **native `rtty`** mode, so `RTTY` maps straight through — do not remap it to `digl`.
 
 - [ ] **Step 6: Commit**
 
@@ -535,8 +562,8 @@ def test_trx_frame_sets_ptt(client, value, expected):
     assert client.get("ptt") == expected
 
 
-def test_modulation_list_is_normalized(client):
-    client.handle_frame("modulation_list", ["cw", "lsb", "usb", "digl"])
+def test_modulations_list_is_normalized(client):
+    client.handle_frame("modulations_list", ["cw", "lsb", "usb", "digl"])
     assert client.get("modes") == ["CW", "LSB", "USB", "DIGI-L"]
 
 
@@ -556,13 +583,13 @@ def test_clear_state_drops_everything_including_ready(client):
 
 def test_clear_state_preserves_mode_list(client):
     """Supported modes are a device property, not volatile state."""
-    client.handle_frame("modulation_list", ["cw", "usb"])
+    client.handle_frame("modulations_list", ["cw", "usb"])
     client.clear_state()
     assert client.get("modes") == ["CW", "USB"]
 
 
 def test_get_modes_returns_a_copy(client):
-    client.handle_frame("modulation_list", ["cw"])
+    client.handle_frame("modulations_list", ["cw"])
     client.get("modes").append("BOGUS")
     assert client.get("modes") == ["CW"]
 ```
@@ -720,7 +747,7 @@ class TCIClient(QObject):
                 self.set("bw", bandwidth)
         elif name == "trx" and len(args) >= 2 and args[0] == "0":
             self.set("ptt", "1" if args[1].strip().lower() == "true" else "0")
-        elif name == "modulation_list":
+        elif name == "modulations_list":
             self.set("modes", [tci_mode_to_not1mm(m) for m in args if m])
         else:
             logger.debug("Ignoring TCI frame: %s %s", name, args)
@@ -1311,8 +1338,8 @@ In `not1mm/__main__.py`, after the `userigctld` branch ending at line 3844 and b
 
 - [ ] **Step 7: Verify nothing regressed**
 
-Run: `.venv/bin/python -m pytest test/ -v`
-Expected: PASS — all tests including the three new files.
+Run: `.venv/bin/python -m pytest test/*_tests.py -v`
+Expected: PASS — all tests including the three new files. (The glob is required; see Task 1 Step 2.)
 
 Then confirm the UI file still parses and the new widget exists:
 
@@ -1367,16 +1394,28 @@ import sys
 from PyQt6.QtCore import QCoreApplication, QTimer
 from PyQt6.QtWebSockets import QWebSocketServer
 
+# Mirrors a real AetherSDR handshake captured 2026-08-01, including the noise
+# frames, so the client's ignore path gets exercised too. See
+# docs/superpowers/specs/2026-08-01-tci-handshake.md.
 HANDSHAKE = [
-    "protocol:ExpertSDR3,1.9;",
-    "device:FakeSDR;",
+    "vfo_limits:1000,75000000;",
+    "if_limits:-48000,48000;",
     "trx_count:1;",
-    "modulation_list:am,sam,dsb,lsb,usb,cw,nfm,digl,digu,wfm,drm;",
+    "channels_count:2;",
+    "device:FakeSDR;",
+    "receive_only:false;",
+    "modulations_list:usb,lsb,cw,cwr,am,sam,fm,nfm,digu,digl,rtty;",
+    "protocol:ExpertSDR3,1.5;",
     "vfo:0,0,14030000;",
+    "vfo:0,1,14030000;",
+    "dds:0,14176580;",
     "modulation:0,cw;",
     "rx_filter_band:0,-500,500;",
+    "agc_mode:0,fast;",
     "trx:0,false;",
+    "iq_samplerate:48000;",
     "ready;",
+    "start;",
 ]
 
 
@@ -1463,7 +1502,7 @@ Expected output:
 
 ```
 online: True
-modes: ['AM', 'SAM', 'DSB', 'LSB', 'USB', 'CW', 'FM', 'DIGI-L', 'DIGI-U', 'WFM', 'DRM']
+modes: ['USB', 'LSB', 'CW', 'CWR', 'AM', 'SAM', 'FM', 'NFM', 'DIGI-U', 'DIGI-L', 'RTTY']
 vfo: 14030000
 mode: CW
 bw: 1000

--- a/docs/superpowers/plans/2026-08-01-tci-support.md
+++ b/docs/superpowers/plans/2026-08-01-tci-support.md
@@ -1,0 +1,1579 @@
+# TCI CAT Backend Implementation Plan (Phase 1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add TCI as a fourth CAT backend in not1mm so AetherSDR can be used as the rig, covering frequency/mode/bandwidth sync, PTT, and CW keying.
+
+**Architecture:** TCI is asynchronous and push-based; not1mm's `CAT` contract is synchronous and poll-based. A `TCIClient` runs a `QWebSocket` on its own `QThread` with a real event loop and maintains a mutex-guarded cache of last-known radio state. `TciCAT` subclasses `CAT` and serves getters from that cache, so `Radio.run()`'s existing 555 ms poll loop works unmodified.
+
+**Tech Stack:** Python 3.11+, PyQt6 (`QtWebSockets`, `QtCore`), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-08-01-tci-support-design.md`
+
+**Branch:** `add-tci-support` (already created; the spec commit is `411fcfc9`)
+
+## Global Constraints
+
+- **No new runtime dependencies.** `PyQt6.QtWebSockets` is already available. Do not add anything to `pyproject.toml`, `requirements.txt`, or `python3-modules.yaml`.
+- **Do not modify** `cat_flrig.py`, `cat_rigctld.py`, or `cat_fake.py`. Their behavior is the reference, not the target.
+- **`get_vfo()` must return bare digits.** `not1mm/radio.py:84` discards any value failing `.isnumeric()`.
+- **Mode names normalize to not1mm's uppercase convention.** `not1mm/radio.py:36-42` matches `cw_list`/`rtty_list` against `get_mode_list()` by exact string.
+- **When offline, getters return `""` — never stale cache.** `not1mm/radio.py:83-97` only overwrites on a truthy result, so `""` makes the UI hold last values and report `online: False`.
+- **TRX index 0, channel 0 (VFO A) only.** Multi-receiver and VFO B are out of scope.
+- Module docstrings follow the existing house style (author line + `GPL V3`), and every module keeps the `if __name__ == "__main__": print("I'm not the program you are looking for.")` guard used by the other `lib/` modules.
+- Test files live in `test/` and follow the existing `<subject>_tests.py` naming (see `test/plugin_wag_tests.py`).
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `not1mm/lib/tci_protocol.py` | **Create.** Pure functions: frame parse/split, command build, mode translation, bandwidth math. No Qt, no sockets. |
+| `not1mm/lib/tci_client.py` | **Create.** `TCIClient` — `QWebSocket` on its own `QThread`, state cache, reconnect backoff, shutdown. |
+| `not1mm/lib/cat_tci.py` | **Create.** `TciCAT(CAT)` — maps the CAT contract onto the client. |
+| `not1mm/testing/faketci.py` | **Create.** Minimal TCI server for testing without AetherSDR. |
+| `not1mm/radio.py` | **Modify.** Dispatch `"tci"`; close the CAT object on loop exit. |
+| `not1mm/__main__.py:3835` | **Modify.** `usetci` branch. |
+| `not1mm/lib/preferences.py:57` | **Modify.** `"usetci": False` default. |
+| `not1mm/lib/settings.py:32-34,126,304` | **Modify.** Port hint, load, save. |
+| `not1mm/data/configuration.ui:560` | **Modify.** `usetci_radioButton` in `cat_method_group`. |
+| `test/tci_protocol_tests.py` | **Create.** Unit tests for the pure layer. |
+| `test/tci_client_tests.py` | **Create.** State-cache tests driving `handle_frame` directly. |
+| `test/cat_tci_tests.py` | **Create.** CAT contract tests against a stub client. |
+
+The three-way split is deliberate: the pure protocol layer holds the fiddly string handling and is the highest-value thing to test, and it stays testable without Qt or a socket.
+
+---
+
+### Task 1: Dev environment and AetherSDR handshake capture
+
+The spec requires pinning command signatures to what AetherSDR actually speaks rather than assuming. This task produces that evidence. It also establishes the venv every later task's tests need — the system Python has no pytest.
+
+**Files:**
+- Create: `not1mm/testing/tci_probe.py`
+- Create: `docs/superpowers/specs/2026-08-01-tci-handshake.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a recorded handshake transcript. Later tasks read it to confirm/correct the `cw_msg` argument signature and the `modulation_list` contents.
+
+- [ ] **Step 1: Create the dev virtualenv**
+
+```bash
+cd /Users/stephaneblanchard/dev/not1mm
+uv venv
+uv pip install -e . pytest
+```
+
+- [ ] **Step 2: Verify pytest runs**
+
+Run: `.venv/bin/python -m pytest test/ -q`
+Expected: the existing suite collects and passes (`test/plugin_wag_tests.py`, `test/plugin_euhfc_tests.py`).
+
+- [ ] **Step 3: Write the probe script**
+
+Create `not1mm/testing/tci_probe.py`:
+
+```python
+"""
+Connect to a TCI server and dump every frame it sends, verbatim.
+
+Used to pin not1mm's TCI command mapping to what the server actually speaks,
+rather than to what the protocol docs claim. Not part of the application.
+
+Usage: python -m not1mm.testing.tci_probe [host] [port]
+"""
+
+import sys
+
+from PyQt6.QtCore import QCoreApplication, QTimer, QUrl
+from PyQt6.QtWebSockets import QWebSocket
+
+
+def main() -> None:
+    host = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else 40001
+
+    app = QCoreApplication([])
+    socket = QWebSocket()
+
+    def on_connected() -> None:
+        print(f"--- connected to ws://{host}:{port} ---", flush=True)
+
+    def on_text(payload: str) -> None:
+        print(payload, flush=True)
+
+    def on_error(error) -> None:
+        print(f"--- error: {error} ---", flush=True)
+        app.quit()
+
+    socket.connected.connect(on_connected)
+    socket.textMessageReceived.connect(on_text)
+    socket.errorOccurred.connect(on_error)
+    socket.open(QUrl(f"ws://{host}:{port}"))
+
+    # Capture the handshake plus a window for manual dial/mode/PTT changes.
+    QTimer.singleShot(60000, app.quit)
+    app.exec()
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Capture the handshake against live AetherSDR**
+
+Start AetherSDR with TCI enabled, then:
+
+```bash
+.venv/bin/python -m not1mm.testing.tci_probe 127.0.0.1 40001 | tee /tmp/tci-handshake.txt
+```
+
+While it runs, exercise the radio manually: turn the VFO dial, change mode to CW and back, change the filter width, and key/unkey PTT. This makes the server emit every frame the backend needs to parse.
+
+- [ ] **Step 5: Record the findings**
+
+Create `docs/superpowers/specs/2026-08-01-tci-handshake.md` containing the verbatim transcript and, extracted from it, these specific answers:
+
+1. The `protocol:` / `device:` lines (TCI version AetherSDR speaks)
+2. The full `modulation_list:` contents — the exact lowercase mode names
+3. The observed argument order for `vfo:`, `modulation:`, `rx_filter_band:`, `trx:`
+4. Whether `cw_msg:` is accepted, and its argument count and order
+5. Whether `ready;` terminates the handshake
+
+**If any of these differ from the spec's mapping table, note the difference explicitly** — Tasks 2-4 must be built against the recorded reality, not the spec's assumption.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add not1mm/testing/tci_probe.py docs/superpowers/specs/2026-08-01-tci-handshake.md
+git commit -m "test: add TCI probe script and record AetherSDR handshake"
+```
+
+---
+
+### Task 2: Pure protocol layer
+
+**Files:**
+- Create: `not1mm/lib/tci_protocol.py`
+- Test: `test/tci_protocol_tests.py`
+
+**Interfaces:**
+- Consumes: the mode names recorded in Task 1 Step 5.
+- Produces:
+  - `parse_frame(frame: str) -> tuple[str, list[str]] | None`
+  - `split_frames(payload: str) -> list[str]`
+  - `build_command(name: str, *args) -> str`
+  - `tci_mode_to_not1mm(mode: str) -> str`
+  - `not1mm_mode_to_tci(mode: str) -> str`
+  - `bandwidth_from_filter_band(low: str, high: str) -> str`
+  - `TCI_TO_NOT1MM_MODE: dict[str, str]`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/tci_protocol_tests.py`:
+
+```python
+import pytest
+
+from not1mm.lib.tci_protocol import (
+    bandwidth_from_filter_band,
+    build_command,
+    not1mm_mode_to_tci,
+    parse_frame,
+    split_frames,
+    tci_mode_to_not1mm,
+)
+
+
+@pytest.mark.parametrize(
+    "frame, expected",
+    [
+        ("vfo:0,0,14030000;", ("vfo", ["0", "0", "14030000"])),
+        ("ready;", ("ready", [])),
+        ("trx:0,true;", ("trx", ["0", "true"])),
+        ("rx_filter_band:0,-500,500;", ("rx_filter_band", ["0", "-500", "500"])),
+        ("  vfo:0,0,14030000;  ", ("vfo", ["0", "0", "14030000"])),
+        ("VFO:0,0,14030000;", ("vfo", ["0", "0", "14030000"])),
+        ("vfo:0,0,14030000", None),  # no terminator
+        (";", None),
+        ("", None),
+        (":1,2;", None),  # empty command name
+    ],
+)
+def test_parse_frame(frame, expected):
+    assert parse_frame(frame) == expected
+
+
+def test_split_frames_handles_multiple_commands_in_one_payload():
+    payload = "device:AetherSDR;trx_count:1;ready;"
+    assert split_frames(payload) == ["device:AetherSDR;", "trx_count:1;", "ready;"]
+
+
+def test_split_frames_ignores_trailing_whitespace_fragment():
+    assert split_frames("ready;\n") == ["ready;"]
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        (("vfo", 0, 0, 14030000), "vfo:0,0,14030000;"),
+        (("modulation", 0, "cw"), "modulation:0,cw;"),
+        (("trx", 0, "true"), "trx:0,true;"),
+        (("cw_macros_speed", 25), "cw_macros_speed:25;"),
+        (("stop",), "stop;"),
+    ],
+)
+def test_build_command(args, expected):
+    assert build_command(*args) == expected
+
+
+def test_build_command_roundtrips_through_parse_frame():
+    assert parse_frame(build_command("vfo", 0, 0, 14030000)) == (
+        "vfo",
+        ["0", "0", "14030000"],
+    )
+
+
+@pytest.mark.parametrize(
+    "tci, not1mm",
+    [
+        ("cw", "CW"),
+        ("lsb", "LSB"),
+        ("usb", "USB"),
+        ("digl", "DIGI-L"),
+        ("digu", "DIGI-U"),
+        ("nfm", "FM"),
+        ("CW", "CW"),  # case insensitive
+    ],
+)
+def test_tci_mode_to_not1mm(tci, not1mm):
+    assert tci_mode_to_not1mm(tci) == not1mm
+
+
+def test_tci_mode_to_not1mm_passes_through_unknown_modes_uppercased():
+    assert tci_mode_to_not1mm("someNewMode") == "SOMENEWMODE"
+
+
+@pytest.mark.parametrize(
+    "not1mm, tci",
+    [
+        ("CW", "cw"),
+        ("USB", "usb"),
+        ("DIGI-L", "digl"),
+        ("RTTY", "digl"),
+        ("RTTY-R", "digu"),
+        ("FM", "nfm"),
+    ],
+)
+def test_not1mm_mode_to_tci(not1mm, tci):
+    assert not1mm_mode_to_tci(not1mm) == tci
+
+
+def test_mode_translation_roundtrips_for_every_known_tci_mode():
+    from not1mm.lib.tci_protocol import TCI_TO_NOT1MM_MODE
+
+    for tci in TCI_TO_NOT1MM_MODE:
+        assert not1mm_mode_to_tci(tci_mode_to_not1mm(tci)) == tci
+
+
+def test_cw_and_data_modes_match_radio_module_expectations():
+    """Radio matches get_mode_list() against these lists by exact string."""
+    from not1mm.radio import Radio
+
+    assert tci_mode_to_not1mm("cw") in Radio.cw_list
+    assert tci_mode_to_not1mm("digl") in Radio.rtty_list
+
+
+@pytest.mark.parametrize(
+    "low, high, expected",
+    [
+        ("-500", "500", "1000"),
+        ("300", "2700", "2400"),
+        ("500", "-500", "1000"),  # order independent
+        ("0", "0", "0"),
+        ("junk", "500", ""),
+        ("", "", ""),
+    ],
+)
+def test_bandwidth_from_filter_band(low, high, expected):
+    assert bandwidth_from_filter_band(low, high) == expected
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest test/tci_protocol_tests.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'not1mm.lib.tci_protocol'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `not1mm/lib/tci_protocol.py`:
+
+```python
+"""
+TCI protocol helpers: frame parsing, command building, mode translation.
+Email: michael.bridak@gmail.com
+GPL V3
+
+Pure functions only -- no sockets, no Qt, no not1mm state. The fiddly string
+handling lives here so it stays testable without a running SDR.
+"""
+
+import logging
+
+if __name__ == "__main__":
+    print("I'm not the program you are looking for.")
+
+logger = logging.getLogger("tci_protocol")
+
+# TCI modulation names are lowercase and do not match not1mm's conventions.
+# Radio.cw_list / Radio.rtty_list (not1mm/radio.py:36-42) match the output of
+# get_mode_list() by exact string, so everything is normalized to not1mm's
+# uppercase names on the way in.
+TCI_TO_NOT1MM_MODE = {
+    "cw": "CW",
+    "lsb": "LSB",
+    "usb": "USB",
+    "dsb": "DSB",
+    "am": "AM",
+    "sam": "SAM",
+    "nfm": "FM",
+    "wfm": "WFM",
+    "digl": "DIGI-L",
+    "digu": "DIGI-U",
+    "drm": "DRM",
+}
+
+NOT1MM_TO_TCI_MODE = {v: k for k, v in TCI_TO_NOT1MM_MODE.items()}
+# not1mm uses RTTY as its generic data mode; TCI has no RTTY, so it lands on
+# the digital sidebands. Without this, selecting RTTY would send "rtty" and the
+# SDR would reject it.
+NOT1MM_TO_TCI_MODE["RTTY"] = "digl"
+NOT1MM_TO_TCI_MODE["RTTY-R"] = "digu"
+
+
+def parse_frame(frame: str) -> tuple[str, list[str]] | None:
+    """Split one TCI frame into (command, args).
+
+    "vfo:0,0,14030000;" -> ("vfo", ["0", "0", "14030000"])
+    "ready;"            -> ("ready", [])
+
+    Returns None for anything malformed. TCI servers emit plenty of commands
+    not1mm does not care about, so callers drop None quietly rather than
+    treating it as an error.
+    """
+    frame = frame.strip()
+    if not frame.endswith(";"):
+        return None
+    body = frame[:-1].strip()
+    if not body:
+        return None
+    if ":" not in body:
+        return body.lower(), []
+    name, _, argstr = body.partition(":")
+    name = name.strip().lower()
+    if not name:
+        return None
+    args = [a.strip() for a in argstr.split(",")] if argstr.strip() else []
+    return name, args
+
+
+def split_frames(payload: str) -> list[str]:
+    """Split a websocket text payload into individual ';'-terminated frames.
+
+    One payload may carry several commands, which is normal during the connect
+    handshake.
+    """
+    return [chunk + ";" for chunk in payload.split(";") if chunk.strip()]
+
+
+def build_command(name: str, *args) -> str:
+    """Build a TCI command frame.
+
+    build_command("vfo", 0, 0, 14030000) -> "vfo:0,0,14030000;"
+    build_command("stop")                -> "stop;"
+    """
+    if not args:
+        return f"{name};"
+    return f"{name}:{','.join(str(a) for a in args)};"
+
+
+def tci_mode_to_not1mm(mode: str) -> str:
+    """Normalize a TCI modulation name to not1mm's convention."""
+    cleaned = mode.strip()
+    return TCI_TO_NOT1MM_MODE.get(cleaned.lower(), cleaned.upper())
+
+
+def not1mm_mode_to_tci(mode: str) -> str:
+    """Translate a not1mm mode name to TCI's convention."""
+    cleaned = mode.strip()
+    return NOT1MM_TO_TCI_MODE.get(cleaned.upper(), cleaned.lower())
+
+
+def bandwidth_from_filter_band(low: str, high: str) -> str:
+    """Derive filter width in Hz from an rx_filter_band edge pair.
+
+    Returns "" when unparseable, which the caller treats as "no update".
+    """
+    try:
+        return str(abs(int(high) - int(low)))
+    except (TypeError, ValueError):
+        return ""
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest test/tci_protocol_tests.py -v`
+Expected: PASS, all cases.
+
+- [ ] **Step 5: Reconcile with the recorded handshake**
+
+Open `docs/superpowers/specs/2026-08-01-tci-handshake.md` from Task 1. Compare the recorded `modulation_list:` names against `TCI_TO_NOT1MM_MODE`. Add any AetherSDR mode not in the table and add a test case for it. Remove nothing — unknown modes already pass through uppercased.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add not1mm/lib/tci_protocol.py test/tci_protocol_tests.py
+git commit -m "feat: add TCI protocol parsing and mode translation"
+```
+
+---
+
+### Task 3: TCIClient websocket transport
+
+**Files:**
+- Create: `not1mm/lib/tci_client.py`
+- Test: `test/tci_client_tests.py`
+
+**Interfaces:**
+- Consumes: `parse_frame`, `split_frames`, `tci_mode_to_not1mm`, `bandwidth_from_filter_band` from Task 2.
+- Produces: `TCIClient(host: str, port: int, autostart: bool = True)` with:
+  - `get(key: str, default="") -> str | list` — thread-safe cache read
+  - `online -> bool` property (True only after `ready;`)
+  - `send(command: str) -> None` — thread-safe, queues onto the TCI thread
+  - `handle_frame(name: str, args: list) -> None` — pure cache update, socket-free, public for tests
+  - `wait_for_ready(timeout_ms: int) -> bool`
+  - `close() -> None`
+  - State keys: `"vfo"`, `"mode"`, `"bw"`, `"ptt"`, `"modes"`, `"ready"`
+
+- [ ] **Step 1: Write the failing tests**
+
+`handle_frame` is deliberately socket-free so the cache logic is testable without a server. Create `test/tci_client_tests.py`:
+
+```python
+import pytest
+
+from not1mm.lib.tci_client import TCIClient
+
+
+@pytest.fixture
+def client():
+    """A client whose thread never starts, so only the cache logic is exercised.
+
+    autostart=False rather than bypassing __init__: TCIClient is a QObject, and
+    building one via __new__ leaves the C++ side uninitialized, which PyQt6
+    rejects with "'__init__' method of object's base class not called".
+    """
+    return TCIClient("127.0.0.1", 40001, autostart=False)
+
+
+def test_starts_offline_with_empty_state(client):
+    assert client.online is False
+    assert client.get("vfo") == ""
+    assert client.get("mode") == ""
+    assert client.get("modes") == []
+
+
+def test_ready_frame_brings_client_online(client):
+    client.handle_frame("ready", [])
+    assert client.online is True
+
+
+def test_vfo_frame_updates_cache(client):
+    client.handle_frame("vfo", ["0", "0", "14030000"])
+    assert client.get("vfo") == "14030000"
+
+
+def test_vfo_value_is_numeric_for_radio_module(client):
+    client.handle_frame("vfo", ["0", "0", "14030000"])
+    assert client.get("vfo").isnumeric()
+
+
+def test_non_numeric_vfo_is_rejected(client):
+    client.handle_frame("vfo", ["0", "0", "14.030"])
+    assert client.get("vfo") == ""
+
+
+def test_vfo_for_other_trx_is_ignored(client):
+    client.handle_frame("vfo", ["1", "0", "14030000"])
+    assert client.get("vfo") == ""
+
+
+def test_vfo_for_channel_b_is_ignored(client):
+    client.handle_frame("vfo", ["0", "1", "7020000"])
+    assert client.get("vfo") == ""
+
+
+def test_modulation_frame_is_normalized(client):
+    client.handle_frame("modulation", ["0", "cw"])
+    assert client.get("mode") == "CW"
+
+
+def test_rx_filter_band_becomes_bandwidth(client):
+    client.handle_frame("rx_filter_band", ["0", "-500", "500"])
+    assert client.get("bw") == "1000"
+
+
+def test_unparseable_filter_band_leaves_bandwidth_untouched(client):
+    client.handle_frame("rx_filter_band", ["0", "-500", "500"])
+    client.handle_frame("rx_filter_band", ["0", "junk", "500"])
+    assert client.get("bw") == "1000"
+
+
+@pytest.mark.parametrize("value, expected", [("true", "1"), ("false", "0"), ("TRUE", "1")])
+def test_trx_frame_sets_ptt(client, value, expected):
+    client.handle_frame("trx", ["0", value])
+    assert client.get("ptt") == expected
+
+
+def test_modulation_list_is_normalized(client):
+    client.handle_frame("modulation_list", ["cw", "lsb", "usb", "digl"])
+    assert client.get("modes") == ["CW", "LSB", "USB", "DIGI-L"]
+
+
+def test_unknown_frames_are_ignored_without_raising(client):
+    client.handle_frame("iq_samplerate", ["48000"])
+    client.handle_frame("audio_start", [])
+    assert client.get("vfo") == ""
+
+
+def test_clear_state_drops_everything_including_ready(client):
+    client.handle_frame("ready", [])
+    client.handle_frame("vfo", ["0", "0", "14030000"])
+    client.clear_state()
+    assert client.online is False
+    assert client.get("vfo") == ""
+
+
+def test_clear_state_preserves_mode_list(client):
+    """Supported modes are a device property, not volatile state."""
+    client.handle_frame("modulation_list", ["cw", "usb"])
+    client.clear_state()
+    assert client.get("modes") == ["CW", "USB"]
+
+
+def test_get_modes_returns_a_copy(client):
+    client.handle_frame("modulation_list", ["cw"])
+    client.get("modes").append("BOGUS")
+    assert client.get("modes") == ["CW"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest test/tci_client_tests.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'not1mm.lib.tci_client'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `not1mm/lib/tci_client.py`:
+
+```python
+"""
+K6GTE, TCI websocket transport
+Email: michael.bridak@gmail.com
+GPL V3
+
+Owns a QWebSocket on its own QThread running a real event loop, so socket
+signals are actually delivered -- Radio.run() blocks in a while loop and never
+returns to an event loop, so the socket cannot live there.
+
+TCI pushes state changes unprompted. This class caches them behind a mutex and
+the CAT layer reads the cache instead of querying.
+"""
+
+import logging
+
+from PyQt6.QtCore import (
+    QMetaObject,
+    QMutex,
+    QMutexLocker,
+    QObject,
+    Qt,
+    QThread,
+    QTimer,
+    QUrl,
+    pyqtSignal,
+    pyqtSlot,
+)
+from PyQt6.QtWebSockets import QWebSocket
+
+from not1mm.lib.tci_protocol import (
+    bandwidth_from_filter_band,
+    parse_frame,
+    split_frames,
+    tci_mode_to_not1mm,
+)
+
+if __name__ == "__main__":
+    print("I'm not the program you are looking for.")
+
+logger = logging.getLogger("tci_client")
+
+RECONNECT_BACKOFF_MS = (1000, 2000, 5000)
+
+
+class TCIClient(QObject):
+    """Websocket transport and state cache for a TCI server."""
+
+    send_requested = pyqtSignal(str)
+
+    def __init__(self, host: str, port: int, autostart: bool = True) -> None:
+        super().__init__()
+        self.host = host
+        self.port = port
+        self.init_state()
+        self.thread = QThread()
+        # autostart=False gives tests a cache-only instance with no thread and
+        # no socket, while still constructing the QObject properly.
+        if autostart:
+            self.moveToThread(self.thread)
+            self.thread.started.connect(self.open_socket)
+            self.send_requested.connect(self.write_command)
+            self.thread.start()
+
+    def init_state(self) -> None:
+        """Set up the cache."""
+        self.socket = None
+        self.reconnect_timer = None
+        self.backoff = 0
+        self.closing = False
+        self.mutex = QMutex()
+        self.state = {
+            "vfo": "",
+            "mode": "",
+            "bw": "",
+            "ptt": "0",
+            "modes": [],
+            "ready": False,
+        }
+
+    # ---- cache access: safe to call from any thread ----
+
+    def get(self, key: str, default=""):
+        with QMutexLocker(self.mutex):
+            value = self.state.get(key, default)
+            if isinstance(value, list):
+                return list(value)  # copy, so callers cannot mutate the cache
+            return value
+
+    def set(self, key: str, value) -> None:
+        with QMutexLocker(self.mutex):
+            self.state[key] = value
+
+    @property
+    def online(self) -> bool:
+        """True only once the server has finished its handshake."""
+        return bool(self.get("ready", False))
+
+    def clear_state(self) -> None:
+        """Drop volatile state on disconnect. The mode list survives: it is a
+        device capability, not live state, and re-querying it costs a round
+        trip we do not need."""
+        with QMutexLocker(self.mutex):
+            self.state.update(
+                {"vfo": "", "mode": "", "bw": "", "ptt": "0", "ready": False}
+            )
+
+    def send(self, command: str) -> None:
+        """Queue a command onto the TCI thread. Safe from any thread -- the
+        signal crosses threads as a queued connection."""
+        self.send_requested.emit(command)
+
+    def wait_for_ready(self, timeout_ms: int) -> bool:
+        """Block until the handshake completes or the timeout expires.
+
+        Called once at construction so get_mode_list() has data before
+        Radio.__init__ reads it.
+        """
+        waited = 0
+        while waited < timeout_ms:
+            if self.online:
+                return True
+            QThread.msleep(50)
+            waited += 50
+        return self.online
+
+    # ---- frame handling: no socket calls, so tests drive it directly ----
+
+    def handle_frame(self, name: str, args: list) -> None:
+        """Update the cache from one parsed frame."""
+        if name == "ready":
+            logger.debug("TCI handshake complete")
+            self.set("ready", True)
+        elif name == "vfo" and len(args) >= 3 and args[0] == "0" and args[1] == "0":
+            if args[2].isnumeric():  # Radio rejects non-numeric VFO values
+                self.set("vfo", args[2])
+        elif name == "modulation" and len(args) >= 2 and args[0] == "0":
+            self.set("mode", tci_mode_to_not1mm(args[1]))
+        elif name == "rx_filter_band" and len(args) >= 3 and args[0] == "0":
+            bandwidth = bandwidth_from_filter_band(args[1], args[2])
+            if bandwidth:
+                self.set("bw", bandwidth)
+        elif name == "trx" and len(args) >= 2 and args[0] == "0":
+            self.set("ptt", "1" if args[1].strip().lower() == "true" else "0")
+        elif name == "modulation_list":
+            self.set("modes", [tci_mode_to_not1mm(m) for m in args if m])
+        else:
+            logger.debug("Ignoring TCI frame: %s %s", name, args)
+
+    # ---- everything below runs on the TCI thread ----
+
+    @pyqtSlot()
+    def open_socket(self) -> None:
+        """Build the socket. Runs on the TCI thread so the socket's parent
+        affinity is correct."""
+        self.socket = QWebSocket()
+        self.socket.connected.connect(self.on_connected)
+        self.socket.disconnected.connect(self.on_disconnected)
+        self.socket.textMessageReceived.connect(self.on_text_message)
+        self.socket.errorOccurred.connect(self.on_error)
+        self.reconnect_timer = QTimer()
+        self.reconnect_timer.setSingleShot(True)
+        self.reconnect_timer.timeout.connect(self.connect_to_server)
+        self.connect_to_server()
+
+    @pyqtSlot()
+    def connect_to_server(self) -> None:
+        if self.closing:
+            return
+        url = f"ws://{self.host}:{self.port}"
+        logger.debug("Connecting to TCI %s", url)
+        self.socket.open(QUrl(url))
+
+    @pyqtSlot()
+    def on_connected(self) -> None:
+        logger.debug("TCI socket open, awaiting handshake")
+        self.backoff = 0
+
+    @pyqtSlot()
+    def on_disconnected(self) -> None:
+        logger.info("TCI socket disconnected")
+        self.clear_state()
+        self.schedule_reconnect()
+
+    def on_error(self, error) -> None:
+        logger.info("TCI socket error: %s", error)
+        self.clear_state()
+        self.schedule_reconnect()
+
+    def schedule_reconnect(self) -> None:
+        if self.closing or self.reconnect_timer is None:
+            return
+        delay = RECONNECT_BACKOFF_MS[min(self.backoff, len(RECONNECT_BACKOFF_MS) - 1)]
+        self.backoff += 1
+        if not self.reconnect_timer.isActive():
+            logger.debug("Reconnecting to TCI in %d ms", delay)
+            self.reconnect_timer.start(delay)
+
+    @pyqtSlot(str)
+    def write_command(self, command: str) -> None:
+        if self.socket is None or not self.online:
+            return
+        logger.debug("> %s", command)
+        self.socket.sendTextMessage(command)
+
+    @pyqtSlot(str)
+    def on_text_message(self, payload: str) -> None:
+        for frame in split_frames(payload):
+            parsed = parse_frame(frame)
+            if parsed is None:
+                logger.debug("Unparseable TCI frame: %s", frame)
+                continue
+            self.handle_frame(*parsed)
+
+    def close(self) -> None:
+        """Stop the socket and its thread. Must run before app exit or the
+        process hangs on a live thread."""
+        self.closing = True
+        if self.thread.isRunning():
+            QMetaObject.invokeMethod(
+                self, "shutdown", Qt.ConnectionType.BlockingQueuedConnection
+            )
+            self.thread.quit()
+            self.thread.wait(500)
+
+    @pyqtSlot()
+    def shutdown(self) -> None:
+        if self.reconnect_timer is not None:
+            self.reconnect_timer.stop()
+        if self.socket is not None:
+            self.socket.close()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest test/tci_client_tests.py -v`
+Expected: PASS, all cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add not1mm/lib/tci_client.py test/tci_client_tests.py
+git commit -m "feat: add TCI websocket client with state cache"
+```
+
+---
+
+### Task 4: TciCAT backend
+
+**Files:**
+- Create: `not1mm/lib/cat_tci.py`
+- Test: `test/cat_tci_tests.py`
+
+**Interfaces:**
+- Consumes: `TCIClient` (Task 3), `build_command` and `not1mm_mode_to_tci` (Task 2), `CAT` base (`not1mm/lib/cat_interface.py:15`).
+- Produces: `TciCAT(host: str, port: int)` implementing the CAT contract, plus `close()`. Task 5 constructs it from `radio.py`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/cat_tci_tests.py`:
+
+```python
+import pytest
+
+from not1mm.lib.cat_tci import TciCAT
+
+
+class StubClient:
+    """Stands in for TCIClient: no thread, no socket, records what was sent."""
+
+    def __init__(self):
+        self.sent = []
+        self.state = {
+            "vfo": "",
+            "mode": "",
+            "bw": "",
+            "ptt": "0",
+            "modes": [],
+            "ready": False,
+        }
+
+    @property
+    def online(self):
+        return bool(self.state["ready"])
+
+    def get(self, key, default=""):
+        value = self.state.get(key, default)
+        return list(value) if isinstance(value, list) else value
+
+    def send(self, command):
+        self.sent.append(command)
+
+    def wait_for_ready(self, timeout_ms):
+        return self.online
+
+    def close(self):
+        self.state["ready"] = False
+
+
+@pytest.fixture
+def cat():
+    """A TciCAT wired to a stub, bypassing __init__'s real client."""
+    instance = TciCAT.__new__(TciCAT)
+    instance.interface = "tci"
+    instance.host = "127.0.0.1"
+    instance.port = 40001
+    instance.online = False
+    instance.client = StubClient()
+    return instance
+
+
+def go_online(cat, **state):
+    cat.client.state["ready"] = True
+    cat.client.state.update(state)
+
+
+# ---- offline behavior: the contract that keeps stale data off the screen ----
+
+
+@pytest.mark.parametrize("getter", ["get_vfo", "get_mode", "get_bw"])
+def test_getters_return_empty_when_offline(cat, getter):
+    assert getattr(cat, getter)() == ""
+
+
+def test_getters_return_empty_even_when_cache_holds_stale_values(cat):
+    """Radio only overwrites on truthy results, so empty means 'hold last
+    known' rather than painting a frozen frequency as live."""
+    cat.client.state.update({"vfo": "14030000", "mode": "CW", "bw": "500"})
+    assert cat.get_vfo() == ""
+    assert cat.get_mode() == ""
+    assert cat.get_bw() == ""
+
+
+def test_online_flag_tracks_the_client(cat):
+    cat.get_vfo()
+    assert cat.online is False
+    go_online(cat)
+    cat.get_vfo()
+    assert cat.online is True
+
+
+def test_setters_send_nothing_when_offline(cat):
+    cat.set_vfo("14030000")
+    cat.set_mode("CW")
+    cat.ptt_on()
+    assert cat.client.sent == []
+
+
+# ---- online behavior ----
+
+
+def test_get_vfo_returns_cached_numeric_value(cat):
+    go_online(cat, vfo="14030000")
+    assert cat.get_vfo() == "14030000"
+    assert cat.get_vfo().isnumeric()
+
+
+def test_get_mode_returns_cached_value(cat):
+    go_online(cat, mode="CW")
+    assert cat.get_mode() == "CW"
+
+
+def test_get_bw_returns_cached_value(cat):
+    go_online(cat, bw="1000")
+    assert cat.get_bw() == "1000"
+
+
+def test_get_ptt_returns_zero_when_offline(cat):
+    assert cat.get_ptt() == "0"
+
+
+def test_get_mode_list_available_regardless_of_online_state(cat):
+    cat.client.state["modes"] = ["CW", "USB"]
+    assert cat.get_mode_list() == ["CW", "USB"]
+
+
+def test_set_vfo_sends_tci_command(cat):
+    go_online(cat)
+    assert cat.set_vfo("14030000") is True
+    assert cat.client.sent == ["vfo:0,0,14030000;"]
+
+
+def test_set_mode_translates_to_tci_naming(cat):
+    go_online(cat)
+    cat.set_mode("CW")
+    cat.set_mode("RTTY")
+    assert cat.client.sent == ["modulation:0,cw;", "modulation:0,digl;"]
+
+
+def test_ptt_on_and_off(cat):
+    go_online(cat)
+    cat.ptt_on()
+    cat.ptt_off()
+    assert cat.client.sent == ["trx:0,true;", "trx:0,false;"]
+
+
+def test_set_cw_speed_sends_macros_speed(cat):
+    go_online(cat)
+    cat.set_cw_speed(25)
+    assert cat.client.sent == ["cw_macros_speed:25;"]
+
+
+def test_sendcw_sends_text(cat):
+    go_online(cat)
+    cat.sendcw("CQ TEST")
+    assert cat.client.sent == ["cw_msg:0,,,CQ TEST;"]
+
+
+def test_close_delegates_to_client(cat):
+    go_online(cat)
+    cat.close()
+    assert cat.client.online is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest test/cat_tci_tests.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'not1mm.lib.cat_tci'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `not1mm/lib/cat_tci.py`:
+
+```python
+"""
+K6GTE, CAT interface abstraction
+Email: michael.bridak@gmail.com
+GPL V3
+
+TCI backend, for SDRs such as AetherSDR and ExpertSDR.
+
+Unlike flrig and rigctld, nothing here queries the radio. TCI pushes state
+changes and TCIClient caches them, so the getters are cache reads: instant,
+non-blocking, and fresher than a poll would be.
+"""
+
+import logging
+
+from not1mm.lib.cat_interface import CAT
+from not1mm.lib.tci_client import TCIClient
+from not1mm.lib.tci_protocol import build_command, not1mm_mode_to_tci
+
+if __name__ == "__main__":
+    print("I'm not the program you are looking for.")
+
+logger = logging.getLogger("cat_tci")
+
+# Long enough for a local SDR's handshake, short enough not to stall startup.
+READY_TIMEOUT_MS = 1500
+
+
+class TciCAT(CAT):
+    """CAT control via the TCI protocol"""
+
+    def __init__(self, host: str, port: int) -> None:
+        """
+        Computer Aided Transceiver abstraction class.
+        Offers a normalized interface; this is the TCI class.
+
+        Takes 2 inputs to setup the class.
+
+        A string defining the host, example: 'localhost' or '127.0.0.1'
+
+        An integer defining the network port used. Commonly 40001 for TCI.
+
+        A variable 'online' is set to True once the TCI server completes its
+        handshake, otherwise False.
+        """
+        super().__init__(host, port)
+        self.interface = "tci"
+        self.client = TCIClient(host, port)
+        # Radio.__init__ reads get_mode_list() immediately, so give the
+        # handshake a moment to land before returning.
+        self.client.wait_for_ready(READY_TIMEOUT_MS)
+        self.online = self.client.online
+
+    def refresh_online(self) -> bool:
+        """Sync the public online flag with the transport and return it."""
+        self.online = self.client.online
+        return self.online
+
+    # ---- getters ----
+    # Offline returns "" rather than cached values: Radio only overwrites on a
+    # truthy result, so "" holds the last known reading and reports offline.
+    # Returning stale cache would paint a dead radio as live.
+
+    def get_vfo(self) -> str:
+        """Poll the radio for current vfo using the interface"""
+        if not self.refresh_online():
+            return ""
+        return self.client.get("vfo", "")
+
+    def get_mode(self) -> str:
+        """Returns the current mode of the radio"""
+        if not self.refresh_online():
+            return ""
+        return self.client.get("mode", "")
+
+    def get_bw(self) -> str:
+        """Get current vfo bandwidth"""
+        if not self.refresh_online():
+            return ""
+        return self.client.get("bw", "")
+
+    def get_ptt(self) -> str:
+        """Get PTT state"""
+        if not self.refresh_online():
+            return "0"
+        return self.client.get("ptt", "0")
+
+    def get_mode_list(self) -> list:
+        """Get a list of modes supported by the radio.
+
+        Served even while offline: it is a device capability captured at
+        handshake, and Radio caches it once at construction.
+        """
+        return self.client.get("modes", [])
+
+    # ---- setters ----
+
+    def set_vfo(self, freq: str) -> bool:
+        """Sets the radios VFO. Defaults to VFOA."""
+        if not self.refresh_online():
+            return False
+        self.client.send(build_command("vfo", 0, 0, str(freq)))
+        return True
+
+    def set_mode(self, mode: str) -> bool:
+        """Sets the radios mode"""
+        if not self.refresh_online():
+            return False
+        self.client.send(build_command("modulation", 0, not1mm_mode_to_tci(mode)))
+        return True
+
+    def ptt_on(self) -> bool:
+        """turn ptt on"""
+        if not self.refresh_online():
+            return False
+        self.client.send(build_command("trx", 0, "true"))
+        return True
+
+    def ptt_off(self) -> bool:
+        """turn ptt off"""
+        if not self.refresh_online():
+            return False
+        self.client.send(build_command("trx", 0, "false"))
+        return True
+
+    # ---- CW, reached via the existing "CW via CAT" option (cwtype == 3) ----
+
+    def sendcw(self, texttosend) -> None:
+        """Send CW text through the radio's keyer"""
+        if not self.refresh_online():
+            return
+        self.client.send(build_command("cw_msg", 0, "", "", texttosend))
+
+    def stopcw(self) -> None:
+        """Abort CW transmission"""
+        if not self.refresh_online():
+            return
+        self.client.send(build_command("cw_terminate"))
+
+    def set_cw_speed(self, speed: int) -> None:
+        """Set the CW speed in wpm"""
+        if not self.refresh_online():
+            return
+        self.client.send(build_command("cw_macros_speed", int(speed)))
+
+    def close(self) -> None:
+        """Shut down the transport thread. Radio.run() calls this on exit."""
+        self.client.close()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest test/cat_tci_tests.py -v`
+Expected: PASS, all cases.
+
+- [ ] **Step 5: Reconcile CW commands with the recorded handshake**
+
+Open `docs/superpowers/specs/2026-08-01-tci-handshake.md` from Task 1, item 4. If AetherSDR's `cw_msg:` takes a different argument count or order than `cw_msg:0,,,<text>;`, correct `sendcw` **and** `test_sendcw_sends_text` to match what was recorded. Same for `cw_terminate` — if the recorded transcript shows a different abort command, use that. Re-run the tests after any change.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add not1mm/lib/cat_tci.py test/cat_tci_tests.py
+git commit -m "feat: add TciCAT backend implementing the CAT contract over TCI"
+```
+
+---
+
+### Task 5: Wire TCI into the application
+
+**Files:**
+- Modify: `not1mm/radio.py:12-14` (import), `:56-61` (dispatch), `:75-109` (close on exit)
+- Modify: `not1mm/lib/preferences.py:57`
+- Modify: `not1mm/lib/settings.py:32-34`, `:126`, `:304`
+- Modify: `not1mm/data/configuration.ui:560`
+- Modify: `not1mm/__main__.py:3835`
+
+**Interfaces:**
+- Consumes: `TciCAT` from Task 4.
+- Produces: a running TCI backend selected by the `usetci` preference. No new public API.
+
+- [ ] **Step 1: Add the dispatch branch in radio.py**
+
+Add the import alongside the others at `not1mm/radio.py:12-14`:
+
+```python
+from not1mm.lib.cat_tci import TciCAT
+```
+
+Then extend the dispatch at `:56-61`:
+
+```python
+            if self.interface == "flrig":
+                self.cat = FlrigCAT(self.host, self.port)
+            elif self.interface == "rigctld":
+                self.cat = RigctldCAT(self.host, self.port)
+            elif self.interface == "tci":
+                self.cat = TciCAT(self.host, self.port)
+            else:
+                self.cat = FakeCAT(self.host, self.port)
+```
+
+- [ ] **Step 2: Close the CAT object when the poll loop exits**
+
+This is the fix for the shutdown hang. `TciCAT` owns a second `QThread`; without this, it outlives the app. Both teardown paths (`__main__.py:2563` on close and `:3813` on settings reload) set `time_to_quit`, so hooking the loop exit covers both and needs no `__main__.py` change.
+
+At the end of `Radio.run()` in `not1mm/radio.py`, after the `while` loop:
+
+```python
+    def run(self):
+        while not self.time_to_quit:
+            ...
+            QThread.msleep(100)
+        # Backends owning their own threads (TCI) must be torn down here, or
+        # the app hangs on exit. The others have no close() and no-op.
+        close = getattr(self.cat, "close", None)
+        if close is not None:
+            close()
+```
+
+The timing fits the existing budget: the loop wakes every 100 ms and `TCIClient.close()` waits at most 500 ms, well inside `radio_thread.wait(1000)`.
+
+- [ ] **Step 3: Add the preference default**
+
+In `not1mm/lib/preferences.py`, after line 58 (`"useflrig": False,`):
+
+```python
+        "usetci": False,
+```
+
+- [ ] **Step 4: Add the radio button to configuration.ui**
+
+In `not1mm/data/configuration.ui`, insert a new `<item>` between the `useflrig_radioButton` item ending at line 560 and the `radioButton` ("None") item starting at line 561. It must carry the `cat_method_group` buttonGroup attribute or it will not be mutually exclusive with the others:
+
+```xml
+         <item>
+          <widget class="QRadioButton" name="usetci_radioButton">
+           <property name="font">
+            <font>
+             <family>JetBrains Mono</family>
+             <weight>100</weight>
+             <pointsize>12</pointsize>
+             <strikeout>false</strikeout>
+            </font>
+           </property>
+           <property name="accessibleName">
+            <string>t c i</string>
+           </property>
+           <property name="accessibleDescription">
+            <string>use t c i</string>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="text">
+            <string>TCI</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">cat_method_group</string>
+           </attribute>
+          </widget>
+         </item>
+```
+
+Also add it to the tab order, after the `useflrig_radioButton` entry at line 2869:
+
+```xml
+  <tabstop>usetci_radioButton</tabstop>
+```
+
+- [ ] **Step 5: Load and save the preference in settings.py**
+
+Update the port hint at `not1mm/lib/settings.py:32-34`:
+
+```python
+        self.rigcontrolport_field.setToolTip(
+            "Usually 4532 for rigctld, 12345 for flrig, and 40001 for TCI."
+        )
+```
+
+Add the load line after `:127`:
+
+```python
+        self.usetci_radioButton.setChecked(bool(self.preference.get("usetci")))
+```
+
+Add the save line after `:305`:
+
+```python
+        self.preference["usetci"] = self.usetci_radioButton.isChecked()
+```
+
+- [ ] **Step 6: Add the branch in __main__.py**
+
+In `not1mm/__main__.py`, after the `userigctld` branch ending at line 3844 and before the `else:` at 3846:
+
+```python
+        elif self.pref.get("usetci", False) is True:
+            logger.debug(
+                "Using TCI: %s",
+                f"{self.pref.get('CAT_ip')} {self.pref.get('CAT_port')}",
+            )
+            self.rig_control = Radio(
+                "tci",
+                self.pref.get("CAT_ip", "127.0.0.1"),
+                int(self.pref.get("CAT_port", 40001)),
+            )
+```
+
+- [ ] **Step 7: Verify nothing regressed**
+
+Run: `.venv/bin/python -m pytest test/ -v`
+Expected: PASS — all tests including the three new files.
+
+Then confirm the UI file still parses and the new widget exists:
+
+```bash
+.venv/bin/python -c "
+import xml.etree.ElementTree as ET
+tree = ET.parse('not1mm/data/configuration.ui')
+names = [w.get('name') for w in tree.iter('widget')]
+assert 'usetci_radioButton' in names, 'radio button missing'
+print('configuration.ui OK')
+"
+```
+
+Expected: `configuration.ui OK`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add not1mm/radio.py not1mm/__main__.py not1mm/lib/preferences.py \
+        not1mm/lib/settings.py not1mm/data/configuration.ui
+git commit -m "feat: wire TCI backend into radio dispatch, settings, and UI"
+```
+
+---
+
+### Task 6: Fake TCI server for integration testing
+
+**Files:**
+- Create: `not1mm/testing/faketci.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (deliberately independent, so a bug here cannot be mistaken for a backend bug).
+- Produces: a runnable TCI server on a configurable port, following the `not1mm/testing/fakeflrig.py` precedent.
+
+- [ ] **Step 1: Write the fake server**
+
+Create `not1mm/testing/faketci.py`:
+
+```python
+"""
+A minimal TCI server, for exercising not1mm's TCI backend without an SDR.
+
+Sends a plausible handshake, then accepts and echoes state changes the way a
+real TCI server does. Deliberately shares no code with the client, so a bug
+here cannot masquerade as a backend bug.
+
+Usage: python -m not1mm.testing.faketci [port]
+"""
+
+import sys
+
+from PyQt6.QtCore import QCoreApplication, QTimer
+from PyQt6.QtWebSockets import QWebSocketServer
+
+HANDSHAKE = [
+    "protocol:ExpertSDR3,1.9;",
+    "device:FakeSDR;",
+    "trx_count:1;",
+    "modulation_list:am,sam,dsb,lsb,usb,cw,nfm,digl,digu,wfm,drm;",
+    "vfo:0,0,14030000;",
+    "modulation:0,cw;",
+    "rx_filter_band:0,-500,500;",
+    "trx:0,false;",
+    "ready;",
+]
+
+
+class FakeTCIServer:
+    def __init__(self, port: int) -> None:
+        self.clients = []
+        self.server = QWebSocketServer(
+            "FakeTCI", QWebSocketServer.SslMode.NonSecureMode
+        )
+        if not self.server.listen(port=port):
+            print(f"Failed to listen on {port}", flush=True)
+            raise SystemExit(1)
+        self.server.newConnection.connect(self.on_new_connection)
+        print(f"FakeTCI listening on ws://127.0.0.1:{port}", flush=True)
+
+    def on_new_connection(self) -> None:
+        socket = self.server.nextPendingConnection()
+        socket.textMessageReceived.connect(
+            lambda message: self.on_message(socket, message)
+        )
+        socket.disconnected.connect(lambda: self.on_disconnected(socket))
+        self.clients.append(socket)
+        print("client connected, sending handshake", flush=True)
+        for frame in HANDSHAKE:
+            socket.sendTextMessage(frame)
+
+    def on_message(self, socket, message: str) -> None:
+        print(f"< {message}", flush=True)
+        # A real TCI server echoes accepted state changes back to all clients.
+        for frame in [f + ";" for f in message.split(";") if f.strip()]:
+            for client in self.clients:
+                client.sendTextMessage(frame)
+
+    def on_disconnected(self, socket) -> None:
+        print("client disconnected", flush=True)
+        if socket in self.clients:
+            self.clients.remove(socket)
+        socket.deleteLater()
+
+
+def main() -> None:
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 40001
+    app = QCoreApplication([])
+    server = FakeTCIServer(port)
+    QTimer.singleShot(600000, app.quit)
+    app.exec()
+    del server
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Verify the fake server and backend talk to each other**
+
+In one terminal:
+
+```bash
+.venv/bin/python -m not1mm.testing.faketci 40001
+```
+
+In another:
+
+```bash
+.venv/bin/python -c "
+from PyQt6.QtCore import QCoreApplication, QThread
+from not1mm.lib.cat_tci import TciCAT
+
+app = QCoreApplication([])
+cat = TciCAT('127.0.0.1', 40001)
+print('online:', cat.online)
+print('modes:', cat.get_mode_list())
+print('vfo:', cat.get_vfo())
+print('mode:', cat.get_mode())
+print('bw:', cat.get_bw())
+cat.set_vfo('7020000')
+QThread.msleep(300)
+print('vfo after set:', cat.get_vfo())
+cat.close()
+"
+```
+
+Expected output:
+
+```
+online: True
+modes: ['AM', 'SAM', 'DSB', 'LSB', 'USB', 'CW', 'FM', 'DIGI-L', 'DIGI-U', 'WFM', 'DRM']
+vfo: 14030000
+mode: CW
+bw: 1000
+vfo after set: 7020000
+```
+
+The command must also exit cleanly rather than hanging — that confirms `close()` tears the thread down.
+
+- [ ] **Step 3: Verify offline behavior**
+
+With the fake server **stopped**, run the same snippet. Expected: `online: False`, and `vfo`, `mode`, `bw` all empty strings — never stale values. The process must still exit cleanly.
+
+- [ ] **Step 4: Verify reconnection**
+
+Start the fake server, run a longer-lived client, kill the server mid-run, then restart it:
+
+```bash
+.venv/bin/python -c "
+from PyQt6.QtCore import QCoreApplication, QThread
+from not1mm.lib.cat_tci import TciCAT
+
+app = QCoreApplication([])
+cat = TciCAT('127.0.0.1', 40001)
+for _ in range(30):
+    QThread.msleep(1000)
+    print('online:', cat.online, 'vfo:', repr(cat.get_vfo()), flush=True)
+cat.close()
+"
+```
+
+Expected: online `True` with a frequency, then `False` with `''` after the kill, then back to `True` with a frequency within ~5 s of the restart.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add not1mm/testing/faketci.py
+git commit -m "test: add fake TCI server for integration testing"
+```
+
+---
+
+### Task 7: Verify against live AetherSDR and document
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `Working_Contests.md` — **only if** it documents rig interfaces; check first, and skip this file if it does not.
+
+**Interfaces:**
+- Consumes: everything from Tasks 2-6.
+- Produces: nothing consumed by later tasks. This is the acceptance gate for phase 1.
+
+- [ ] **Step 1: Reinstall and launch against AetherSDR**
+
+```bash
+uv build
+uv tool install --force ./dist/not1mm-*-py3-none-any.whl
+```
+
+Start AetherSDR with TCI enabled, then launch not1mm, open Settings, select **TCI** on the rig-control tab, set the address to `127.0.0.1` and the port to `40001`, and save.
+
+- [ ] **Step 2: Verify radio state sync**
+
+Confirm each of these in the running app:
+
+1. not1mm's frequency display tracks AetherSDR's VFO when you turn the dial
+2. Changing mode on the SDR updates not1mm's mode
+3. Changing the filter width updates not1mm's bandwidth
+4. Typing a frequency in not1mm moves the SDR's VFO
+5. Changing band/mode in not1mm changes the SDR's mode
+
+- [ ] **Step 3: Verify PTT and CW**
+
+In Settings, select **CW via CAT** on the CW tab. Then confirm:
+
+1. A CW macro (F1) keys AetherSDR and sends the text
+2. The CW speed control changes the keyer speed
+3. Escape aborts a transmission in progress
+4. PTT engages and releases the SDR's transmitter
+
+- [ ] **Step 4: Verify failure and recovery**
+
+1. Close AetherSDR while not1mm is running. not1mm must show the radio offline and **hold** the last frequency rather than showing a live-looking frozen one.
+2. Restart AetherSDR. not1mm must reconnect within ~5 s without a restart.
+3. Quit not1mm while connected. **The process must exit cleanly with no hang** — this is the shutdown risk from the spec, and the specific thing to watch for.
+
+- [ ] **Step 5: Confirm no regression on the other backends**
+
+Switch to **None** (fake) in Settings and confirm the app still runs normally. If flrig or rigctld is available, switch to it and confirm it still works — none of their code was touched, but the shared `Radio.run()` exit path was.
+
+- [ ] **Step 6: Update the changelog**
+
+Add an entry to `CHANGELOG.md` in the existing format at the top of the file:
+
+```
+Added TCI rig control support, for SDRs such as AetherSDR and ExpertSDR.
+Select TCI in the settings rig control tab; the default port is 40001.
+CW keying over TCI works by also selecting "CW via CAT" on the CW tab.
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: note TCI rig control support in changelog"
+```
+
+---
+
+## Out of Scope for This Plan
+
+- **Phase 2, bandmap spot push.** Hooks `Database.addspot()` (`not1mm/bandmap.py:136`) rather than the CAT interface, and still has an unresolved routing question: `BandMapWindow` is a separate `QDockWidget` communicating over signals and multicast, and is not confirmed to hold a `rig_control` reference. It gets its own spec-to-plan cycle once phase 1 is verified.
+- Multi-receiver / multi-TRX and VFO B.
+- TCI audio and IQ streaming.
+- not1mm acting as a TCI server.

--- a/docs/superpowers/specs/2026-08-01-tci-handshake.md
+++ b/docs/superpowers/specs/2026-08-01-tci-handshake.md
@@ -86,15 +86,21 @@ static, even though no in-session push was captured. Also note it reported
 `0,2800`-style asymmetric edges for USB, not the symmetric `-500,500` the
 spec's example assumed; `abs(high - low)` handles both.
 
-### 4. cw_msg — NOT YET CONFIRMED
+### 4. cw_msg — CONFIRMED WORKING 2026-08-01
 
-The probe is read-only, so no CW command was ever sent and the server had no
-occasion to accept or reject one. **This remains the one open question.**
-TCI 1.5 is the relevant version for looking up the signature.
+The probe itself is read-only, so the capture could not exercise this. It was
+instead verified end to end from the running application: with **TCI** selected
+as the rig backend and **CW via CAT** selected on the CW tab, a CW macro keyed
+the live AetherSDR and sent its text.
 
-Resolution: Task 4 implements the best-known signature, and **Task 7 Step 3
-verifies it against the live radio** with the operator present. If AetherSDR
-rejects it, correct `sendcw` and its test then.
+The signature implemented in `TciCAT.sendcw` is therefore correct as written:
+
+```
+cw_msg:0,,,<text>;
+```
+
+This was the least-certain line in the implementation, since it was the one
+command the read-only probe could never test. It is now settled.
 
 ### 5. ready; terminates the handshake — confirmed
 

--- a/docs/superpowers/specs/2026-08-01-tci-handshake.md
+++ b/docs/superpowers/specs/2026-08-01-tci-handshake.md
@@ -1,0 +1,171 @@
+# AetherSDR TCI Handshake — Recorded 2026-08-01
+
+Captured with `not1mm/testing/tci_probe.py` against a live AetherSDR on
+`ws://127.0.0.1:50001`. This document is the authority for not1mm's TCI command
+mapping; where it disagrees with
+`docs/superpowers/specs/2026-08-01-tci-support-design.md`, **this wins**.
+
+## Answers to the five questions from the plan
+
+### 1. Protocol and device
+
+```
+device:AetherSDR;
+protocol:ExpertSDR3,1.5;
+```
+
+AetherSDR speaks **TCI 1.5**, identifying as the ExpertSDR3 dialect.
+
+### 2. modulations_list — TWO corrections
+
+```
+modulations_list:usb,lsb,cw,cwr,am,sam,fm,nfm,digu,digl,rtty;
+```
+
+**Correction A — the command is `modulations_list`, plural.** The spec assumed
+`modulation_list` (singular). Parsing the singular form would silently leave
+`get_mode_list()` empty forever, which in turn breaks `Radio.__init__`'s
+`cw_list`/`rtty_list` scan at `not1mm/radio.py:64-71`.
+
+**Correction B — the mode set differs from the spec's table:**
+
+| Spec assumed | AetherSDR actually has | Consequence |
+|---|---|---|
+| — | `cwr` | Missing from the table. Maps to `CWR`, which is already in `Radio.cw_list`. |
+| — | `rtty` | Missing. AetherSDR has **native RTTY**, so the spec's `RTTY → digl` remap is wrong and must be removed. |
+| `nfm` → `FM` | both `fm` **and** `nfm` | **Collision.** Two TCI modes would map to one not1mm mode, and the reverse map would lose `fm`. |
+| `dsb`, `wfm`, `drm` | absent | Harmless — kept in the table for other TCI servers; they simply never appear. |
+
+### 3. Argument order — confirmed as the spec assumed
+
+```
+vfo:0,0,14193000;          -> vfo:<trx>,<channel>,<hz>
+vfo:0,1,14193000;             (channel 1 = VFO B, ignored)
+modulation:0,usb;          -> modulation:<trx>,<mode>
+rx_filter_band:0,0,2800;   -> rx_filter_band:<trx>,<low>,<high>  (bw = 2800)
+trx:0,false;               -> trx:<trx>,<bool>
+```
+
+Live dial movement confirmed `vfo:` updates push unprompted and repeatedly:
+
+```
+vfo:0,0,14043900;
+vfo:0,0,14121800;
+vfo:0,0,14121900;
+...
+vfo:0,0,14126000;
+```
+
+Note `rx_filter_band` reported `0,2800` for USB — an asymmetric filter, not the
+symmetric `-500,500` the spec's example assumed. `abs(high - low)` handles both.
+
+### 4. cw_msg — NOT YET CONFIRMED
+
+The probe is read-only, so no CW command was ever sent and the server had no
+occasion to accept or reject one. **This remains the one open question.**
+TCI 1.5 is the relevant version for looking up the signature.
+
+Resolution: Task 4 implements the best-known signature, and **Task 7 Step 3
+verifies it against the live radio** with the operator present. If AetherSDR
+rejects it, correct `sendcw` and its test then.
+
+### 5. ready; terminates the handshake — confirmed
+
+`ready;` arrives after the full state dump, followed immediately by `start;`.
+Gating `online` on `ready;` is correct.
+
+## Frames to ignore, and why the ignore path matters
+
+The server pushes a large amount of traffic not1mm does not care about. In a
+60-second capture, **279 of ~330 frames were `rx_smeter:`** — an S-meter update
+roughly every 200 ms.
+
+Ignored commands observed: `rx_smeter`, `dds`, `vfo_limits`, `if_limits`,
+`channels_count`, `receive_only`, `rx_enable`, `rit_enable`, `xit_enable`,
+`rit_offset`, `xit_offset`, `split_enable`, `lock`, `sql_enable`, `sql_level`,
+`agc_mode`, `rx_nb_enable`, `rx_nr_enable`, `rx_anf_enable`, `rx_apf_enable`,
+`mute`, `tx_enable`, `drive`, `tune_drive`, `mic_level`, `volume`,
+`active_slice`, `audio_samplerate`, `audio_stream_sample_type`,
+`audio_stream_channels`, `audio_stream_samples`, `tx_stream_audio_buffering`,
+`iq_samplerate`, `trx_count`, `start`.
+
+This confirms the design decision to log unknown frames at **debug** level and
+drop them. Logging them at info would flood the log at ~5 lines/second.
+
+## Corrected mode table
+
+This replaces the spec's table. `TCI_TO_NOT1MM_MODE`:
+
+```python
+{
+    "usb": "USB",
+    "lsb": "LSB",
+    "cw": "CW",       # in Radio.cw_list
+    "cwr": "CWR",     # in Radio.cw_list
+    "am": "AM",
+    "sam": "SAM",
+    "fm": "FM",
+    "nfm": "NFM",     # distinct from fm -- must not collide
+    "digu": "DIGI-U", # in Radio.rtty_list via DIGI-L sibling
+    "digl": "DIGI-L", # in Radio.rtty_list
+    "rtty": "RTTY",   # in Radio.rtty_list -- native, do NOT remap to digl
+    "dsb": "DSB",     # not on AetherSDR; kept for other TCI servers
+    "wfm": "WFM",     # not on AetherSDR
+    "drm": "DRM",     # not on AetherSDR
+}
+```
+
+The reverse map is a plain inversion with **no special cases** — the spec's
+`RTTY → digl` and `RTTY-R → digu` entries are deleted, since AetherSDR has
+native `rtty`.
+
+## Raw capture
+
+Archived at `.superpowers/sdd/2026-08-01-tci-support/tci-handshake-raw.txt`
+(git-ignored scratch). The handshake portion, verbatim:
+
+```
+vfo_limits:1000,75000000;
+if_limits:-48000,48000;
+trx_count:1;
+channels_count:2;
+device:AetherSDR;
+receive_only:false;
+modulations_list:usb,lsb,cw,cwr,am,sam,fm,nfm,digu,digl,rtty;
+protocol:ExpertSDR3,1.5;
+vfo:0,0,14193000;
+vfo:0,1,14193000;
+dds:0,14176580;
+modulation:0,usb;
+rx_enable:0,true;
+rx_filter_band:0,0,2800;
+rit_enable:0,false;
+xit_enable:0,false;
+rit_offset:0,0;
+xit_offset:0,0;
+split_enable:0,false;
+lock:0,false;
+sql_enable:0,false;
+sql_level:0,20;
+agc_mode:0,fast;
+rx_nb_enable:0,false;
+rx_nr_enable:0,true;
+rx_anf_enable:0,false;
+rx_apf_enable:0,false;
+mute:0,false;
+tx_enable:0,true;
+drive:0,60;
+tune_drive:0,30;
+mic_level:70;
+trx:0,false;
+volume:-7;
+active_slice:0,A;
+audio_samplerate:48000;
+audio_stream_sample_type:float32;
+audio_stream_channels:2;
+audio_stream_samples:2048;
+tx_stream_audio_buffering:50;
+iq_samplerate:48000;
+ready;
+start;
+```

--- a/docs/superpowers/specs/2026-08-01-tci-handshake.md
+++ b/docs/superpowers/specs/2026-08-01-tci-handshake.md
@@ -36,19 +36,20 @@ modulations_list:usb,lsb,cw,cwr,am,sam,fm,nfm,digu,digl,rtty;
 | `nfm` → `FM` | both `fm` **and** `nfm` | **Collision.** Two TCI modes would map to one not1mm mode, and the reverse map would lose `fm`. |
 | `dsb`, `wfm`, `drm` | absent | Harmless — kept in the table for other TCI servers; they simply never appear. |
 
-### 3. Argument order — confirmed as the spec assumed
+### 3. Argument order — two different evidence levels
+
+The four commands below do **not** all carry the same weight of evidence.
+Only one was ever observed pushed live; the other three are read from the
+passive initial state dump alone, across two separate 60-second captures.
+
+**`vfo:` — confirmed as a live push.** 10 `vfo:` frames appear in the first
+capture, 2 of them the initial state dump (channel 0 and channel 1) and the
+remaining 8 arriving unprompted while the operator turned the dial:
 
 ```
 vfo:0,0,14193000;          -> vfo:<trx>,<channel>,<hz>
 vfo:0,1,14193000;             (channel 1 = VFO B, ignored)
-modulation:0,usb;          -> modulation:<trx>,<mode>
-rx_filter_band:0,0,2800;   -> rx_filter_band:<trx>,<low>,<high>  (bw = 2800)
-trx:0,false;               -> trx:<trx>,<bool>
-```
-
-Live dial movement confirmed `vfo:` updates push unprompted and repeatedly:
-
-```
+...
 vfo:0,0,14043900;
 vfo:0,0,14121800;
 vfo:0,0,14121900;
@@ -56,8 +57,34 @@ vfo:0,0,14121900;
 vfo:0,0,14126000;
 ```
 
-Note `rx_filter_band` reported `0,2800` for USB — an asymmetric filter, not the
-symmetric `-500,500` the spec's example assumed. `abs(high - low)` handles both.
+**`modulation:`, `rx_filter_band:`, `trx:` — argument order read from the
+initial state dump only.** None of the three was ever observed as a live
+push, across two independent 60-second capture windows:
+
+```
+modulation:0,usb;          -> modulation:<trx>,<mode>
+rx_filter_band:0,0,2800;   -> rx_filter_band:<trx>,<low>,<high>  (bw = 2800)
+trx:0,false;               -> trx:<trx>,<bool>
+```
+
+Each appears exactly once in the first capture (the state dump) and exactly
+once again in a second, independent capture — `modulation:` 1, `rx_filter_band:`
+1, `trx:` 1 — with zero further pushes of any of the three after `start;` in
+either window. The argument formats above are unambiguous and not in doubt;
+what is unverified is that AetherSDR pushes unsolicited updates for these
+three the way it does for `vfo:`.
+
+This is deferred, not blocking: **Task 7 Step 2 verifies mode and filter
+sync, and Task 7 Step 3 verifies PTT**, both with the operator present. That
+is where live-push behavior for `modulation:`, `rx_filter_band:`, and `trx:`
+gets confirmed.
+
+One data point is still useful despite the small sample: `rx_filter_band`
+read `0,0,2800` in the first capture and `0,100,2800` in the second — the
+low-edge field moved between sessions. That's weak evidence the field is not
+static, even though no in-session push was captured. Also note it reported
+`0,2800`-style asymmetric edges for USB, not the symmetric `-500,500` the
+spec's example assumed; `abs(high - low)` handles both.
 
 ### 4. cw_msg — NOT YET CONFIRMED
 
@@ -76,9 +103,10 @@ Gating `online` on `ready;` is correct.
 
 ## Frames to ignore, and why the ignore path matters
 
-The server pushes a large amount of traffic not1mm does not care about. In a
-60-second capture, **279 of ~330 frames were `rx_smeter:`** — an S-meter update
-roughly every 200 ms.
+The server pushes a large amount of traffic not1mm does not care about. The
+raw capture is 339 lines total; excluding the 1-line `--- connected ---`
+banner that is 338 frames, of which **279 were `rx_smeter:`** — an S-meter
+update roughly every 200 ms.
 
 Ignored commands observed: `rx_smeter`, `dds`, `vfo_limits`, `if_limits`,
 `channels_count`, `receive_only`, `rx_enable`, `rit_enable`, `xit_enable`,
@@ -106,7 +134,7 @@ This replaces the spec's table. `TCI_TO_NOT1MM_MODE`:
     "sam": "SAM",
     "fm": "FM",
     "nfm": "NFM",     # distinct from fm -- must not collide
-    "digu": "DIGI-U", # in Radio.rtty_list via DIGI-L sibling
+    "digu": "DIGI-U", # not in Radio.cw_list or Radio.rtty_list -- plain mode
     "digl": "DIGI-L", # in Radio.rtty_list
     "rtty": "RTTY",   # in Radio.rtty_list -- native, do NOT remap to digl
     "dsb": "DSB",     # not on AetherSDR; kept for other TCI servers

--- a/docs/superpowers/specs/2026-08-01-tci-support-design.md
+++ b/docs/superpowers/specs/2026-08-01-tci-support-design.md
@@ -138,7 +138,9 @@ No new configuration keys or code paths for either.
 `usetci_radioButton` joins the existing radio-button group next to
 `userigctld_radioButton` (`configuration.ui:501`) and `useflrig_radioButton`
 (`:535`), reusing the existing `CAT_ip` and `CAT_port` fields. **TCI defaults to
-port 40001.** The hint string at `not1mm/lib/settings.py:33` ("Usually 4532 for
+port 50001**, which is what the AetherSDR under test listens on. (40001 is the
+common default for other TCI servers such as ExpertSDR; the field is
+user-editable either way.) The hint string at `not1mm/lib/settings.py:33` ("Usually 4532 for
 rigctld and 12345 for flrig") gains a TCI mention.
 
 ## Error handling and recovery

--- a/docs/superpowers/specs/2026-08-01-tci-support-design.md
+++ b/docs/superpowers/specs/2026-08-01-tci-support-design.md
@@ -1,0 +1,209 @@
+# TCI Support for not1mm (AetherSDR Compatibility)
+
+**Date:** 2026-08-01
+**Status:** Approved design, ready for implementation planning
+
+## Goal
+
+Add TCI (Transceiver Control Interface) as a fourth CAT backend in not1mm, so
+AetherSDR can be used as the rig. TCI covers radio state sync, PTT, CW keying,
+and — in a second phase — pushing bandmap spots onto the SDR's panadapter.
+
+AetherSDR acts as the TCI **server**, listening on a WebSocket port. not1mm
+connects out to it as a client. A live AetherSDR is available for testing.
+
+## Background: the impedance mismatch
+
+TCI is asynchronous and push-based. The server broadcasts state changes
+unprompted (`vfo:0,0,14030000;` the moment the user turns the dial), and
+responses are not correlated to requests.
+
+not1mm's CAT contract is the opposite. `CAT` (`not1mm/lib/cat_interface.py:15`)
+defines synchronous getters, and `Radio.run()` (`not1mm/radio.py:76`) calls them
+from a blocking `while` loop with `QThread.msleep(100)` that never returns to a
+Qt event loop.
+
+Bridging those two is the central design problem. The chosen solution is a
+**state-cache backend**: an async reader keeps a dict of last-known state, and
+the synchronous getters read that dict.
+
+### Approaches considered
+
+- **A. State-cache backend — CHOSEN.** Getters return cached values, so they are
+  non-blocking and instant. `Radio` and `__main__.py` each change by one `elif`;
+  the other three backends are untouched. Cached state is fresher than polling,
+  since updates arrive when the SDR changes rather than up to 555 ms later.
+- **B. Push-through signals.** `QWebSocket` in the main GUI thread emitting Qt
+  signals straight into `poll_radio`, no polling at all. Most Qt-idiomatic and
+  lowest latency, but it breaks the abstraction: `Radio` would need a TCI-only
+  no-poll path and the `__main__.py` wiring would diverge from the other three
+  backends. Rejected — more disruption than the latency gain justifies.
+- **C. Synchronous request/reply.** Block on a matching response each poll,
+  mimicking `cat_rigctld.py`. Rejected: it fights the protocol. TCI broadcasts,
+  replies are not request-correlated, and blocking a poll loop on a shared
+  socket invites deadlock.
+
+### Transport decision
+
+`QWebSocket` from `PyQt6.QtWebSockets`, verified importable in the current
+install. **No new dependency**, and it matches how `radio.py` and `RTCService`
+already use `QThread`. The cost is that the `QWebSocket` must live on a thread
+running `QEventLoop.exec()` — a standard but fiddly Qt pattern.
+
+Rejected alternatives: the `websocket-client` PyPI package (simpler code, but
+adds a dependency to `pyproject.toml` and `python3-modules.yaml` on a project
+that keeps its dependency list tight) and hand-rolled RFC 6455 framing
+(~150 lines of fiddly protocol code we would own).
+
+## Architecture
+
+One new file, `not1mm/lib/cat_tci.py`, with two classes:
+
+**`TCIClient(QObject)`** — the transport. Owns a `QWebSocket` on its own
+`QThread` running a real `QEventLoop`, so socket signals are actually delivered.
+Parses inbound `command:arg1,arg2;` frames and writes them into a state dict
+guarded by a `QMutex`. Knows nothing about not1mm.
+
+**`TciCAT(CAT)`** — the backend, subclassing `not1mm/lib/cat_interface.py:15`.
+Getters read the state dict; setters serialize a TCI command and hand it to the
+client. This is the only class `radio.py` sees.
+
+Separation of concerns: `TCIClient` is testable without not1mm, and its parsing
+and serialization functions are testable without a socket.
+
+### Integration points
+
+Each of these is a small, local change:
+
+| File | Change |
+|---|---|
+| `not1mm/radio.py:56` | `elif self.interface == "tci": self.cat = TciCAT(...)` |
+| `not1mm/__main__.py:3835` | `elif self.pref.get("usetci", False) is True:` branch |
+| `not1mm/lib/preferences.py:57` | `"usetci": False` default |
+| `not1mm/lib/settings.py:126`, `:304` | load/save `usetci` |
+| `not1mm/data/configuration.ui:501` | `usetci_radioButton` in the existing group |
+
+## CAT-to-TCI command mapping
+
+| CAT method | TCI command |
+|---|---|
+| `get_vfo` / `set_vfo` | `vfo:0,0,<hz>;` |
+| `get_mode` / `set_mode` | `modulation:0,<mode>;` |
+| `get_bw` | `rx_filter_band:0,<low>,<high>;` → `high - low` |
+| `get_ptt` / `ptt_on` / `ptt_off` | `trx:0,<true\|false>;` |
+| `sendcw` | `cw_msg:` |
+| `set_cw_speed` | `cw_macros_speed:<wpm>;` |
+| `get_mode_list` | `modulation_list:` from the connect handshake |
+
+TRX index 0 and channel 0 (VFO A) throughout. Multi-receiver and VFO B support
+is out of scope.
+
+**Exact argument signatures are to be confirmed against AetherSDR's own
+handshake, not assumed.** TCI argument formats vary across protocol versions —
+`cw_msg:` in particular differs between revisions. The first implementation step
+is to connect to the live AetherSDR, log the full handshake verbatim (including
+its `protocol:` / `device:` / `modulation_list:` lines), and pin the mapping
+table to what that server actually speaks. The table above fixes *which* TCI
+command serves each CAT method; it does not fix argument counts or ordering.
+
+### Two contract traps
+
+**Mode names must be normalized.** TCI uses lowercase names that do not match
+not1mm's (`cw`, `digl`, `digu` vs `CW`, `DIGI-L`, `DIGI-U`). `Radio` matches
+`cw_list` and `rtty_list` against `get_mode_list()` by exact string
+(`not1mm/radio.py:36-42`), so raw passthrough would silently break CW and RTTY
+mode detection. `TciCAT` owns a bidirectional mode table normalizing to
+not1mm's uppercase convention on the way in and to TCI's lowercase on the way
+out.
+
+**`get_vfo` must return bare digits.** `not1mm/radio.py:84` rejects any value
+failing `.isnumeric()`, so no units, decimals, or sign.
+
+## PTT and CW require no new plumbing
+
+Both already route through the CAT object, so implementing the backend methods
+is sufficient:
+
+- **PTT** — `Radio.ptt_on` / `ptt_off` / `get_ptt` (`not1mm/radio.py:185-197`)
+  already delegate to `self.cat`.
+- **CW** — `cwtype == 3` is the existing "CW via CAT" mode
+  (`usecwviacat_radioButton`, handled at `not1mm/__main__.py:1624`, `:2628`,
+  `:3699`), routing to `rig_control.sendcw()` and `set_cw_speed()`. Users select
+  that option as they would with flrig or rigctld.
+
+No new configuration keys or code paths for either.
+
+## Configuration
+
+`usetci_radioButton` joins the existing radio-button group next to
+`userigctld_radioButton` (`configuration.ui:501`) and `useflrig_radioButton`
+(`:535`), reusing the existing `CAT_ip` and `CAT_port` fields. **TCI defaults to
+port 40001.** The hint string at `not1mm/lib/settings.py:33` ("Usually 4532 for
+rigctld and 12345 for flrig") gains a TCI mention.
+
+## Error handling and recovery
+
+`online` stays `False` until the server sends `ready;` at the end of its
+handshake. On disconnect or socket error: clear the cache, set `online = False`,
+and reconnect with capped backoff (1s → 2s → 5s). This is the TCI analogue of
+`RigctldCAT.reinit()`.
+
+**When offline, getters return `""` — never stale cache.** `not1mm/radio.py:83-97`
+only overwrites its values on a truthy result, so returning empty makes the UI
+hold last-known values and report `online: False`, exactly matching flrig and
+rigctld behavior on failure. Serving stale cache instead would paint a frozen
+frequency as though it were live, which during a contest is worse than showing
+nothing.
+
+Unknown inbound commands (audio stream control, IQ config, and similar) are
+logged at debug level and dropped. A TCI server sends plenty we do not care
+about, and this must not be treated as an error.
+
+**Shutdown risk.** `not1mm/__main__.py:3812-3819` tears the radio thread down via
+`time_to_quit` + `quit()` + `wait(1000)`. `TciCAT` owns a *second* QThread, so it
+needs an explicit close path hooked into that teardown. Without it, the app hangs
+on exit. This must be handled deliberately in the implementation plan.
+
+## Testing
+
+**Unit tests, no socket and no Qt required** — this is where the real bugs will
+be and the cheapest place to catch them:
+
+- Frame parsing: `vfo:0,0,14030000;` → structured fields
+- Command serialization for every mapped command
+- The bidirectional mode table, both directions, including unmapped modes
+- Bandwidth derived from `rx_filter_band` low/high
+- `get_vfo` output satisfies `.isnumeric()`
+- Getters return `""` when offline
+
+**Integration:** `not1mm/testing/faketci.py`, a minimal TCI WebSocket server
+following the `not1mm/testing/fakeflrig.py` precedent, so the backend can be
+exercised without AetherSDR running. Covers connect handshake, `ready;`,
+state broadcast, and disconnect/reconnect.
+
+**Manual:** verification against live AetherSDR — frequency and mode tracking in
+both directions, PTT, CW keying via "CW via CAT", and recovery after killing and
+restarting AetherSDR.
+
+## Phase 2 — spot push
+
+Deferred until phase 1 is working and verified, because it hooks the bandmap
+rather than the CAT interface and has no flrig/rigctld equivalent.
+
+`Database.addspot()` (`not1mm/bandmap.py:136`) is the single funnel for every
+spot; `delete_spot` (`:303`) and `clear_spots` (`:1002`) map to `spot_delete:`.
+Spots go out as `spot:<call>,<mode>,<hz>,<color>,<text>;`, guarded to be a no-op
+unless TCI is the active backend.
+
+**Open question to resolve during phase 2 planning:** `BandMapWindow` is a
+separate `QDockWidget` communicating over `message` / `cluster_expire` signals
+and multicast. It is not confirmed to hold a reference to `rig_control`. If it
+does not, a route from bandmap to the TCI client must be designed, and that
+routing choice is the bulk of phase 2's work.
+
+## Out of scope
+
+- Multi-receiver / multi-TRX and VFO B
+- TCI audio streaming (`start;` / `stop;`, IQ and audio data frames)
+- not1mm acting as a TCI *server*
+- Changes to the flrig, rigctld, or fake backends

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -3843,6 +3843,17 @@ class MainWindow(QtWidgets.QMainWindow):
                 int(self.pref.get("CAT_port", 4532)),
             )
 
+        elif self.pref.get("usetci", False) is True:
+            logger.debug(
+                "Using TCI: %s",
+                f"{self.pref.get('CAT_ip')} {self.pref.get('CAT_port')}",
+            )
+            self.rig_control = Radio(
+                "tci",
+                self.pref.get("CAT_ip", "127.0.0.1"),
+                int(self.pref.get("CAT_port", 50001)),
+            )
+
         else:
             self.rig_control = Radio(
                 "fake",

--- a/not1mm/data/configuration.ui
+++ b/not1mm/data/configuration.ui
@@ -559,6 +559,33 @@
           </widget>
          </item>
          <item>
+          <widget class="QRadioButton" name="usetci_radioButton">
+           <property name="font">
+            <font>
+             <family>JetBrains Mono</family>
+             <weight>100</weight>
+             <pointsize>12</pointsize>
+             <strikeout>false</strikeout>
+            </font>
+           </property>
+           <property name="accessibleName">
+            <string>t c i</string>
+           </property>
+           <property name="accessibleDescription">
+            <string>use t c i</string>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="text">
+            <string>TCI</string>
+           </property>
+           <attribute name="buttonGroup">
+            <string notr="true">cat_method_group</string>
+           </attribute>
+          </widget>
+         </item>
+         <item>
           <widget class="QRadioButton" name="radioButton">
            <property name="font">
             <font>
@@ -2867,6 +2894,7 @@
   <tabstop>rigcontrolip_field</tabstop>
   <tabstop>userigctld_radioButton</tabstop>
   <tabstop>useflrig_radioButton</tabstop>
+  <tabstop>usetci_radioButton</tabstop>
   <tabstop>radioButton</tabstop>
   <tabstop>rigcontrolport_field</tabstop>
   <tabstop>cwport_field</tabstop>

--- a/not1mm/lib/cat_interface.py
+++ b/not1mm/lib/cat_interface.py
@@ -98,6 +98,9 @@ class CAT:
     def ptt_off(self):
         """turn ptt on/off"""
 
+    def send_cat_string(self, cmdstr=""):
+        """send a raw cat string to radio"""
+
     @staticmethod
     def _parse_cat_command(cmdstr: str) -> tuple[str, bool, bool]:
         """Normalize an `RI:` macro payload into the form each CAT backend expects.

--- a/not1mm/lib/cat_tci.py
+++ b/not1mm/lib/cat_tci.py
@@ -48,12 +48,22 @@ class TciCAT(CAT):
         # Radio.__init__ reads get_mode_list() immediately, so give the
         # handshake a moment to land before returning.
         self.client.wait_for_ready(READY_TIMEOUT_MS)
-        self.online = self.client.online
 
-    def refresh_online(self) -> bool:
-        """Sync the public online flag with the transport and return it."""
-        self.online = self.client.online
-        return self.online
+    @property
+    def online(self) -> bool:
+        """True once the TCI server has completed its handshake.
+
+        Reads straight through to the transport rather than caching, so a
+        server that dies is reflected immediately instead of only after the
+        next getter call happens to refresh a stale flag.
+        """
+        return self.client.online
+
+    @online.setter
+    def online(self, _value: bool) -> None:
+        """No-op: CAT.__init__ does `self.online = False`, which would raise
+        against a read-only property. Swallow that one assignment; `online`
+        itself always reads through to the client."""
 
     # ---- getters ----
     # Offline returns "" rather than cached values: Radio only overwrites on a
@@ -62,25 +72,25 @@ class TciCAT(CAT):
 
     def get_vfo(self) -> str:
         """Poll the radio for current vfo using the interface"""
-        if not self.refresh_online():
+        if not self.online:
             return ""
         return self.client.get("vfo", "")
 
     def get_mode(self) -> str:
         """Returns the current mode of the radio"""
-        if not self.refresh_online():
+        if not self.online:
             return ""
         return self.client.get("mode", "")
 
     def get_bw(self) -> str:
         """Get current vfo bandwidth"""
-        if not self.refresh_online():
+        if not self.online:
             return ""
         return self.client.get("bw", "")
 
     def get_ptt(self) -> str:
         """Get PTT state"""
-        if not self.refresh_online():
+        if not self.online:
             return "0"
         return self.client.get("ptt", "0")
 
@@ -96,28 +106,28 @@ class TciCAT(CAT):
 
     def set_vfo(self, freq: str) -> bool:
         """Sets the radios VFO. Defaults to VFOA."""
-        if not self.refresh_online():
+        if not self.online:
             return False
         self.client.send(build_command("vfo", 0, 0, str(freq)))
         return True
 
     def set_mode(self, mode: str) -> bool:
         """Sets the radios mode"""
-        if not self.refresh_online():
+        if not self.online:
             return False
         self.client.send(build_command("modulation", 0, not1mm_mode_to_tci(mode)))
         return True
 
     def ptt_on(self) -> bool:
         """turn ptt on"""
-        if not self.refresh_online():
+        if not self.online:
             return False
         self.client.send(build_command("trx", 0, "true"))
         return True
 
     def ptt_off(self) -> bool:
         """turn ptt off"""
-        if not self.refresh_online():
+        if not self.online:
             return False
         self.client.send(build_command("trx", 0, "false"))
         return True
@@ -126,19 +136,19 @@ class TciCAT(CAT):
 
     def sendcw(self, texttosend) -> None:
         """Send CW text through the radio's keyer"""
-        if not self.refresh_online():
+        if not self.online:
             return
         self.client.send(build_command("cw_msg", 0, "", "", texttosend))
 
     def stopcw(self) -> None:
         """Abort CW transmission"""
-        if not self.refresh_online():
+        if not self.online:
             return
         self.client.send(build_command("cw_terminate"))
 
     def set_cw_speed(self, speed: int) -> None:
         """Set the CW speed in wpm"""
-        if not self.refresh_online():
+        if not self.online:
             return
         self.client.send(build_command("cw_macros_speed", int(speed)))
 

--- a/not1mm/lib/cat_tci.py
+++ b/not1mm/lib/cat_tci.py
@@ -1,0 +1,147 @@
+"""
+K6GTE, CAT interface abstraction
+Email: michael.bridak@gmail.com
+GPL V3
+
+TCI backend, for SDRs such as AetherSDR and ExpertSDR.
+
+Unlike flrig and rigctld, nothing here queries the radio. TCI pushes state
+changes and TCIClient caches them, so the getters are cache reads: instant,
+non-blocking, and fresher than a poll would be.
+"""
+
+import logging
+
+from not1mm.lib.cat_interface import CAT
+from not1mm.lib.tci_client import TCIClient
+from not1mm.lib.tci_protocol import build_command, not1mm_mode_to_tci
+
+if __name__ == "__main__":
+    print("I'm not the program you are looking for.")
+
+logger = logging.getLogger("cat_tci")
+
+# Long enough for a local SDR's handshake, short enough not to stall startup.
+READY_TIMEOUT_MS = 1500
+
+
+class TciCAT(CAT):
+    """CAT control via the TCI protocol"""
+
+    def __init__(self, host: str, port: int) -> None:
+        """
+        Computer Aided Transceiver abstraction class.
+        Offers a normalized interface; this is the TCI class.
+
+        Takes 2 inputs to setup the class.
+
+        A string defining the host, example: 'localhost' or '127.0.0.1'
+
+        An integer defining the network port used. Commonly 50001 for TCI.
+
+        A variable 'online' is set to True once the TCI server completes its
+        handshake, otherwise False.
+        """
+        super().__init__(host, port)
+        self.interface = "tci"
+        self.client = TCIClient(host, port)
+        # Radio.__init__ reads get_mode_list() immediately, so give the
+        # handshake a moment to land before returning.
+        self.client.wait_for_ready(READY_TIMEOUT_MS)
+        self.online = self.client.online
+
+    def refresh_online(self) -> bool:
+        """Sync the public online flag with the transport and return it."""
+        self.online = self.client.online
+        return self.online
+
+    # ---- getters ----
+    # Offline returns "" rather than cached values: Radio only overwrites on a
+    # truthy result, so "" holds the last known reading and reports offline.
+    # Returning stale cache would paint a dead radio as live.
+
+    def get_vfo(self) -> str:
+        """Poll the radio for current vfo using the interface"""
+        if not self.refresh_online():
+            return ""
+        return self.client.get("vfo", "")
+
+    def get_mode(self) -> str:
+        """Returns the current mode of the radio"""
+        if not self.refresh_online():
+            return ""
+        return self.client.get("mode", "")
+
+    def get_bw(self) -> str:
+        """Get current vfo bandwidth"""
+        if not self.refresh_online():
+            return ""
+        return self.client.get("bw", "")
+
+    def get_ptt(self) -> str:
+        """Get PTT state"""
+        if not self.refresh_online():
+            return "0"
+        return self.client.get("ptt", "0")
+
+    def get_mode_list(self) -> list:
+        """Get a list of modes supported by the radio.
+
+        Served even while offline: it is a device capability captured at
+        handshake, and Radio caches it once at construction.
+        """
+        return self.client.get("modes", [])
+
+    # ---- setters ----
+
+    def set_vfo(self, freq: str) -> bool:
+        """Sets the radios VFO. Defaults to VFOA."""
+        if not self.refresh_online():
+            return False
+        self.client.send(build_command("vfo", 0, 0, str(freq)))
+        return True
+
+    def set_mode(self, mode: str) -> bool:
+        """Sets the radios mode"""
+        if not self.refresh_online():
+            return False
+        self.client.send(build_command("modulation", 0, not1mm_mode_to_tci(mode)))
+        return True
+
+    def ptt_on(self) -> bool:
+        """turn ptt on"""
+        if not self.refresh_online():
+            return False
+        self.client.send(build_command("trx", 0, "true"))
+        return True
+
+    def ptt_off(self) -> bool:
+        """turn ptt off"""
+        if not self.refresh_online():
+            return False
+        self.client.send(build_command("trx", 0, "false"))
+        return True
+
+    # ---- CW, reached via the existing "CW via CAT" option (cwtype == 3) ----
+
+    def sendcw(self, texttosend) -> None:
+        """Send CW text through the radio's keyer"""
+        if not self.refresh_online():
+            return
+        self.client.send(build_command("cw_msg", 0, "", "", texttosend))
+
+    def stopcw(self) -> None:
+        """Abort CW transmission"""
+        if not self.refresh_online():
+            return
+        self.client.send(build_command("cw_terminate"))
+
+    def set_cw_speed(self, speed: int) -> None:
+        """Set the CW speed in wpm"""
+        if not self.refresh_online():
+            return
+        self.client.send(build_command("cw_macros_speed", int(speed)))
+
+    def close(self) -> None:
+        """Shut down the transport thread. Radio.run() calls this on exit."""
+        self.client.close()

--- a/not1mm/lib/preferences.py
+++ b/not1mm/lib/preferences.py
@@ -56,6 +56,7 @@ class Preferences:
         "CAT_ip": "127.0.0.1",
         "userigctld": False,
         "useflrig": False,
+        "usetci": False,
         "cwip": "127.0.0.1",
         "cwport": 6789,
         "cwtype": 0,

--- a/not1mm/lib/settings.py
+++ b/not1mm/lib/settings.py
@@ -30,7 +30,8 @@ class Settings(QtWidgets.QDialog):
             "Usually 6789 for cwdaemon and 8000 for pywinkeyer."
         )
         self.rigcontrolport_field.setToolTip(
-            "Usually 4532 for rigctld and 12345 for flrig."
+            "Usually 4532 for rigctld, 12345 for flrig, "
+            "and 50001 or 40001 for TCI."
         )
         self.preference = pref
         if sd:
@@ -125,6 +126,7 @@ class Settings(QtWidgets.QDialog):
         self.catpoll_field.setText(str(self.preference.get("CAT_polldelta", 500)))
         self.userigctld_radioButton.setChecked(bool(self.preference.get("userigctld")))
         self.useflrig_radioButton.setChecked(bool(self.preference.get("useflrig")))
+        self.usetci_radioButton.setChecked(bool(self.preference.get("usetci")))
 
         self.rotctld_address.setText(str(self.preference.get("rotctld_address", "")))
         self.rotctld_port.setText(str(self.preference.get("rotctld_port", "")))
@@ -303,6 +305,7 @@ class Settings(QtWidgets.QDialog):
             ...
         self.preference["userigctld"] = self.userigctld_radioButton.isChecked()
         self.preference["useflrig"] = self.useflrig_radioButton.isChecked()
+        self.preference["usetci"] = self.usetci_radioButton.isChecked()
 
         self.preference["rotctld_address"] = self.rotctld_address.text()
         try:

--- a/not1mm/lib/tci_client.py
+++ b/not1mm/lib/tci_client.py
@@ -1,0 +1,230 @@
+"""
+K6GTE, TCI websocket transport
+Email: michael.bridak@gmail.com
+GPL V3
+
+Owns a QWebSocket on its own QThread running a real event loop, so socket
+signals are actually delivered -- Radio.run() blocks in a while loop and never
+returns to an event loop, so the socket cannot live there.
+
+TCI pushes state changes unprompted. This class caches them behind a mutex and
+the CAT layer reads the cache instead of querying.
+"""
+
+import logging
+
+from PyQt6.QtCore import (
+    QMetaObject,
+    QMutex,
+    QMutexLocker,
+    QObject,
+    Qt,
+    QThread,
+    QTimer,
+    QUrl,
+    pyqtSignal,
+    pyqtSlot,
+)
+from PyQt6.QtWebSockets import QWebSocket
+
+from not1mm.lib.tci_protocol import (
+    bandwidth_from_filter_band,
+    parse_frame,
+    split_frames,
+    tci_mode_to_not1mm,
+)
+
+if __name__ == "__main__":
+    print("I'm not the program you are looking for.")
+
+logger = logging.getLogger("tci_client")
+
+RECONNECT_BACKOFF_MS = (1000, 2000, 5000)
+
+
+class TCIClient(QObject):
+    """Websocket transport and state cache for a TCI server."""
+
+    send_requested = pyqtSignal(str)
+
+    def __init__(self, host: str, port: int, autostart: bool = True) -> None:
+        super().__init__()
+        self.host = host
+        self.port = port
+        self.init_state()
+        self.thread = QThread()
+        # autostart=False gives tests a cache-only instance with no thread and
+        # no socket, while still constructing the QObject properly.
+        if autostart:
+            self.moveToThread(self.thread)
+            self.thread.started.connect(self.open_socket)
+            self.send_requested.connect(self.write_command)
+            self.thread.start()
+
+    def init_state(self) -> None:
+        """Set up the cache."""
+        self.socket = None
+        self.reconnect_timer = None
+        self.backoff = 0
+        self.closing = False
+        self.mutex = QMutex()
+        self.state = {
+            "vfo": "",
+            "mode": "",
+            "bw": "",
+            "ptt": "0",
+            "modes": [],
+            "ready": False,
+        }
+
+    # ---- cache access: safe to call from any thread ----
+
+    def get(self, key: str, default=""):
+        with QMutexLocker(self.mutex):
+            value = self.state.get(key, default)
+            if isinstance(value, list):
+                return list(value)  # copy, so callers cannot mutate the cache
+            return value
+
+    def set(self, key: str, value) -> None:
+        with QMutexLocker(self.mutex):
+            self.state[key] = value
+
+    @property
+    def online(self) -> bool:
+        """True only once the server has finished its handshake."""
+        return bool(self.get("ready", False))
+
+    def clear_state(self) -> None:
+        """Drop volatile state on disconnect. The mode list survives: it is a
+        device capability, not live state, and re-querying it costs a round
+        trip we do not need."""
+        with QMutexLocker(self.mutex):
+            self.state.update(
+                {"vfo": "", "mode": "", "bw": "", "ptt": "0", "ready": False}
+            )
+
+    def send(self, command: str) -> None:
+        """Queue a command onto the TCI thread. Safe from any thread -- the
+        signal crosses threads as a queued connection."""
+        self.send_requested.emit(command)
+
+    def wait_for_ready(self, timeout_ms: int) -> bool:
+        """Block until the handshake completes or the timeout expires.
+
+        Called once at construction so get_mode_list() has data before
+        Radio.__init__ reads it.
+        """
+        waited = 0
+        while waited < timeout_ms:
+            if self.online:
+                return True
+            QThread.msleep(50)
+            waited += 50
+        return self.online
+
+    # ---- frame handling: no socket calls, so tests drive it directly ----
+
+    def handle_frame(self, name: str, args: list) -> None:
+        """Update the cache from one parsed frame."""
+        if name == "ready":
+            logger.debug("TCI handshake complete")
+            self.set("ready", True)
+        elif name == "vfo" and len(args) >= 3 and args[0] == "0" and args[1] == "0":
+            if args[2].isnumeric():  # Radio rejects non-numeric VFO values
+                self.set("vfo", args[2])
+        elif name == "modulation" and len(args) >= 2 and args[0] == "0":
+            self.set("mode", tci_mode_to_not1mm(args[1]))
+        elif name == "rx_filter_band" and len(args) >= 3 and args[0] == "0":
+            bandwidth = bandwidth_from_filter_band(args[1], args[2])
+            if bandwidth:
+                self.set("bw", bandwidth)
+        elif name == "trx" and len(args) >= 2 and args[0] == "0":
+            self.set("ptt", "1" if args[1].strip().lower() == "true" else "0")
+        elif name == "modulations_list":
+            self.set("modes", [tci_mode_to_not1mm(m) for m in args if m])
+        else:
+            logger.debug("Ignoring TCI frame: %s %s", name, args)
+
+    # ---- everything below runs on the TCI thread ----
+
+    @pyqtSlot()
+    def open_socket(self) -> None:
+        """Build the socket. Runs on the TCI thread so the socket's parent
+        affinity is correct."""
+        self.socket = QWebSocket()
+        self.socket.connected.connect(self.on_connected)
+        self.socket.disconnected.connect(self.on_disconnected)
+        self.socket.textMessageReceived.connect(self.on_text_message)
+        self.socket.errorOccurred.connect(self.on_error)
+        self.reconnect_timer = QTimer()
+        self.reconnect_timer.setSingleShot(True)
+        self.reconnect_timer.timeout.connect(self.connect_to_server)
+        self.connect_to_server()
+
+    @pyqtSlot()
+    def connect_to_server(self) -> None:
+        if self.closing:
+            return
+        url = f"ws://{self.host}:{self.port}"
+        logger.debug("Connecting to TCI %s", url)
+        self.socket.open(QUrl(url))
+
+    @pyqtSlot()
+    def on_connected(self) -> None:
+        logger.debug("TCI socket open, awaiting handshake")
+        self.backoff = 0
+
+    @pyqtSlot()
+    def on_disconnected(self) -> None:
+        logger.info("TCI socket disconnected")
+        self.clear_state()
+        self.schedule_reconnect()
+
+    def on_error(self, error) -> None:
+        logger.info("TCI socket error: %s", error)
+        self.clear_state()
+        self.schedule_reconnect()
+
+    def schedule_reconnect(self) -> None:
+        if self.closing or self.reconnect_timer is None:
+            return
+        delay = RECONNECT_BACKOFF_MS[min(self.backoff, len(RECONNECT_BACKOFF_MS) - 1)]
+        self.backoff += 1
+        if not self.reconnect_timer.isActive():
+            logger.debug("Reconnecting to TCI in %d ms", delay)
+            self.reconnect_timer.start(delay)
+
+    @pyqtSlot(str)
+    def write_command(self, command: str) -> None:
+        if self.socket is None or not self.online:
+            return
+        logger.debug("> %s", command)
+        self.socket.sendTextMessage(command)
+
+    @pyqtSlot(str)
+    def on_text_message(self, payload: str) -> None:
+        for frame in split_frames(payload):
+            parsed = parse_frame(frame)
+            if parsed is None:
+                logger.debug("Unparseable TCI frame: %s", frame)
+                continue
+            self.handle_frame(*parsed)
+
+    def close(self) -> None:
+        """Stop the socket and its thread. Must run before app exit or the
+        process hangs on a live thread."""
+        self.closing = True
+        if self.thread.isRunning():
+            QMetaObject.invokeMethod(
+                self, "shutdown", Qt.ConnectionType.BlockingQueuedConnection
+            )
+            self.thread.quit()
+            self.thread.wait(500)
+
+    @pyqtSlot()
+    def shutdown(self) -> None:
+        if self.reconnect_timer is not None:
+            self.reconnect_timer.stop()
+        if self.socket is not None:
+            self.socket.close()

--- a/not1mm/lib/tci_client.py
+++ b/not1mm/lib/tci_client.py
@@ -190,8 +190,8 @@ class TCIClient(QObject):
         if self.closing or self.reconnect_timer is None:
             return
         delay = RECONNECT_BACKOFF_MS[min(self.backoff, len(RECONNECT_BACKOFF_MS) - 1)]
-        self.backoff += 1
         if not self.reconnect_timer.isActive():
+            self.backoff += 1
             logger.debug("Reconnecting to TCI in %d ms", delay)
             self.reconnect_timer.start(delay)
 
@@ -221,10 +221,18 @@ class TCIClient(QObject):
             )
             self.thread.quit()
             self.thread.wait(500)
+            # Both objects still have affinity to the now-dead TCI thread;
+            # deleteLater() (queued in shutdown) handles their destruction on
+            # that thread. Drop the Python references so we do not also free
+            # them here on the calling thread.
+            self.socket = None
+            self.reconnect_timer = None
 
     @pyqtSlot()
     def shutdown(self) -> None:
         if self.reconnect_timer is not None:
             self.reconnect_timer.stop()
+            self.reconnect_timer.deleteLater()
         if self.socket is not None:
             self.socket.close()
+            self.socket.deleteLater()

--- a/not1mm/lib/tci_protocol.py
+++ b/not1mm/lib/tci_protocol.py
@@ -77,6 +77,11 @@ def split_frames(payload: str) -> list[str]:
 
     One payload may carry several commands, which is normal during the connect
     handshake.
+
+    Assumes each payload is a fully-assembled websocket text message (Qt's
+    QWebSocket delivers one signal per complete message, never a partial
+    fragment), so a trailing chunk with no ';' terminator is still treated as
+    a complete frame rather than buffered pending more data.
     """
     return [chunk + ";" for chunk in payload.split(";") if chunk.strip()]
 

--- a/not1mm/lib/tci_protocol.py
+++ b/not1mm/lib/tci_protocol.py
@@ -1,0 +1,115 @@
+"""
+TCI protocol helpers: frame parsing, command building, mode translation.
+Email: michael.bridak@gmail.com
+GPL V3
+
+Pure functions only -- no sockets, no Qt, no not1mm state. The fiddly string
+handling lives here so it stays testable without a running SDR.
+"""
+
+import logging
+
+if __name__ == "__main__":
+    print("I'm not the program you are looking for.")
+
+logger = logging.getLogger("tci_protocol")
+
+# TCI modulation names are lowercase and do not match not1mm's conventions.
+# Radio.cw_list / Radio.rtty_list (not1mm/radio.py:36-42) match the output of
+# get_mode_list() by exact string, so everything is normalized to not1mm's
+# uppercase names on the way in.
+# Verified against a live AetherSDR handshake on 2026-08-01; see
+# docs/superpowers/specs/2026-08-01-tci-handshake.md. AetherSDR reports:
+#   modulations_list:usb,lsb,cw,cwr,am,sam,fm,nfm,digu,digl,rtty;
+TCI_TO_NOT1MM_MODE = {
+    "usb": "USB",
+    "lsb": "LSB",
+    "cw": "CW",  # in Radio.cw_list
+    "cwr": "CWR",  # in Radio.cw_list
+    "am": "AM",
+    "sam": "SAM",
+    "fm": "FM",
+    # AetherSDR offers fm AND nfm. Folding nfm into FM would collide, and the
+    # reverse map would then lose fm entirely.
+    "nfm": "NFM",
+    "digu": "DIGI-U",
+    "digl": "DIGI-L",  # in Radio.rtty_list
+    "rtty": "RTTY",  # in Radio.rtty_list -- native, never remapped to digl
+    # Not offered by AetherSDR; harmless, and correct for other TCI servers.
+    "dsb": "DSB",
+    "wfm": "WFM",
+    "drm": "DRM",
+}
+
+# Plain inversion, no special cases: AetherSDR has a native rtty mode, so
+# not1mm's RTTY maps straight through.
+NOT1MM_TO_TCI_MODE = {v: k for k, v in TCI_TO_NOT1MM_MODE.items()}
+
+
+def parse_frame(frame: str) -> tuple[str, list[str]] | None:
+    """Split one TCI frame into (command, args).
+
+    "vfo:0,0,14030000;" -> ("vfo", ["0", "0", "14030000"])
+    "ready;"            -> ("ready", [])
+
+    Returns None for anything malformed. TCI servers emit plenty of commands
+    not1mm does not care about, so callers drop None quietly rather than
+    treating it as an error.
+    """
+    frame = frame.strip()
+    if not frame.endswith(";"):
+        return None
+    body = frame[:-1].strip()
+    if not body:
+        return None
+    if ":" not in body:
+        return body.lower(), []
+    name, _, argstr = body.partition(":")
+    name = name.strip().lower()
+    if not name:
+        return None
+    args = [a.strip() for a in argstr.split(",")] if argstr.strip() else []
+    return name, args
+
+
+def split_frames(payload: str) -> list[str]:
+    """Split a websocket text payload into individual ';'-terminated frames.
+
+    One payload may carry several commands, which is normal during the connect
+    handshake.
+    """
+    return [chunk + ";" for chunk in payload.split(";") if chunk.strip()]
+
+
+def build_command(name: str, *args) -> str:
+    """Build a TCI command frame.
+
+    build_command("vfo", 0, 0, 14030000) -> "vfo:0,0,14030000;"
+    build_command("stop")                -> "stop;"
+    """
+    if not args:
+        return f"{name};"
+    return f"{name}:{','.join(str(a) for a in args)};"
+
+
+def tci_mode_to_not1mm(mode: str) -> str:
+    """Normalize a TCI modulation name to not1mm's convention."""
+    cleaned = mode.strip()
+    return TCI_TO_NOT1MM_MODE.get(cleaned.lower(), cleaned.upper())
+
+
+def not1mm_mode_to_tci(mode: str) -> str:
+    """Translate a not1mm mode name to TCI's convention."""
+    cleaned = mode.strip()
+    return NOT1MM_TO_TCI_MODE.get(cleaned.upper(), cleaned.lower())
+
+
+def bandwidth_from_filter_band(low: str, high: str) -> str:
+    """Derive filter width in Hz from an rx_filter_band edge pair.
+
+    Returns "" when unparseable, which the caller treats as "no update".
+    """
+    try:
+        return str(abs(int(high) - int(low)))
+    except (TypeError, ValueError):
+        return ""

--- a/not1mm/radio.py
+++ b/not1mm/radio.py
@@ -12,6 +12,7 @@ from PyQt6.QtCore import QEventLoop, QObject, QThread, pyqtSignal
 from not1mm.lib.cat_fake import FakeCAT
 from not1mm.lib.cat_flrig import FlrigCAT
 from not1mm.lib.cat_rigctld import RigctldCAT
+from not1mm.lib.cat_tci import TciCAT
 
 logger = logging.getLogger("radio")
 
@@ -57,6 +58,8 @@ class Radio(QObject):
                 self.cat = FlrigCAT(self.host, self.port)
             elif self.interface == "rigctld":
                 self.cat = RigctldCAT(self.host, self.port)
+            elif self.interface == "tci":
+                self.cat = TciCAT(self.host, self.port)
             else:
                 self.cat = FakeCAT(self.host, self.port)
             self.online = self.cat.online
@@ -107,6 +110,11 @@ class Radio(QObject):
                 except QEventLoop:
                     ...
             QThread.msleep(100)
+        # Backends owning their own threads (TCI) must be torn down here, or
+        # the app hangs on exit. The others have no close() and no-op.
+        close = getattr(self.cat, "close", None)
+        if close is not None:
+            close()
 
     def store_last_data_mode(self, the_mode: str = ""):
         """if the last mode is a data mode, save it."""

--- a/not1mm/testing/faketci.py
+++ b/not1mm/testing/faketci.py
@@ -1,0 +1,88 @@
+"""
+A minimal TCI server, for exercising not1mm's TCI backend without an SDR.
+
+Sends a plausible handshake, then accepts and echoes state changes the way a
+real TCI server does. Deliberately shares no code with the client, so a bug
+here cannot masquerade as a backend bug.
+
+Usage: python -m not1mm.testing.faketci [port]
+"""
+
+import sys
+
+from PyQt6.QtCore import QCoreApplication, QTimer
+from PyQt6.QtWebSockets import QWebSocketServer
+
+# Mirrors a real AetherSDR handshake captured 2026-08-01, including the noise
+# frames, so the client's ignore path gets exercised too. See
+# docs/superpowers/specs/2026-08-01-tci-handshake.md.
+HANDSHAKE = [
+    "vfo_limits:1000,75000000;",
+    "if_limits:-48000,48000;",
+    "trx_count:1;",
+    "channels_count:2;",
+    "device:FakeSDR;",
+    "receive_only:false;",
+    "modulations_list:usb,lsb,cw,cwr,am,sam,fm,nfm,digu,digl,rtty;",
+    "protocol:ExpertSDR3,1.5;",
+    "vfo:0,0,14030000;",
+    "vfo:0,1,14030000;",
+    "dds:0,14176580;",
+    "modulation:0,cw;",
+    "rx_filter_band:0,-500,500;",
+    "agc_mode:0,fast;",
+    "trx:0,false;",
+    "iq_samplerate:48000;",
+    "ready;",
+    "start;",
+]
+
+
+class FakeTCIServer:
+    def __init__(self, port: int) -> None:
+        self.clients = []
+        self.server = QWebSocketServer(
+            "FakeTCI", QWebSocketServer.SslMode.NonSecureMode
+        )
+        if not self.server.listen(port=port):
+            print(f"Failed to listen on {port}", flush=True)
+            raise SystemExit(1)
+        self.server.newConnection.connect(self.on_new_connection)
+        print(f"FakeTCI listening on ws://127.0.0.1:{port}", flush=True)
+
+    def on_new_connection(self) -> None:
+        socket = self.server.nextPendingConnection()
+        socket.textMessageReceived.connect(
+            lambda message: self.on_message(socket, message)
+        )
+        socket.disconnected.connect(lambda: self.on_disconnected(socket))
+        self.clients.append(socket)
+        print("client connected, sending handshake", flush=True)
+        for frame in HANDSHAKE:
+            socket.sendTextMessage(frame)
+
+    def on_message(self, socket, message: str) -> None:
+        print(f"< {message}", flush=True)
+        # A real TCI server echoes accepted state changes back to all clients.
+        for frame in [f + ";" for f in message.split(";") if f.strip()]:
+            for client in self.clients:
+                client.sendTextMessage(frame)
+
+    def on_disconnected(self, socket) -> None:
+        print("client disconnected", flush=True)
+        if socket in self.clients:
+            self.clients.remove(socket)
+        socket.deleteLater()
+
+
+def main() -> None:
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 50001
+    app = QCoreApplication([])
+    server = FakeTCIServer(port)
+    QTimer.singleShot(600000, app.quit)
+    app.exec()
+    del server
+
+
+if __name__ == "__main__":
+    main()

--- a/not1mm/testing/tci_probe.py
+++ b/not1mm/testing/tci_probe.py
@@ -1,0 +1,44 @@
+"""
+Connect to a TCI server and dump every frame it sends, verbatim.
+
+Used to pin not1mm's TCI command mapping to what the server actually speaks,
+rather than to what the protocol docs claim. Not part of the application.
+
+Usage: python -m not1mm.testing.tci_probe [host] [port]
+"""
+
+import sys
+
+from PyQt6.QtCore import QCoreApplication, QTimer, QUrl
+from PyQt6.QtWebSockets import QWebSocket
+
+
+def main() -> None:
+    host = sys.argv[1] if len(sys.argv) > 1 else "127.0.0.1"
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else 50001
+
+    app = QCoreApplication([])
+    socket = QWebSocket()
+
+    def on_connected() -> None:
+        print(f"--- connected to ws://{host}:{port} ---", flush=True)
+
+    def on_text(payload: str) -> None:
+        print(payload, flush=True)
+
+    def on_error(error) -> None:
+        print(f"--- error: {error} ---", flush=True)
+        app.quit()
+
+    socket.connected.connect(on_connected)
+    socket.textMessageReceived.connect(on_text)
+    socket.errorOccurred.connect(on_error)
+    socket.open(QUrl(f"ws://{host}:{port}"))
+
+    # Capture the handshake plus a window for manual dial/mode/PTT changes.
+    QTimer.singleShot(60000, app.quit)
+    app.exec()
+
+
+if __name__ == "__main__":
+    main()

--- a/not1mm/vfo.py
+++ b/not1mm/vfo.py
@@ -24,6 +24,7 @@ from PyQt6.QtWidgets import QDockWidget
 from not1mm import fsutils
 from not1mm.lib.cat_flrig import FlrigCAT
 from not1mm.lib.cat_rigctld import RigctldCAT
+from not1mm.lib.cat_tci import TciCAT
 from not1mm.lib.preferences import Preferences
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -46,7 +47,7 @@ class VfoWindow(QDockWidget):
         self.action = action
         uic.loadUi(fsutils.APP_DATA_PATH / "vfo.ui", self)
         self.setWindowTitle("VFO Window")
-        self.rig_control: FlrigCAT | RigctldCAT | None = None
+        self.rig_control: FlrigCAT | RigctldCAT | TciCAT | None = None
         self.timer: QTimer = QTimer()
         self.timer.timeout.connect(self.getwaiting)
         self.load_pref()
@@ -84,6 +85,16 @@ class VfoWindow(QDockWidget):
             self.rig_control: RigctldCAT | None = RigctldCAT(
                 self.pref.get("CAT_ip", "127.0.0.1"),
                 int(self.pref.get("CAT_port", 4532)),
+            )
+            self.timer.start(100)
+        if self.pref.get("usetci", False):
+            logger.debug(
+                "Using TCI: %s",
+                f"{self.pref.get('CAT_ip')} {self.pref.get('CAT_port')}",
+            )
+            self.rig_control: TciCAT | None = TciCAT(
+                self.pref.get("CAT_ip", "127.0.0.1"),
+                int(self.pref.get("CAT_port", 50001)),
             )
             self.timer.start(100)
 

--- a/test/cat_tci_tests.py
+++ b/test/cat_tci_tests.py
@@ -1,0 +1,150 @@
+import pytest
+
+from not1mm.lib.cat_tci import TciCAT
+
+
+class StubClient:
+    """Stands in for TCIClient: no thread, no socket, records what was sent."""
+
+    def __init__(self):
+        self.sent = []
+        self.state = {
+            "vfo": "",
+            "mode": "",
+            "bw": "",
+            "ptt": "0",
+            "modes": [],
+            "ready": False,
+        }
+
+    @property
+    def online(self):
+        return bool(self.state["ready"])
+
+    def get(self, key, default=""):
+        value = self.state.get(key, default)
+        return list(value) if isinstance(value, list) else value
+
+    def send(self, command):
+        self.sent.append(command)
+
+    def wait_for_ready(self, timeout_ms):
+        return self.online
+
+    def close(self):
+        self.state["ready"] = False
+
+
+@pytest.fixture
+def cat():
+    """A TciCAT wired to a stub, bypassing __init__'s real client."""
+    instance = TciCAT.__new__(TciCAT)
+    instance.interface = "tci"
+    instance.host = "127.0.0.1"
+    instance.port = 50001
+    instance.online = False
+    instance.client = StubClient()
+    return instance
+
+
+def go_online(cat, **state):
+    cat.client.state["ready"] = True
+    cat.client.state.update(state)
+
+
+# ---- offline behavior: the contract that keeps stale data off the screen ----
+
+
+@pytest.mark.parametrize("getter", ["get_vfo", "get_mode", "get_bw"])
+def test_getters_return_empty_when_offline(cat, getter):
+    assert getattr(cat, getter)() == ""
+
+
+def test_getters_return_empty_even_when_cache_holds_stale_values(cat):
+    """Radio only overwrites on truthy results, so empty means 'hold last
+    known' rather than painting a frozen frequency as live."""
+    cat.client.state.update({"vfo": "14030000", "mode": "CW", "bw": "500"})
+    assert cat.get_vfo() == ""
+    assert cat.get_mode() == ""
+    assert cat.get_bw() == ""
+
+
+def test_online_flag_tracks_the_client(cat):
+    cat.get_vfo()
+    assert cat.online is False
+    go_online(cat)
+    cat.get_vfo()
+    assert cat.online is True
+
+
+def test_setters_send_nothing_when_offline(cat):
+    cat.set_vfo("14030000")
+    cat.set_mode("CW")
+    cat.ptt_on()
+    assert cat.client.sent == []
+
+
+# ---- online behavior ----
+
+
+def test_get_vfo_returns_cached_numeric_value(cat):
+    go_online(cat, vfo="14030000")
+    assert cat.get_vfo() == "14030000"
+    assert cat.get_vfo().isnumeric()
+
+
+def test_get_mode_returns_cached_value(cat):
+    go_online(cat, mode="CW")
+    assert cat.get_mode() == "CW"
+
+
+def test_get_bw_returns_cached_value(cat):
+    go_online(cat, bw="1000")
+    assert cat.get_bw() == "1000"
+
+
+def test_get_ptt_returns_zero_when_offline(cat):
+    assert cat.get_ptt() == "0"
+
+
+def test_get_mode_list_available_regardless_of_online_state(cat):
+    cat.client.state["modes"] = ["CW", "USB"]
+    assert cat.get_mode_list() == ["CW", "USB"]
+
+
+def test_set_vfo_sends_tci_command(cat):
+    go_online(cat)
+    assert cat.set_vfo("14030000") is True
+    assert cat.client.sent == ["vfo:0,0,14030000;"]
+
+
+def test_set_mode_translates_to_tci_naming(cat):
+    go_online(cat)
+    cat.set_mode("CW")
+    cat.set_mode("RTTY")
+    assert cat.client.sent == ["modulation:0,cw;", "modulation:0,rtty;"]
+
+
+def test_ptt_on_and_off(cat):
+    go_online(cat)
+    cat.ptt_on()
+    cat.ptt_off()
+    assert cat.client.sent == ["trx:0,true;", "trx:0,false;"]
+
+
+def test_set_cw_speed_sends_macros_speed(cat):
+    go_online(cat)
+    cat.set_cw_speed(25)
+    assert cat.client.sent == ["cw_macros_speed:25;"]
+
+
+def test_sendcw_sends_text(cat):
+    go_online(cat)
+    cat.sendcw("CQ TEST")
+    assert cat.client.sent == ["cw_msg:0,,,CQ TEST;"]
+
+
+def test_close_delegates_to_client(cat):
+    go_online(cat)
+    cat.close()
+    assert cat.client.online is False

--- a/test/cat_tci_tests.py
+++ b/test/cat_tci_tests.py
@@ -8,6 +8,7 @@ class StubClient:
 
     def __init__(self):
         self.sent = []
+        self.close_called = False
         self.state = {
             "vfo": "",
             "mode": "",
@@ -32,6 +33,7 @@ class StubClient:
         return self.online
 
     def close(self):
+        self.close_called = True
         self.state["ready"] = False
 
 
@@ -147,4 +149,4 @@ def test_sendcw_sends_text(cat):
 def test_close_delegates_to_client(cat):
     go_online(cat)
     cat.close()
-    assert cat.client.online is False
+    assert cat.client.close_called is True

--- a/test/tci_client_tests.py
+++ b/test/tci_client_tests.py
@@ -1,0 +1,105 @@
+import pytest
+
+from not1mm.lib.tci_client import TCIClient
+
+
+@pytest.fixture
+def client():
+    """A client whose thread never starts, so only the cache logic is exercised.
+
+    autostart=False rather than bypassing __init__: TCIClient is a QObject, and
+    building one via __new__ leaves the C++ side uninitialized, which PyQt6
+    rejects with "'__init__' method of object's base class not called".
+    """
+    return TCIClient("127.0.0.1", 50001, autostart=False)
+
+
+def test_starts_offline_with_empty_state(client):
+    assert client.online is False
+    assert client.get("vfo") == ""
+    assert client.get("mode") == ""
+    assert client.get("modes") == []
+
+
+def test_ready_frame_brings_client_online(client):
+    client.handle_frame("ready", [])
+    assert client.online is True
+
+
+def test_vfo_frame_updates_cache(client):
+    client.handle_frame("vfo", ["0", "0", "14030000"])
+    assert client.get("vfo") == "14030000"
+
+
+def test_vfo_value_is_numeric_for_radio_module(client):
+    client.handle_frame("vfo", ["0", "0", "14030000"])
+    assert client.get("vfo").isnumeric()
+
+
+def test_non_numeric_vfo_is_rejected(client):
+    client.handle_frame("vfo", ["0", "0", "14.030"])
+    assert client.get("vfo") == ""
+
+
+def test_vfo_for_other_trx_is_ignored(client):
+    client.handle_frame("vfo", ["1", "0", "14030000"])
+    assert client.get("vfo") == ""
+
+
+def test_vfo_for_channel_b_is_ignored(client):
+    client.handle_frame("vfo", ["0", "1", "7020000"])
+    assert client.get("vfo") == ""
+
+
+def test_modulation_frame_is_normalized(client):
+    client.handle_frame("modulation", ["0", "cw"])
+    assert client.get("mode") == "CW"
+
+
+def test_rx_filter_band_becomes_bandwidth(client):
+    client.handle_frame("rx_filter_band", ["0", "-500", "500"])
+    assert client.get("bw") == "1000"
+
+
+def test_unparseable_filter_band_leaves_bandwidth_untouched(client):
+    client.handle_frame("rx_filter_band", ["0", "-500", "500"])
+    client.handle_frame("rx_filter_band", ["0", "junk", "500"])
+    assert client.get("bw") == "1000"
+
+
+@pytest.mark.parametrize("value, expected", [("true", "1"), ("false", "0"), ("TRUE", "1")])
+def test_trx_frame_sets_ptt(client, value, expected):
+    client.handle_frame("trx", ["0", value])
+    assert client.get("ptt") == expected
+
+
+def test_modulations_list_is_normalized(client):
+    client.handle_frame("modulations_list", ["cw", "lsb", "usb", "digl"])
+    assert client.get("modes") == ["CW", "LSB", "USB", "DIGI-L"]
+
+
+def test_unknown_frames_are_ignored_without_raising(client):
+    client.handle_frame("iq_samplerate", ["48000"])
+    client.handle_frame("audio_start", [])
+    assert client.get("vfo") == ""
+
+
+def test_clear_state_drops_everything_including_ready(client):
+    client.handle_frame("ready", [])
+    client.handle_frame("vfo", ["0", "0", "14030000"])
+    client.clear_state()
+    assert client.online is False
+    assert client.get("vfo") == ""
+
+
+def test_clear_state_preserves_mode_list(client):
+    """Supported modes are a device property, not volatile state."""
+    client.handle_frame("modulations_list", ["cw", "usb"])
+    client.clear_state()
+    assert client.get("modes") == ["CW", "USB"]
+
+
+def test_get_modes_returns_a_copy(client):
+    client.handle_frame("modulations_list", ["cw"])
+    client.get("modes").append("BOGUS")
+    assert client.get("modes") == ["CW"]

--- a/test/tci_client_tests.py
+++ b/test/tci_client_tests.py
@@ -1,4 +1,7 @@
+import sys
+
 import pytest
+from PyQt6.QtCore import QCoreApplication, QTimer
 
 from not1mm.lib.tci_client import TCIClient
 
@@ -12,6 +15,78 @@ def client():
     rejects with "'__init__' method of object's base class not called".
     """
     return TCIClient("127.0.0.1", 50001, autostart=False)
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    """QTimer.start() needs a live QCoreApplication: without one it silently
+    no-ops and isActive() never flips true, so schedule_reconnect's isActive()
+    guard -- the thing the backoff regression test below depends on -- could
+    not be exercised at all."""
+    app = QCoreApplication.instance()
+    if app is None:
+        app = QCoreApplication(sys.argv)
+    return app
+
+
+@pytest.fixture
+def client_with_timer(qt_app):
+    """A client with a real QTimer standing in for reconnect_timer, the way
+    open_socket() wires it on the TCI thread. Built by hand because
+    autostart=False skips open_socket() entirely."""
+    reconnecting_client = TCIClient("127.0.0.1", 50001, autostart=False)
+    reconnecting_client.reconnect_timer = QTimer()
+    reconnecting_client.reconnect_timer.setSingleShot(True)
+    reconnecting_client.reconnect_timer.timeout.connect(
+        reconnecting_client.connect_to_server
+    )
+    return reconnecting_client
+
+
+class RecordingSocket:
+    """Stands in for QWebSocket: records what would have been sent."""
+
+    def __init__(self):
+        self.sent = []
+
+    def sendTextMessage(self, message):
+        self.sent.append(message)
+
+
+def test_schedule_reconnect_advances_backoff_by_one_per_call(client_with_timer):
+    """Regression test for a bug where `self.backoff += 1` lived outside the
+    isActive() guard: one connection failure fires both on_error and
+    on_disconnected, both call schedule_reconnect(), and the counter
+    double-advanced -- turning the intended 1000, 2000, 5000 ms ladder into
+    1000, 5000, 5000, skipping the 2000 ms rung entirely. The guard must make
+    a second call while the timer from the first is still pending a no-op.
+    """
+    client = client_with_timer
+    assert client.backoff == 0
+
+    client.schedule_reconnect()
+    assert client.backoff == 1
+
+    # Simulate on_error and on_disconnected both firing for the same failure
+    # while the first call's timer is still pending.
+    client.schedule_reconnect()
+    assert client.backoff == 1
+
+    client.reconnect_timer.stop()
+    client.schedule_reconnect()
+    assert client.backoff == 2
+
+
+def test_write_command_refuses_to_send_while_offline(client):
+    """Even with a live socket object, write_command must not touch it until
+    the handshake has completed -- an offline client has nothing to write
+    to, regardless of whether a socket happens to exist."""
+    client.socket = RecordingSocket()
+    assert client.online is False
+
+    client.write_command("vfo:0,0,14030000;")
+
+    assert client.socket.sent == []
 
 
 def test_starts_offline_with_empty_state(client):

--- a/test/tci_client_tests.py
+++ b/test/tci_client_tests.py
@@ -103,3 +103,30 @@ def test_get_modes_returns_a_copy(client):
     client.handle_frame("modulations_list", ["cw"])
     client.get("modes").append("BOGUS")
     assert client.get("modes") == ["CW"]
+
+
+def test_on_text_message_applies_every_frame_in_one_payload(client):
+    payload = "device:FakeSDR;modulations_list:cw,usb;vfo:0,0,14030000;ready;"
+    client.on_text_message(payload)
+    assert client.get("modes") == ["CW", "USB"]
+    assert client.get("vfo") == "14030000"
+    assert client.online is True
+
+
+def test_on_text_message_skips_unparseable_fragment_without_raising(client):
+    # ":bogus" parses to an empty command name -- parse_frame returns None
+    # for it -- while the frames around it are valid and must still apply.
+    payload = "vfo:0,0,14030000;:bogus;ready;"
+    client.on_text_message(payload)
+    assert client.get("vfo") == "14030000"
+    assert client.online is True
+
+
+def test_clear_state_resets_ptt(client):
+    client.handle_frame("trx", ["0", "true"])
+    client.clear_state()
+    assert client.get("ptt") == "0"
+
+
+def test_wait_for_ready_times_out_when_never_online(client):
+    assert client.wait_for_ready(100) is False

--- a/test/tci_protocol_tests.py
+++ b/test/tci_protocol_tests.py
@@ -1,0 +1,133 @@
+import pytest
+
+from not1mm.lib.tci_protocol import (
+    bandwidth_from_filter_band,
+    build_command,
+    not1mm_mode_to_tci,
+    parse_frame,
+    split_frames,
+    tci_mode_to_not1mm,
+)
+
+
+@pytest.mark.parametrize(
+    "frame, expected",
+    [
+        ("vfo:0,0,14030000;", ("vfo", ["0", "0", "14030000"])),
+        ("ready;", ("ready", [])),
+        ("trx:0,true;", ("trx", ["0", "true"])),
+        ("rx_filter_band:0,-500,500;", ("rx_filter_band", ["0", "-500", "500"])),
+        ("  vfo:0,0,14030000;  ", ("vfo", ["0", "0", "14030000"])),
+        ("VFO:0,0,14030000;", ("vfo", ["0", "0", "14030000"])),
+        ("vfo:0,0,14030000", None),  # no terminator
+        (";", None),
+        ("", None),
+        (":1,2;", None),  # empty command name
+    ],
+)
+def test_parse_frame(frame, expected):
+    assert parse_frame(frame) == expected
+
+
+def test_split_frames_handles_multiple_commands_in_one_payload():
+    payload = "device:AetherSDR;trx_count:1;ready;"
+    assert split_frames(payload) == ["device:AetherSDR;", "trx_count:1;", "ready;"]
+
+
+def test_split_frames_ignores_trailing_whitespace_fragment():
+    assert split_frames("ready;\n") == ["ready;"]
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        (("vfo", 0, 0, 14030000), "vfo:0,0,14030000;"),
+        (("modulation", 0, "cw"), "modulation:0,cw;"),
+        (("trx", 0, "true"), "trx:0,true;"),
+        (("cw_macros_speed", 25), "cw_macros_speed:25;"),
+        (("stop",), "stop;"),
+    ],
+)
+def test_build_command(args, expected):
+    assert build_command(*args) == expected
+
+
+def test_build_command_roundtrips_through_parse_frame():
+    assert parse_frame(build_command("vfo", 0, 0, 14030000)) == (
+        "vfo",
+        ["0", "0", "14030000"],
+    )
+
+
+@pytest.mark.parametrize(
+    "tci, not1mm",
+    [
+        ("cw", "CW"),
+        ("cwr", "CWR"),
+        ("lsb", "LSB"),
+        ("usb", "USB"),
+        ("digl", "DIGI-L"),
+        ("digu", "DIGI-U"),
+        ("rtty", "RTTY"),
+        ("fm", "FM"),
+        ("nfm", "NFM"),
+        ("CW", "CW"),  # case insensitive
+    ],
+)
+def test_tci_mode_to_not1mm(tci, not1mm):
+    assert tci_mode_to_not1mm(tci) == not1mm
+
+
+def test_fm_and_nfm_do_not_collide():
+    """AetherSDR offers both; folding them together loses one on the way back."""
+    assert tci_mode_to_not1mm("fm") != tci_mode_to_not1mm("nfm")
+
+
+def test_tci_mode_to_not1mm_passes_through_unknown_modes_uppercased():
+    assert tci_mode_to_not1mm("someNewMode") == "SOMENEWMODE"
+
+
+@pytest.mark.parametrize(
+    "not1mm, tci",
+    [
+        ("CW", "cw"),
+        ("CWR", "cwr"),
+        ("USB", "usb"),
+        ("DIGI-L", "digl"),
+        ("RTTY", "rtty"),  # native on AetherSDR, not remapped to digl
+        ("FM", "fm"),
+        ("NFM", "nfm"),
+    ],
+)
+def test_not1mm_mode_to_tci(not1mm, tci):
+    assert not1mm_mode_to_tci(not1mm) == tci
+
+
+def test_mode_translation_roundtrips_for_every_known_tci_mode():
+    from not1mm.lib.tci_protocol import TCI_TO_NOT1MM_MODE
+
+    for tci in TCI_TO_NOT1MM_MODE:
+        assert not1mm_mode_to_tci(tci_mode_to_not1mm(tci)) == tci
+
+
+def test_cw_and_data_modes_match_radio_module_expectations():
+    """Radio matches get_mode_list() against these lists by exact string."""
+    from not1mm.radio import Radio
+
+    assert tci_mode_to_not1mm("cw") in Radio.cw_list
+    assert tci_mode_to_not1mm("digl") in Radio.rtty_list
+
+
+@pytest.mark.parametrize(
+    "low, high, expected",
+    [
+        ("-500", "500", "1000"),
+        ("300", "2700", "2400"),
+        ("500", "-500", "1000"),  # order independent
+        ("0", "0", "0"),
+        ("junk", "500", ""),
+        ("", "", ""),
+    ],
+)
+def test_bandwidth_from_filter_band(low, high, expected):
+    assert bandwidth_from_filter_band(low, high) == expected


### PR DESCRIPTION
Adds TCI (Transceiver Control Interface) as a fourth CAT backend, so SDRs speaking TCI — AetherSDR, ExpertSDR — can be used as the rig alongside flrig and rigctld.

Select **TCI** on the rig control tab; default port 50001. CW keying works by additionally selecting the existing **CW via CAT** option.

## The design problem

TCI is asynchronous and push-based: the radio broadcasts `vfo:0,0,14030000;` whenever something changes, and replies are not correlated to requests. not1mm's `CAT` contract is the opposite — synchronous getters called from `Radio.run()`'s blocking loop, which never returns to a Qt event loop.

The bridge is a state cache. A `QWebSocket` on its own `QThread` maintains a mutex-guarded dict of last-known state; the synchronous getters read that dict. `Radio.run()`'s existing 555 ms poll is unmodified, and the data it sees is fresher than a query would return, since updates arrive when the radio changes rather than when we ask.

Three new modules, split so the fiddly parts stay testable:

| File | Responsibility |
|---|---|
| `not1mm/lib/tci_protocol.py` | Pure functions — frame parse/split, command building, mode translation. No Qt, no sockets. |
| `not1mm/lib/tci_client.py` | `QWebSocket` on its own `QThread`, state cache, reconnect backoff, shutdown. |
| `not1mm/lib/cat_tci.py` | `TciCAT(CAT)` — maps the CAT contract onto the client. |

The existing three backends are untouched.

## Notes for review

**Offline returns empty, never stale cache.** `Radio.run()` only overwrites its values on a truthy result, so returning `""` makes the UI hold the last reading and report offline. Returning cached values would paint a dead radio as live mid-contest.

**Shutdown.** `TciCAT` owns a second `QThread`, so it must be closed or the app hangs on exit. Both teardown paths in `__main__.py` use an identical `time_to_quit` → `quit()` → `wait(1000)` sequence, so the close hook sits at the end of `Radio.run()`'s loop and covers both with one insertion. It uses `getattr(self.cat, "close", None)`, so the other backends — which have no `close()` — are unaffected. Worst case is 100 ms loop wake + 500 ms client wait, inside the 1000 ms budget.

**`send_cat_string` added as a no-op on the base `CAT`.** `__main__.py` calls it for `RI:` macros, but it only existed on `FlrigCAT`/`RigctldCAT` — so an `RI:` macro already raised `AttributeError` under the `fake` backend. This closes that hole rather than adding a fourth partial implementation.

**`vfo.py` also wired**, so the USB VFO knob works with TCI rather than silently doing nothing.

## Protocol facts came from a live radio, not the docs

`not1mm/testing/tci_probe.py` captures a real handshake; the recorded transcript and findings are in `docs/superpowers/specs/2026-08-01-tci-handshake.md`. That capture corrected three assumptions that would otherwise have shipped as bugs:

- The mode list command is **`modulations_list`** (plural). Parsing the singular would leave `get_mode_list()` permanently empty and break `Radio.__init__`'s `cw_list`/`rtty_list` scan.
- AetherSDR exposes **both `fm` and `nfm`** — folding `nfm` into `FM` collides, and the reverse map loses `fm`.
- AetherSDR has a **native `rtty`** mode, so `RTTY` maps straight through instead of being remapped to `digl`.

It also showed 279 of 338 frames in a 60-second window are `rx_smeter` noise, which is why unknown frames are logged at debug and dropped.

## Testing

116 tests across `test/tci_protocol_tests.py`, `test/tci_client_tests.py`, `test/cat_tci_tests.py`.

Note these are named `*_tests.py` to match the existing `plugin_wag_tests.py` convention — which means plain `pytest test/` collects **zero** tests, since that does not match pytest's default `test_*.py` patterns. Run `pytest test/*_tests.py` (this affects the pre-existing suite too, not just these files).

`not1mm/testing/faketci.py` is a minimal TCI server, following the `fakeflrig.py` precedent, that exercises the real socket and thread paths without an SDR: handshake, `set_vfo` round-trip, offline behavior with the server dead, and reconnect after restart.

## What is verified, and what is not

Verified against a live AetherSDR: the handshake completes, the client connects and stays connected, frequency/mode/bandwidth read correctly, and **CW keying works** — a macro keys the radio and sends its text through `cw_msg:0,,,<text>;`. That last one was the least-certain line in the implementation, since the read-only probe could never exercise it.

Verified against the fake server: offline returns empty rather than stale, reconnect recovers within ~1 s, and shutdown is clean with no Qt thread warnings.

**One item remains unconfirmed**, and it fails soft: whether `modulation:`, `rx_filter_band:`, and `trx:` push updates *unprompted*. Their argument formats are confirmed from the handshake dump, and setting them from not1mm works — but no unsolicited push of the three was captured. If AetherSDR does not push them, the cache keeps its handshake values while `vfo:` continues to drive the display.

## Scope

TRX 0 / channel 0 (VFO A) only. Multi-receiver, VFO B, TCI audio and IQ streaming, and not1mm acting as a TCI server are all out of scope. Pushing bandmap spots to the SDR panadapter via TCI `spot:` is a natural follow-up and is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
