### PR TITLE
Fix formatting of the code of conduct header

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,1 @@
-#Don't be bad.
+# Don't be bad.


### PR DESCRIPTION
Was supposed to be an h1 header but the writer didn't put a space after the #