### PR TITLE
Consolidate band/frequency conversion into a single source-of-truth table

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -125,7 +125,6 @@ class MainWindow(QtWidgets.QMainWindow):
     """
 
     ctyfile: typing.ClassVar = {}
-    appstarted = False
     contact: typing.ClassVar = {}
     contest = None
     contest_settings: typing.ClassVar = {}
@@ -134,21 +133,15 @@ class MainWindow(QtWidgets.QMainWindow):
     station: typing.ClassVar = {}
     spaceweather = ""
     current_mode = ""
-    current_band = ""
-    default_rst = "59"
     cw = None
-    look_up = None
     run_state = False
     fkeys: typing.ClassVar = {}
     about_dialog = None
-    qrz_dialog = None
     settings_dialog = None
     edit_macro_dialog = None
     edit_keys_dialog = None
     contest_dialog = None
     configuration_dialog = None
-    opon_dialog = None
-    rove_dialog = None
     dbname = fsutils.USER_DATA_PATH, "/ham.db"
     radio_state: typing.ClassVar = {}
     worked_list: typing.ClassVar = {}
@@ -180,7 +173,6 @@ class MainWindow(QtWidgets.QMainWindow):
     dxcc_window = None
     zone_window = None
     rotator_window = None
-    voice_window = None
     settings = None
     lookup_service = None
     fldigi_util = None

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -459,206 +459,212 @@ class MainWindow(QtWidgets.QMainWindow):
         self.F12.clicked.connect(lambda x: self.process_function_key(self.F12))
 
         self.cw_band_160.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            160, "CW"
+            "160m", "CW"
         )
         self.cw_band_80.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            80, "CW"
+            "80m", "CW"
         )
         self.cw_band_60.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            60, "CW"
+            "60m", "CW"
         )
         self.cw_band_40.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            40, "CW"
+            "40m", "CW"
         )
         self.cw_band_30.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            30, "CW"
+            "30m", "CW"
         )
         self.cw_band_20.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            20, "CW"
+            "20m", "CW"
         )
         self.cw_band_17.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            17, "CW"
+            "17m", "CW"
         )
         self.cw_band_15.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            15, "CW"
+            "15m", "CW"
         )
         self.cw_band_12.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            12, "CW"
+            "12m", "CW"
         )
         self.cw_band_10.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            10, "CW"
+            "10m", "CW"
         )
-        self.cw_band_6.mousePressEvent = lambda x: self.change_to_band_and_mode(6, "CW")
-        self.cw_band_4.mousePressEvent = lambda x: self.change_to_band_and_mode(4, "CW")
-        self.cw_band_2.mousePressEvent = lambda x: self.change_to_band_and_mode(2, "CW")
+        self.cw_band_6.mousePressEvent = lambda x: self.change_to_band_and_mode(
+            "6m", "CW"
+        )
+        self.cw_band_4.mousePressEvent = lambda x: self.change_to_band_and_mode(
+            "4m", "CW"
+        )
+        self.cw_band_2.mousePressEvent = lambda x: self.change_to_band_and_mode(
+            "2m", "CW"
+        )
         self.cw_band_125.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            222, "CW"
+            "1.25m", "CW"
         )
         self.cw_band_70cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            432, "CW"
+            "70cm", "CW"
         )
         self.cw_band_33cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            902, "CW"
+            "33cm", "CW"
         )
         self.cw_band_23cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            1240, "CW"
+            "23cm", "CW"
         )
 
         self.ssb_band_160.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            160, "SSB"
+            "160m", "SSB"
         )
         self.ssb_band_80.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            80, "SSB"
+            "80m", "SSB"
         )
         self.ssb_band_60.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            60, "SSB"
+            "60m", "SSB"
         )
         self.ssb_band_40.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            40, "SSB"
+            "40m", "SSB"
         )
         self.ssb_band_20.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            20, "SSB"
+            "20m", "SSB"
         )
         self.ssb_band_17.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            17, "SSB"
+            "17m", "SSB"
         )
         self.ssb_band_15.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            15, "SSB"
+            "15m", "SSB"
         )
         self.ssb_band_12.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            12, "SSB"
+            "12m", "SSB"
         )
         self.ssb_band_10.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            10, "SSB"
+            "10m", "SSB"
         )
         self.ssb_band_6.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            6, "SSB"
+            "6m", "SSB"
         )
         self.ssb_band_4.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            4, "SSB"
+            "4m", "SSB"
         )
         self.ssb_band_2.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            2, "SSB"
+            "2m", "SSB"
         )
         self.ssb_band_125.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            222, "SSB"
+            "1.25m", "SSB"
         )
         self.ssb_band_70cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            432, "SSB"
+            "70cm", "SSB"
         )
         self.ssb_band_33cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            902, "SSB"
+            "33cm", "SSB"
         )
         self.ssb_band_23cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            1240, "SSB"
+            "23cm", "SSB"
         )
 
         self.rtty_band_160.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            160, "RTTY"
+            "160m", "RTTY"
         )
         self.rtty_band_80.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            80, "RTTY"
+            "80m", "RTTY"
         )
         self.rtty_band_60.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            60, "RTTY"
+            "60m", "RTTY"
         )
         self.rtty_band_40.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            40, "RTTY"
+            "40m", "RTTY"
         )
         self.rtty_band_30.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            30, "RTTY"
+            "30m", "RTTY"
         )
         self.rtty_band_20.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            20, "RTTY"
+            "20m", "RTTY"
         )
         self.rtty_band_17.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            17, "RTTY"
+            "17m", "RTTY"
         )
         self.rtty_band_15.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            15, "RTTY"
+            "15m", "RTTY"
         )
         self.rtty_band_12.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            12, "RTTY"
+            "12m", "RTTY"
         )
         self.rtty_band_10.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            10, "RTTY"
+            "10m", "RTTY"
         )
         self.rtty_band_6.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            6, "RTTY"
+            "6m", "RTTY"
         )
         self.rtty_band_4.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            4, "RTTY"
+            "4m", "RTTY"
         )
         self.rtty_band_2.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            2, "RTTY"
+            "2m", "RTTY"
         )
         self.rtty_band_125.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            222, "RTTY"
+            "1.25m", "RTTY"
         )
         self.rtty_band_70cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            432, "RTTY"
+            "70cm", "RTTY"
         )
         self.rtty_band_33cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            902, "RTTY"
+            "33cm", "RTTY"
         )
         self.rtty_band_23cm.mousePressEvent = lambda x: self.change_to_band_and_mode(
-            1240, "RTTY"
+            "23cm", "RTTY"
         )
 
         self.band_indicators_cw = {
-            "160": self.cw_band_160,
-            "80": self.cw_band_80,
-            "60": self.cw_band_60,
-            "40": self.cw_band_40,
-            "30": self.cw_band_30,
-            "20": self.cw_band_20,
-            "17": self.cw_band_17,
-            "15": self.cw_band_15,
-            "12": self.cw_band_12,
-            "10": self.cw_band_10,
-            "6": self.cw_band_6,
-            "4": self.cw_band_4,
-            "2": self.cw_band_2,
-            "1.25": self.cw_band_125,
+            "160m": self.cw_band_160,
+            "80m": self.cw_band_80,
+            "60m": self.cw_band_60,
+            "40m": self.cw_band_40,
+            "30m": self.cw_band_30,
+            "20m": self.cw_band_20,
+            "17m": self.cw_band_17,
+            "15m": self.cw_band_15,
+            "12m": self.cw_band_12,
+            "10m": self.cw_band_10,
+            "6m": self.cw_band_6,
+            "4m": self.cw_band_4,
+            "2m": self.cw_band_2,
+            "1.25m": self.cw_band_125,
             "70cm": self.cw_band_70cm,
             "33cm": self.cw_band_33cm,
             "23cm": self.cw_band_23cm,
         }
 
         self.band_indicators_ssb = {
-            "160": self.ssb_band_160,
-            "80": self.ssb_band_80,
-            "60": self.ssb_band_60,
-            "40": self.ssb_band_40,
-            "20": self.ssb_band_20,
-            "17": self.ssb_band_17,
-            "15": self.ssb_band_15,
-            "12": self.ssb_band_12,
-            "10": self.ssb_band_10,
-            "6": self.ssb_band_6,
-            "4": self.ssb_band_4,
-            "2": self.ssb_band_2,
-            "1.25": self.ssb_band_125,
+            "160m": self.ssb_band_160,
+            "80m": self.ssb_band_80,
+            "60m": self.ssb_band_60,
+            "40m": self.ssb_band_40,
+            "20m": self.ssb_band_20,
+            "17m": self.ssb_band_17,
+            "15m": self.ssb_band_15,
+            "12m": self.ssb_band_12,
+            "10m": self.ssb_band_10,
+            "6m": self.ssb_band_6,
+            "4m": self.ssb_band_4,
+            "2m": self.ssb_band_2,
+            "1.25m": self.ssb_band_125,
             "70cm": self.ssb_band_70cm,
             "33cm": self.ssb_band_33cm,
             "23cm": self.ssb_band_23cm,
         }
 
         self.band_indicators_rtty = {
-            "160": self.rtty_band_160,
-            "80": self.rtty_band_80,
-            "60": self.rtty_band_60,
-            "40": self.rtty_band_40,
-            "30": self.rtty_band_30,
-            "20": self.rtty_band_20,
-            "17": self.rtty_band_17,
-            "15": self.rtty_band_15,
-            "12": self.rtty_band_12,
-            "10": self.rtty_band_10,
-            "6": self.rtty_band_6,
-            "4": self.rtty_band_4,
-            "2": self.rtty_band_2,
-            "1.25": self.rtty_band_125,
+            "160m": self.rtty_band_160,
+            "80m": self.rtty_band_80,
+            "60m": self.rtty_band_60,
+            "40m": self.rtty_band_40,
+            "30m": self.rtty_band_30,
+            "20m": self.rtty_band_20,
+            "17m": self.rtty_band_17,
+            "15m": self.rtty_band_15,
+            "12m": self.rtty_band_12,
+            "10m": self.rtty_band_10,
+            "6m": self.rtty_band_6,
+            "4m": self.rtty_band_4,
+            "2m": self.rtty_band_2,
+            "1.25m": self.rtty_band_125,
             "70cm": self.rtty_band_70cm,
             "33cm": self.rtty_band_33cm,
             "23cm": self.rtty_band_23cm,
@@ -691,6 +697,17 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.show_splash_msg("Reading preferences.")
         self.pref = Preferences.load()
+
+        # Migrate legacy short-form band names ("160") to ADIF form ("160m")
+        # so band_indicators_* dict lookups work.
+        # If anything actually changed, write the new format to disk so the
+        # legacy form never reappears on subsequent loads.
+        _original_bands = self.pref.get("bands", [])
+        _migrated_bands = [f"{b}m" if b.isdigit() else b for b in _original_bands]
+        if _migrated_bands != _original_bands:
+            self.pref["bands"] = _migrated_bands
+            Preferences.save()
+
         self.apply_preferences()
 
         self.show_splash_msg("Starting LookUp Service.")
@@ -1640,23 +1657,28 @@ class MainWindow(QtWidgets.QMainWindow):
             self.cw.sendcw(newtext[len(self.oldtext) :])
         self.oldtext = newtext
 
-    def change_to_band_and_mode(self, band: int, mode: str) -> None:
+    def change_to_band_and_mode(self, band_name: str, mode: str) -> None:
         """
