### PR TITLE
@mbridak Fix: Update datetime parsing to handle timezone information …

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -1041,7 +1041,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if self.pref.get("useserver", False) is True:
             for index, item in enumerate(self.server_commands):
                 expired = datetime.datetime.strptime(
-                    item.get("expire"), "%Y-%m-%dT%H:%M:%S.%f"
+                    item.get("expire"), "%Y-%m-%dT%H:%M:%S.%f%z"
                 ).astimezone(datetime.UTC)
                 if datetime.datetime.now(tz=datetime.UTC) > expired:
                     newexpire = datetime.datetime.now(


### PR DESCRIPTION
…in server command expiration

In short earlier in history a linter was complaining about a datetime object being naive.
So I fixed it.
And broke other things...
