### PR TITLE
Move SPOTDX to clusterwindow.py

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -2714,8 +2714,8 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.bandmap_window.msg_from_main(cmd)
 
     def spot_dx(self) -> None:
-        """If a bandmap_window exists, send it a SPOTDX command to forward info to the cluster."""
-        if self.bandmap_window:
+        """Build a SPOTDX command and send it to the cluster window."""
+        if self.cluster_window:
             freq = self.radio_state.get("vfoa")
             dx = self.callsign.text()
             if freq and dx:
@@ -2729,7 +2729,7 @@ class MainWindow(QtWidgets.QMainWindow):
             else:
                 cmd = None
             if cmd:
-                self.bandmap_window.msg_from_main(cmd)
+                self.cluster_window.msg_from_main(cmd)
 
     def get_sn(self) -> None:
         """Generate a serial number."""

--- a/not1mm/actions.py
+++ b/not1mm/actions.py
@@ -103,8 +103,8 @@ def SPOT_DX(self) -> None:
         cmd["cmd"] = "SPOTDX"
         cmd["dx"] = dx
         cmd["freq"] = float(int(freq) / 1000)
-        if self.bandmap_window:
-            self.bandmap_window.msg_from_main(cmd)
+        if self.cluster_window:
+            self.cluster_window.msg_from_main(cmd)
 
 
 def MARK_SPOT(self) -> None:

--- a/not1mm/bandmap.py
+++ b/not1mm/bandmap.py
@@ -513,12 +513,7 @@ class BandMapWindow(QDockWidget):
                 cmd["spot"] = spot.get("callsign", "")
                 self.message.emit(cmd)
             return
-        if packet.get("cmd", "") == "SPOTDX":
-            dx = packet.get("dx", "")
-            freq = packet.get("freq", 0.0)
-            spotdx = f"dx {dx} {freq}"
-            self.send_command(spotdx)
-            return
+
         if packet.get("cmd", "") == "DX":
             spot = packet
             spot["callsign"] = packet.get("dx", "")  # rename field

--- a/not1mm/clusterwindow.py
+++ b/not1mm/clusterwindow.py
@@ -184,6 +184,16 @@ class ClusterWindow(QDockWidget):
         self.cluster_send(data)
         self.clusterInput.clear()
 
+    def msg_from_main(self, packet):
+        """Process messages from the main screen."""
+
+        if packet.get("cmd", "") == "SPOTDX":
+            if "dx" in packet and "freq" in packet:
+                dx = packet.get("dx")
+                freq = packet.get("freq")
+                spotdx = f"dx {dx} {freq}"
+                self.cluster_send(spotdx)
+
     def closeEvent(self, _event: QtGui.QCloseEvent) -> None:
         """Triggered when instance closes. Cluster connection stays open."""
         self.action.setChecked(False)


### PR DESCRIPTION
send_command is now called cluster_send and moved to a different class. Bug introduced by me in 591fb4d3a.

Fix #642.