-        Gets a sane frequency for the chosen band and mode.
-        Then changes to that,
+        Look up a sensible frequency for the chosen band and mode via fakefreq(),
+        then push it to the rig (and bandmap) through change_freq() and change_mode().
+
+        Used by the on-screen band buttons (CW/SSB/RTTY x 17 bands). For modes other
+        than CW/SSB/RTTY the call is a no-op.
 
         Parameters
         ----------
-        band : int
+        band_name : str
+            ADIF band name, e.g. "20m", "70cm". Must be a key of the BANDS table.
         mode : str
+            One of "CW", "SSB", "RTTY" (others are silently ignored).
 
         Returns
         -------
-        Nothing
+        None
         """
 
         if mode in ["CW", "SSB", "RTTY"]:
-            freq = fakefreq(str(band), mode)
+            freq = fakefreq(band_name, mode)
             self.change_freq(freq)
             vfo = float(freq)
             vfo = int(vfo * 1000)
@@ -3936,12 +3958,12 @@ class MainWindow(QtWidgets.QMainWindow):
         # If bands list is empty fill it with HF.
         if self.pref.get("bands", []) == []:
             self.pref["bands"] = [
-                "160",
-                "80",
-                "40",
-                "20",
-                "15",
-                "10",
+                "160m",
+                "80m",
+                "40m",
+                "20m",
+                "15m",
+                "10m",
             ]
 
         # Hide all the bands and then show only the wanted bands.

--- a/not1mm/bandmap.py
+++ b/not1mm/bandmap.py
@@ -21,6 +21,7 @@ from PyQt6.QtGui import QColor, QColorConstants, QFont
 from PyQt6.QtWidgets import QDockWidget, QStyle
 
 from not1mm import fsutils
+from not1mm.lib.ham_utility import band2banddef, khz2banddef
 from not1mm.lib.preferences import Preferences
 
 # from not1mm.lib.multicast import Multicast
@@ -30,41 +31,6 @@ logger = logging.getLogger(__name__)
 PIXELSPERSTEP = 10
 UPDATE_INTERVAL = 2000
 CLEAR_FREQ = 0.1  # 100 Hz
-
-
-class Band:
-    """the band"""
-
-    bands = { # noqa: RUF012
-        "160m":     (1800,     2000,    1.8),
-        "80m":      (3500,     4000,    3.5),
-        "60m":      (5102,     5407,    5.1),
-        "40m":      (7000,     7300,    7.0),
-        "30m":     (10100,    10150,   10.0),
-        "20m":     (14000,    14350,   14.0),
-        "17m":     (18068,    18168,   18.0),
-        "15m":     (21000,    21450,   21.0),
-        "12m":     (24890,    24990,   24.0),
-        "10m":     (28000,    29700,   28.0),
-        "6m":      (50000,    54000,   50.0),
-        "4m":      (70000,    71000,   70.0),
-        "2m":    (144_000,  148_000,  144.0),
-        "70cm":  (420_000,  450_000,  432.0),
-        "33cm":  (902_000,  928_000,  932.0),
-        "23cm": (1240_000, 1300_000, 1232.0),
-    }  # fmt: skip
-
-    def __init__(self, band: str) -> None:
-        self.start, self.end, self.altname = self.bands.get(band, (0.0, 1.0, 0.0))
-        self.name = band
-
-    def new_from_freq(freq: float) -> (float, float):
-        """Find band matching a frequency."""
-
-        for band, edges in Band.bands.items():
-            if edges[0] <= freq <= edges[1]:
-                return Band(band)
-        return Band("unknown")
 
 
 class Database:
@@ -153,9 +119,9 @@ class Database:
         """
 
         if "band" in spot:
