### PR TITLE
Cabrillo file formatting in cwo.py

### DIFF
--- a/not1mm/plugins/cwo.py
+++ b/not1mm/plugins/cwo.py
@@ -398,8 +398,8 @@ def cabrillo(self, file_encoding):
                     f"{str(contact.get('SentNr', '')).ljust(6)} "
                     f"{str(self.station.get('Name', '')).partition(' ')[0]} "
                     f"{contact.get('Call', '').ljust(13)} "
-                    f"{str(contact.get('Name', '')).ljust(10)} "  # Name from DB
-                    f"{str(contact.get('NR', '')).ljust(6)}",  # Received number
+                    f"{str(contact.get('NR', '')).ljust(6)}"  # Received number
+                    f"{str(contact.get('Name', '')).ljust(10)} ",  # Name from DB
                     "\r\n",
                     file_descriptor,
                     file_encoding,


### PR DESCRIPTION
Cabrillo logs from the CW Open must be uploaded to contesting.com. The existing cwo.py plugin places Name followed by Serial number. The bot, however, requires the sequence of SN + Name for each QSO and rejects the .log file generated by not1mm due to incorrect formatting. This is easily fixed by switching the order of two lines in the CWO plugin.

Of peripheral interest: Folks on the CWops reflector have been complaining about N1MM lacking a spotting capability for this contest. The N1MM gatekeepers will not implement the desired changes without a formal request from the contest organizers. It evidently did not happen in time. This illustrates another risk of using closed-source software.  