-            band = Band(spot.get("band"))
+            band = band2banddef(spot.get("band", ""), unknown_band=True)
         else:
-            band = Band.new_from_freq(spot.get("freq"))
+            band = khz2banddef(spot.get("freq"), unknown_band=True)
 
         try:
             delete_call_q = (
@@ -406,7 +372,7 @@ class BandMapWindow(QDockWidget):
         (4, 0),
         (10, 0),
     ]
-    currentBand = Band("20m")
+    currentBand = band2banddef("20m")
     txMark = []  # noqa: RUF012
     rxMark = []  # noqa: RUF012
     rx_freq = None
@@ -472,12 +438,7 @@ class BandMapWindow(QDockWidget):
         if self.active is False or not self.isVisible():
             return
         if packet.get("cmd", "") == "RADIO_STATE":
-            target_band_name = packet.get("band", "")
-            if len(target_band_name):
-                if target_band_name[-1:] == "m":
-                    self.set_band(target_band_name)
-                else:
-                    self.set_band(packet.get("band") + "m")
+            self.set_band(packet.get("band", ""))
             try:
                 if self.rx_freq != float(packet.get("vfoa")) / 1000:
                     self.rx_freq = float(packet.get("vfoa")) / 1000
@@ -621,6 +582,7 @@ class BandMapWindow(QDockWidget):
             ...
         # if self.active is False:
         #     return
+        self.setWindowTitle(f"BandMap: {self.currentBand.name}")
         self.clear_all_callsign_from_scene()
         self.clear_freq_mark(self.rxMark)
         self.clear_freq_mark(self.txMark)
@@ -801,7 +763,7 @@ class BandMapWindow(QDockWidget):
                         pen_color = QColor(0, 160, 0)
                 if items.get("callsign") in self.worked_list:
                     call_bandlist = self.worked_list.get(items.get("callsign"))
-                    if self.currentBand.altname in call_bandlist:
+                    if self.currentBand.band_mhz in call_bandlist:
                         pen_color = self.worked_color
                 freq_y = (
                     (items.get("freq") - self.currentBand.start) / step
@@ -853,8 +815,8 @@ class BandMapWindow(QDockWidget):
 
     def set_band(self, band: str) -> None:
         """Change band being shown."""
-        if band != self.currentBand.name:
-            self.currentBand = Band(band)
+        if band and band != self.currentBand.name:
+            self.currentBand = band2banddef(band, unknown_band=True)
             self.update()
 
     def spot_aging(self) -> None:

--- a/not1mm/lib/ham_utility.py
+++ b/not1mm/lib/ham_utility.py
@@ -3,6 +3,7 @@
 import logging
 import re
 import socket
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from math import asin, atan2, cos, pi, radians, sin, sqrt
@@ -85,334 +86,141 @@ def gridtolatlon(maiden):
         return 0, 0
 
 
-def getband(freq: str) -> str:
-    """
-    Convert a (string) frequency into a (string) band.
-    Returns a (string) band.
-    Returns a "0" if frequency is out of band.
-    """
-    # logger.info("getband: %s %s", type(freq), freq)
-    if freq.isnumeric():
-        frequency = int(float(freq))
-        if 2000000 >= frequency >= 1800000:
-            return "160"
-        if 4000000 >= frequency >= 3500000:
-            return "80"
-        if 5406000 >= frequency >= 5330000:
-            return "60"
-        if 7300000 >= frequency >= 7000000:
-            return "40"
-        if 10150000 >= frequency >= 10100000:
-            return "30"
-        if 14350000 >= frequency >= 14000000:
-            return "20"
-        if 18168000 >= frequency >= 18068000:
-            return "17"
-        if 21450000 >= frequency >= 21000000:
-            return "15"
-        if 24990000 >= frequency >= 24890000:
-            return "12"
-        if 29700000 >= frequency >= 28000000:
-            return "10"
-        if 54000000 >= frequency >= 50000000:
-            return "6"
-        if 70500000 >= frequency >= 70000000:
-            return "4"
-        if 148000000 >= frequency >= 144000000:
-            return "2"
-        if 225000000 >= frequency >= 222000000:
-            return "1.25"
-        if 450000000 >= frequency >= 420000000:
-            return "70cm"
-        if 928000000 >= frequency >= 902000000:
-            return "33cm"
-        if 1300000000 >= frequency >= 1240000000:
-            return "23cm"
-    return "0"
+@dataclass(frozen=True)
+class BandDef:
+    """A radio amateur band.
 
-
-def get_logged_band(freq: str) -> str:
-    """
-    Convert a (string) frequency into a (string) band.
-    Returns a (string) band.
-    Returns a "0" if frequency is out of band.
+    band_mhz is the canonical DXLOG.Band value (independent of band edges).
     """
 
-    if freq.isnumeric():
-        frequency = int(float(freq))
-        if 2000000 >= frequency >= 1800000:
-            return "1.8"
-        if 4000000 >= frequency >= 3500000:
-            return "3.5"
-        if 5406000 >= frequency >= 5330000:
-            return "5"
-        if 7300000 >= frequency >= 7000000:
-            return "7"
-        if 10150000 >= frequency >= 10100000:
-            return "10"
-        if 14350000 >= frequency >= 14000000:
-            return "14"
-        if 18168000 >= frequency >= 18068000:
-            return "18"
-        if 21450000 >= frequency >= 21000000:
-            return "21"
-        if 24990000 >= frequency >= 24890000:
-            return "24"
-        if 29700000 >= frequency >= 28000000:
-            return "28"
-        if 54000000 >= frequency >= 50000000:
-            return "50"
-        if 70500000 >= frequency >= 70000000:
-            return "70"
-        if 148000000 >= frequency >= 144000000:
-            return "144"
-        if 225000000 >= frequency >= 222000000:
-            return "222"
-        if 450000000 >= frequency >= 420000000:
-            return "432"
-        if 928000000 >= frequency >= 902000000:
-            return "902"
-        if 1300000000 >= frequency >= 1240000000:
-            return "1296"
-        if 10500000000 >= frequency >= 2300000000:
-            return "2300+"
-    return "0"
+    start: float  # kHz
+    end: float  # kHz
+    name: str  # "40m", "13cm"
+    band_mhz: float
+    cw_khz: int
+    digi_khz: int
+    ssb_khz: int
 
 
-def get_adif_band(freq: Decimal) -> str:
-    """xxx"""
-    if 7500000 >= freq >= 300000:
-        return "submm"
-    if 250000 >= freq >= 241000:
-        return "1mm"
-    if 149000 >= freq >= 134000:
-        return "2mm"
-    if 123000 >= freq >= 119980:
-        return "2.5mm"
-    if 81000 >= freq >= 75500:
-        return "4mm"
-    if 47200 >= freq >= 47000:
-        return "6mm"
-    if 24250 >= freq >= 24000:
-        return "1.25cm"
-    if 10500 >= freq >= 10000:
-        return "3cm"
-    if 5925 >= freq >= 5650:
-        return "6cm"
-    if 3500 >= freq >= 3300:
-        return "9cm"
-    if 2450 >= freq >= 2300:
-        return "13cm"
-    if 1300 >= freq >= 1240:
-        return "23cm"
-    if 928 >= freq >= 902:
-        return "33cm"
-    if 450 >= freq >= 420:
-        return "70cm"
-    if 225 >= freq >= 222:
-        return "1.25m"
-    if 148 >= freq >= 144:
-        return "2m"
-    if 71 >= freq >= 70:
-        return "4m"
-    if 69.9 >= freq >= 54.000001:
-        return "5m"
-    if 54 >= freq >= 50:
-        return "6m"
-    if 45 >= freq >= 40:
-        return "8m"
-    if 29.7 >= freq >= 28.0:
-        return "10m"
-    if 24.99 >= freq >= 24.890:
-        return "12m"
-    if 21.45 >= freq >= 21.0:
-        return "15m"
-    if 18.168 >= freq >= 18.068:
-        return "17m"
-    if 14.35 >= freq >= 14.0:
-        return "20m"
-    if 10.15 >= freq >= 10.1:
-        return "30m"
-    if 7.3 >= freq >= 7.0:
-        return "40m"
-    if 5.45 >= freq >= 5.06:
-        return "60m"
-    if 4.0 >= freq >= 3.5:
-        return "80m"
-    if 2.0 >= freq >= 1.8:
-        return "160m"
-    if 0.504 >= freq >= 0.501:
-        return "560m"
-    if 0.479 >= freq >= 0.472:
-        return "630m"
-    if 0.1378 >= freq >= 0.1357:
-        return "2190m"
-    return "0m"
+BANDS: tuple[BandDef, ...] = (
+    #       start (kHz)     end (kHz)      name      band_mhz  cw_khz     digi_khz   ssb_khz
+    #       -------------  --------------  --------  --------  ---------  ---------  ---------
+    BandDef(        135.7,          137.8,  "2190m",     0.137,         0,         0,         0),
+    BandDef(        472.0,          479.0,   "630m",     0.472,         0,         0,         0),
+    BandDef(        501.0,          504.0,   "560m",     0.502,         0,         0,         0),
+    BandDef(      1_800.0,        2_000.0,   "160m",       1.8,      1830,      1805,      1840),
+    BandDef(      3_500.0,        4_000.0,    "80m",       3.5,      3530,      3559,      3970),
+    BandDef(      5_060.0,        5_450.0,    "60m",       5.0,      5332,      5373,      5405),
+    BandDef(      7_000.0,        7_300.0,    "40m",       7.0,      7030,      7040,      7250),
+    BandDef(     10_100.0,       10_150.0,    "30m",      10.0,    10_130,    10_130,    10_130),
+    BandDef(     14_000.0,       14_350.0,    "20m",      14.0,    14_030,    14_070,    14_250),
+    BandDef(     18_068.0,       18_168.0,    "17m",      18.0,    18_080,    18_100,    18_150),
+    BandDef(     21_000.0,       21_450.0,    "15m",      21.0,    21_065,    21_070,    21_200),
+    BandDef(     24_890.0,       24_990.0,    "12m",      24.0,    24_911,    24_920,    24_970),
+    BandDef(     28_000.0,       29_700.0,    "10m",      28.0,    28_065,    28_070,    28_400),
+    BandDef(     40_000.0,       45_000.0,     "8m",      40.0,         0,         0,         0),
+    BandDef(     50_000.0,       54_000.0,     "6m",      50.0,    50_030,    50_300,    50_125),
+    BandDef(     54_000.0,       69_900.0,     "5m",      54.0,         0,         0,         0),
+    BandDef(     70_000.0,       71_000.0,     "4m",      70.0,    70_030,    70_300,    70_125),
+    BandDef(    144_000.0,      148_000.0,     "2m",     144.0,   144_030,   144_144,   144_250),
+    BandDef(    222_000.0,      225_000.0,  "1.25m",     222.0,   222_100,   222_070,   222_100),
+    BandDef(    420_000.0,      450_000.0,   "70cm",     432.0,   432_070,   432_200,   432_100),
+    BandDef(    902_000.0,      928_000.0,   "33cm",     902.0,   902_100,   902_100,   902_100),
+    BandDef(  1_240_000.0,    1_300_000.0,   "23cm",    1296.0, 1_296_100, 1_296_100, 1_296_100),
+    BandDef(  2_300_000.0,    2_450_000.0,   "13cm",    2300.0,         0,         0,         0),
+    BandDef(  3_300_000.0,    3_500_000.0,    "9cm",    3300.0,         0,         0,         0),
+    BandDef(  5_650_000.0,    5_925_000.0,    "6cm",    5650.0,         0,         0,         0),
+    BandDef( 10_000_000.0,   10_500_000.0,    "3cm",  10_000.0,         0,         0,         0),
+    BandDef( 24_000_000.0,   24_250_000.0, "1.25cm",  24_000.0,         0,         0,         0),
+    BandDef( 47_000_000.0,   47_200_000.0,    "6mm",  47_000.0,         0,         0,         0),
+    BandDef( 75_500_000.0,   81_000_000.0,    "4mm",  75_500.0,         0,         0,         0),
+    BandDef(119_980_000.0,  123_000_000.0,  "2.5mm", 119_980.0,         0,         0,         0),
+    BandDef(134_000_000.0,  149_000_000.0,    "2mm", 134_000.0,         0,         0,         0),
+    BandDef(241_000_000.0,  250_000_000.0,    "1mm", 241_000.0,         0,         0,         0),
+    BandDef(300_000_000.0, 7500_000_000.0,  "submm", 300_000.0,         0,         0,         0),
+)  # fmt: skip
+
+_UNKNOWN_BAND = BandDef(0.0, 1.0, "unknown", 0.0, 0, 0, 0)
+_BY_BAND_NAME: dict[str, BandDef] = {b.name: b for b in BANDS}
+_BY_BAND_MHZ: dict[float, BandDef] = {b.band_mhz: b for b in BANDS}
+
+
+def khz2banddef(freq_khz: Decimal, unknown_band=False) -> BandDef | None:
+    """Convert a frequency in kHz into a BandDef.
+
+    Returns None if the frequency is out of band unless unknown_band is True,
+    then returns _UNKNOWN_BAND (a 1 kHz window at 0 Hz).
+    """
+    for b in BANDS:
+        if b.start <= freq_khz < b.end:
+            return b
+    if unknown_band:
+        return _UNKNOWN_BAND
+    return None
+
+
+def band2banddef(band_name: str, unknown_band=False) -> BandDef | None:
+    """Look up band data for a given band name."""
+    if band := _BY_BAND_NAME.get(band_name):
+        return band
+    if unknown_band:
+        return _UNKNOWN_BAND
+    return None
+
+
+def getband(freq_hz: str) -> str:
+    """Convert a (string) frequency in Hz into a band name.
+
+    Returns "" if the frequency is out of band.
+    """
+    band = khz2banddef(Decimal(freq_hz) / 1000)
+    if band:
+        return band.name
+    return ""
+
+
+def get_logged_band(freq_hz: str) -> str:
+    """Convert a (string) frequency in Hz into a band_mhz (canonical DXLOG value).
+
+    Returns "0.0" if the frequency is out of band.
+    """
+    band = khz2banddef(Decimal(freq_hz) / 1000)
+    if band:
+        return str(band.band_mhz)
+    return "0.0"
+
+
+def get_adif_band(freq_mhz: Decimal) -> str:
+    """Convert a frequency in MHz into a band name.
+
+    Returns "" if the frequency is out of band.
+    """
+    band = khz2banddef(freq_mhz * 1000)
+    if band:
+        return band.name
+    return ""
 
 
 def get_not1mm_band(band: str) -> float:
-    if band == "2190m":
-        return 0.137
-    if band == "630m":
-        return 0.472
-    if band == "560m":
-        return 0.501
-    if band == "160m":
-        return 1.8
-    if band == "80m":
-        return 3.5
-    if band == "60m":
-        return 5.0
-    if band == "40m":
-        return 7.0
-    if band == "30m":
-        return 10.1
-    if band == "20m":
-        return 14.0
-    if band == "17m":
-        return 18.068
-    if band == "15m":
-        return 21.0
-    if band == "12m":
-        return 24.890
-    if band == "10m":
-        return 28.0
-    if band == "8m":
-        return 40.0
-    if band == "6m":
-        return 50.0
-    if band == "5m":
-        return 54.0
-    if band == "4m":
-        return 70.0
-    if band == "2m":
-        return 144.0
-    if band == "1.25m":
-        return 222.0
-    if band == "70cm":
-        return 420.0
-    if band == "33cm":
-        return 902.0
-    if band == "23cm":
-        return 1240.0
-    if band == "13cm":
-        return 2300.0
-    if band == "9cm":
-        return 3300.0
-    if band == "6cm":
-        return 5650.0
-    if band == "3cm":
-        return 10000.0
-    if band == "1.25cm":
-        return 24000.0
-    if band == "6mm":
-        return 47000.0
-    if band == "4mm":
-        return 75500.0
-    if band == "2.5mm":
-        return 119980.0
-    if band == "2mm":
-        return 134000.0
-    if band == "1mm":
-        return 241000.0
-    return 0.0
+    """Convert band name into band_mhz (canonical DXLOG value).
 
-
-def get_not1mm_band_xlog(band: str) -> float:
-    if band == "0.136":
-        return 0.137
-    if band == "0.472":
-        return 0.472
-    if band == "0.501":
-        return 0.501
-    if band == "1.8":
-        return 1.8
-    if band == "3.5":
-        return 3.5
-    if band == "5":
-        return 5.0
-    if band == "7":
-        return 7.0
-    if band == "10":
-        return 10.1
-    if band == "14":
-        return 14.0
-    if band == "18":
-        return 18.068
-    if band == "21":
-        return 21.0
-    if band == "24":
-        return 24.890
-    if band == "28":
-        return 28.0
-    if band == "50":
-        return 50.0
-    if band == "70":
-        return 70.0
-    if band == "144":
-        return 144.0
-    if band == "222":
-        return 222.0
-    if band == "420":
-        return 420.0
-    if band == "902":
-        return 902.0
-    if band == "1240":
-        return 1240.0
-    if band == "2300":
-        return 2300.0
-    if band == "3300":
-        return 3300.0
-    if band == "5650":
-        return 5650.0
-    if band == "10000":
-        return 10000.0
-    if band == "24000":
-        return 24000.0
-    if band == "47000":
-        return 47000.0
-    if band == "75500":
-        return 75500.0
-    if band == "120000":
-        return 119980.0
-    if band == "142000":
-        return 134000.0
-    if band == "241000":
-        return 241000.0
-    return "0"
-
-
-def fakefreq(band: str, mode: str) -> str:
+    Returns 0.0 if the band is unknown.
     """
-    If unable to obtain a frequency from the rig,
-    This will return a sane value for a frequency mainly for the cabrillo and adif log.
-    Takes a band and mode as input and returns freq in khz.
+    b = _BY_BAND_NAME.get(band)
+    return b.band_mhz if b else 0.0
+
+
+def fakefreq(band_name: str, mode: str) -> str:
+    """Return a sensible kHz-as-string frequency for cabrillo/ADIF when the rig is offline.
+
+    Looks up by ADIF band name (e.g., "20m"). Returns "" if band name is unknown
+    or the band has no fakefreq (cw_khz == 0). Unknown modes default to CW.
     """
-    # logger.info("fakefreq: band:%s mode:%s", band, mode)
-    modes = {"CW": 0, "RTTY": 1, "DG": 1, "PH": 2, "FT8": 1, "SSB": 2}
-    fakefreqs = {
-        "160": ["1830", "1805", "1840"],
-        "80": ["3530", "3559", "3970"],
-        "60": ["5332", "5373", "5405"],
-        "40": ["7030", "7040", "7250"],
-        "30": ["10130", "10130", "10130"],
-        "20": ["14030", "14070", "14250"],
-        "17": ["18080", "18100", "18150"],
-        "15": ["21065", "21070", "21200"],
-        "12": ["24911", "24920", "24970"],
-        "10": ["28065", "28070", "28400"],
-        "6": ["50030", "50300", "50125"],
-        "4": ["70030", "70300", "70125"],
-        "2": ["144030", "144144", "144250"],
-        "222": ["222100", "222070", "222100"],
-        "432": ["432070", "432200", "432100"],
-        "902": ["902100", "902100", "902100"],
-        "1240": ["1241000", "1241000", "1241000"],
-        "SAT": ["144144", "144144", "144144"],
-    }
-    freqtoreturn = fakefreqs[band][modes[mode]]
-    # logger.info("fakefreq: returning:%s", freqtoreturn)
-    return freqtoreturn
+    b = _BY_BAND_NAME.get(band_name)
+    if b is None or b.cw_khz == 0:
+        return ""
+    mode_idx = {"CW": 0, "RTTY": 1, "DG": 1, "PH": 2, "FT8": 1, "SSB": 2}.get(mode, 0)
+    return [str(b.cw_khz), str(b.digi_khz), str(b.ssb_khz)][mode_idx]
 
 
 def has_internet():

--- a/not1mm/lib/plugin_common.py
+++ b/not1mm/lib/plugin_common.py
@@ -11,7 +11,7 @@ import adif_io
 from PyQt6.QtCore import QCoreApplication, Qt
 from PyQt6.QtWidgets import QApplication, QDialog, QProgressDialog, QPushButton
 
-from not1mm.lib.ham_utility import get_adif_band, get_not1mm_band, get_not1mm_band_xlog
+from not1mm.lib.ham_utility import get_adif_band, get_not1mm_band
 from not1mm.lib.version import __version__
 
 logger = logging.getLogger(__name__)
@@ -108,8 +108,9 @@ def gen_adif(self, cabrillo_name: str, contest_id=""):
                     themode = "CW"
                 if cabrillo_name in ("CQ-WW-RTTY", "WEEKLY-RTTY"):
                     themode = "RTTY"
-                frequency = str(Decimal(str(contact.get("Freq", 0))) / 1000)
-                band = get_adif_band(Decimal(str(contact.get("Freq", 0))) / 1000)
+                freq_mhz = Decimal(str(contact.get("Freq", 0))) / 1000
+                frequency = str(freq_mhz)
+                band = get_adif_band(freq_mhz)
                 sentrst = contact.get("SNT", "")
                 rcvrst = contact.get("RCV", "")
                 sentnr = str(contact.get("SentNr", "0"))
@@ -449,6 +450,15 @@ def imp_adif(self):
 
         this_contact["Freq"] = freq_mhz * 1000.0
 
+        # ADIF Band is in Meters (eg, "20m"), not1mm is in (float) MHz
+        # 1st attempt: ADIF style like "18m"
+        if band := get_not1mm_band(str(q.get("BAND")).lower()):
+            this_contact["Band"] = band
+        else:
+            # convert the QSO frequency to a not1mm band float (0.0 when invalid)
+            band_name = get_adif_band(Decimal(str(freq_mhz)))
+            this_contact["Band"] = get_not1mm_band(band_name)
+
         if q.get("QSXFREQ"):
             this_contact["QSXFreq"] = float(q.get("QSXFREQ")) * 1000.0
         else:
@@ -538,29 +548,6 @@ def imp_adif(self):
             this_contact["Power"] = q.get("POWER")
         elif q.get("TX_PWR"):
             this_contact["Power"] = q.get("TX_PWR")
-
-        # ADIF Band is in Meters (eg, "20m"), not1mm is in (float) MHz
-        # xlog does not export a Band field, so Band should not be mandatory
-        # 1st attempt: ADIF style like "18m"
-        temp = str(q.get("BAND"))
-        temp = get_not1mm_band(temp.lower())
-        # 2nd attempt: no Band field, so take a Freq like "18.160" and double-convert
-        if q.get("FREQ"):
-            temp2 = get_adif_band(float(q.get("FREQ")))
-            temp3 = get_not1mm_band(temp2.lower())
-            temp4 = get_not1mm_band_xlog(q.get("FREQ"))
-        else:
-            temp3 = 0.0
-            temp4 = 0.0
-        if temp != 0.0:
-            this_contact["Band"] = temp
-        elif temp3 != 0.0:
-            this_contact["Band"] = temp3
-        elif temp4 != 0.0:
-            this_contact["Band"] = temp4
-        else:
-            # Well, we tried.
-            this_contact["Band"] = 0.0
 
         if q.get("WPXPREFIX"):
             this_contact["WPXPrefix"] = q.get("WPXPREFIX")

--- a/not1mm/lib/preferences.py
+++ b/not1mm/lib/preferences.py
@@ -30,7 +30,7 @@ class Preferences:
         "command_buttons": False,
         "cw_macros": True,
         "bands_modes": True,
-        "bands": ["160", "80", "40", "20", "15", "10"],
+        "bands": ["160m", "80m", "40m", "20m", "15m", "10m"],
         "current_database": "ham.db",
         "contest": "",
         "multicast_group": "239.1.1.1",

--- a/not1mm/lib/settings.py
+++ b/not1mm/lib/settings.py
@@ -213,21 +213,21 @@ class Settings(QtWidgets.QDialog):
         if index != -1:
             self.cluster_mode.setCurrentIndex(index)
 
-        self.activate_160m.setChecked(bool("160" in self.preference.get("bands", [])))
-        self.activate_80m.setChecked(bool("80" in self.preference.get("bands", [])))
-        self.activate_60m.setChecked(bool("60" in self.preference.get("bands", [])))
-        self.activate_40m.setChecked(bool("40" in self.preference.get("bands", [])))
-        self.activate_30m.setChecked(bool("30" in self.preference.get("bands", [])))
-        self.activate_20m.setChecked(bool("20" in self.preference.get("bands", [])))
-        self.activate_17m.setChecked(bool("17" in self.preference.get("bands", [])))
-        self.activate_15m.setChecked(bool("15" in self.preference.get("bands", [])))
-        self.activate_12m.setChecked(bool("12" in self.preference.get("bands", [])))
-        self.activate_10m.setChecked(bool("10" in self.preference.get("bands", [])))
-        self.activate_6m.setChecked(bool("6" in self.preference.get("bands", [])))
-        self.activate_4m.setChecked(bool("4" in self.preference.get("bands", [])))
-        self.activate_2m.setChecked(bool("2" in self.preference.get("bands", [])))
+        self.activate_160m.setChecked(bool("160m" in self.preference.get("bands", [])))
+        self.activate_80m.setChecked(bool("80m" in self.preference.get("bands", [])))
+        self.activate_60m.setChecked(bool("60m" in self.preference.get("bands", [])))
+        self.activate_40m.setChecked(bool("40m" in self.preference.get("bands", [])))
+        self.activate_30m.setChecked(bool("30m" in self.preference.get("bands", [])))
+        self.activate_20m.setChecked(bool("20m" in self.preference.get("bands", [])))
+        self.activate_17m.setChecked(bool("17m" in self.preference.get("bands", [])))
+        self.activate_15m.setChecked(bool("15m" in self.preference.get("bands", [])))
+        self.activate_12m.setChecked(bool("12m" in self.preference.get("bands", [])))
+        self.activate_10m.setChecked(bool("10m" in self.preference.get("bands", [])))
+        self.activate_6m.setChecked(bool("6m" in self.preference.get("bands", [])))
+        self.activate_4m.setChecked(bool("4m" in self.preference.get("bands", [])))
+        self.activate_2m.setChecked(bool("2m" in self.preference.get("bands", [])))
         self.activate_1dot25.setChecked(
-            bool("1.25" in self.preference.get("bands", []))
+            bool("1.25m" in self.preference.get("bands", []))
         )
         self.activate_70cm.setChecked(bool("70cm" in self.preference.get("bands", [])))
         self.activate_33cm.setChecked(bool("33cm" in self.preference.get("bands", [])))
@@ -382,33 +382,33 @@ class Settings(QtWidgets.QDialog):
         self.preference["cluster_mode"] = self.cluster_mode.currentText()
         bandlist = []
         if self.activate_160m.isChecked():
-            bandlist.append("160")
+            bandlist.append("160m")
         if self.activate_80m.isChecked():
-            bandlist.append("80")
+            bandlist.append("80m")
         if self.activate_60m.isChecked():
-            bandlist.append("60")
+            bandlist.append("60m")
         if self.activate_40m.isChecked():
-            bandlist.append("40")
+            bandlist.append("40m")
         if self.activate_30m.isChecked():
-            bandlist.append("30")
+            bandlist.append("30m")
         if self.activate_20m.isChecked():
-            bandlist.append("20")
+            bandlist.append("20m")
         if self.activate_17m.isChecked():
-            bandlist.append("17")
+            bandlist.append("17m")
         if self.activate_15m.isChecked():
-            bandlist.append("15")
+            bandlist.append("15m")
         if self.activate_12m.isChecked():
-            bandlist.append("12")
+            bandlist.append("12m")
         if self.activate_10m.isChecked():
-            bandlist.append("10")
+            bandlist.append("10m")
         if self.activate_6m.isChecked():
-            bandlist.append("6")
+            bandlist.append("6m")
         if self.activate_4m.isChecked():
-            bandlist.append("4")
+            bandlist.append("4m")
         if self.activate_2m.isChecked():
-            bandlist.append("2")
+            bandlist.append("2m")
         if self.activate_1dot25.isChecked():
-            bandlist.append("1.25")
+            bandlist.append("1.25m")
         if self.activate_70cm.isChecked():
             bandlist.append("70cm")
         if self.activate_33cm.isChecked():

--- a/not1mm/testing/simulant.py
+++ b/not1mm/testing/simulant.py
@@ -14,6 +14,8 @@ import argparse
 from random import randint
 from json import dumps, loads, JSONDecodeError
 
+from not1mm.lib.ham_utility import fakefreq
+
 parser = argparse.ArgumentParser(description="Simulate a Field Day participant.")
 parser.add_argument("-c", "--call", type=str, help="Your Callsign")
 parser.add_argument("-b", "--band", type=str, help="Your Band")
@@ -177,34 +179,6 @@ def generate_section(call):
     return sections[random.randint(0, len(sections) - 1)]
 
 
-def fakefreq(band, mode):
-    """
-    If unable to obtain a frequency from the rig,
-    This will return a sane value for a frequency mainly for the cabrillo and adif log.
-    Takes a band and mode as input and returns freq in khz.
-    """
-    _modes = {"CW": 0, "DI": 1, "PH": 2, "FT8": 1, "SSB": 2}
-    fakefreqs = {
-        "160": ["1830", "1805", "1840"],
-        "80": ["3530", "3559", "3970"],
-        "60": ["5332", "5373", "5405"],
-        "40": ["7030", "7040", "7250"],
-        "30": ["10130", "10130", "0000"],
-        "20": ["14030", "14070", "14250"],
-        "17": ["18080", "18100", "18150"],
-        "15": ["21065", "21070", "21200"],
-        "12": ["24911", "24920", "24970"],
-        "10": ["28065", "28070", "28400"],
-        "6": ["50.030", "50300", "50125"],
-        "2": ["144030", "144144", "144250"],
-        "222": ["222100", "222070", "222100"],
-        "432": ["432070", "432200", "432100"],
-        "SAT": ["144144", "144144", "144144"],
-    }
-    freqtoreturn = fakefreqs[band][_modes[mode]]
-    return freqtoreturn
-
-
 def log_contact():
     """Send a contgact to the server."""
     unique_id = uuid.uuid4().hex
@@ -216,7 +190,7 @@ def log_contact():
         "section": generate_section(callsign),
         "mode": MODE,
         "band": BAND,
-        "frequency": int(float(fakefreq(BAND, MODE)) * 1000),
+        "frequency": int(float(fakefreq(f"{BAND}m", MODE)) * 1000),
         "date_and_time": datetime.datetime.now(datetime.timezone.utc).strftime(
             "%Y-%m-%d %H:%M:%S"
         ),


### PR DESCRIPTION
All band references are now either a MHz float value (1.8) suitable for
    the DXLOG.band column or the standard ADIF band name ("160m"). Plain
    band names like "160" are not used anymore.

Replace the independent functions in ham_utility.py (getband,
    get_logged_band, get_adif_band, get_not1mm_band, fakefreq) with one
    BANDS table of BandDef rows plus thin wrappers. Each row carries start,
    end, name, band_mhz, cw_khz, digi_khz, ssb_khz; two dicts
    (_BY_BAND_NAME, _BY_BAND_MHZ) back the name- and value-keyed lookups.
    get_not1mm_band_xlog is dropped in favor of using get_not1mm_band.

The bandmap window is updated to use the same list.