### PR TITLE
Send an N1MM-style score packet over UDP

### DIFF
--- a/not1mm.tex
+++ b/not1mm.tex
@@ -379,7 +379,7 @@ Detailed information can be found at \url{http://www.nc7j.com/arcluster/aruserma
 
 \subsection{N1MM Packets}
 
-Work has started on N1MM\index{N1MM} UDP\index{UDP} packets. So far just RadioInfo, contactinfo, contactreplace and contactdelete.
+Work has started on N1MM\index{N1MM} UDP\index{UDP} packets. So far RadioInfo, contactinfo, contactreplace, contactdelete and score (a \texttt{dynamicresults} packet, the same score XML the RTC/online-score poster uses, sent after every QSO and once a minute).
 
 \vspace{0.5cm}
 \includegraphics[width=0.9\linewidth]{pic/n1mm_packet_config.png}

--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -182,6 +182,7 @@ class MainWindow(QtWidgets.QMainWindow):
     settings = None
     lookup_service = None
     fldigi_util = None
+    n1mm = None
     rtc_service = None
     rtc_interval = 2
     rtc_user = ""
@@ -299,6 +300,12 @@ class MainWindow(QtWidgets.QMainWindow):
         self.server_message_watch_timer = QtCore.QTimer()
         self.server_message_watch_timer.timeout.connect(self.check_udp_queue)
         self.server_message_watch_timer.start(1000)
+        # Re-send the contest score to the RTC poster / N1MM score port on a
+        # slow cadence, so it keeps updating during a lull and a scoreboard
+        # that restarts mid-contest re-syncs without waiting for the next QSO.
+        self.score_report_timer = QtCore.QTimer()
+        self.score_report_timer.timeout.connect(self.update_rtc_xml)
+        self.score_report_timer.start(60000)
         self.inputs_dict = {
             self.callsign: "callsign",
             self.sent: "sent",
@@ -3246,15 +3253,28 @@ class MainWindow(QtWidgets.QMainWindow):
             self.rate_window.msg_from_main(cmd)
 
     def update_rtc_xml(self) -> None:
-        """Update RTC XML"""
-        if self.pref.get("send_rtc_scores", False):
-            if self.contest is None:
-                return
-            if (
-                hasattr(self.contest, "online_score_xml")
-                and self.rtc_service is not None
-            ):
-                self.rtc_service.xml = self.contest.online_score_xml(self)
+        """Refresh the contest score XML and hand it to any enabled reporter.
+
+        Feeds the RTC (real-time contest) HTTP poster and, when "Send N1MM
+        score packets" is enabled, an N1MM-style <dynamicresults> UDP datagram
+        to the configured score port. Called after every logged QSO and on a
+        slow timer so the score keeps flowing during a lull.
+        """
+        if self.contest is None or not hasattr(self.contest, "online_score_xml"):
+            return
+
+        want_rtc = (
+            self.pref.get("send_rtc_scores", False) and self.rtc_service is not None
+        )
+        want_udp = self.n1mm is not None and self.n1mm.send_score_packets
+        if not (want_rtc or want_udp):
+            return
+
+        score_xml = self.contest.online_score_xml(self)
+        if want_rtc:
+            self.rtc_service.xml = score_xml
+        if want_udp:
+            self.n1mm.send_score(score_xml)
 
     def new_contest_dialog(self) -> None:
         """
@@ -3931,7 +3951,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     self.pref.get("n1mm_radioport", "127.0.0.1:12060"),
                     self.pref.get("n1mm_contactport", "127.0.0.1:12061"),
                     self.pref.get("n1mm_lookupport", "127.0.0.1:12060"),
-                    self.pref.get("n1mm_scoreport", "127.0.0.1:12060"),
+                    self.pref.get("n1mm_scoreport", "127.0.0.1:12062"),
                 )
             except ValueError:
                 logger.warning("%s", f"{ValueError}")

--- a/not1mm/data/not1mm.html
+++ b/not1mm/data/not1mm.html
@@ -305,7 +305,7 @@ While I&#39;m not watching TV, Right vs Left political &#39;News&#39; programs, 
 
 <h4 id="toc_1.16.6">N1MM Packets</h4>
 
-<p>Work has started on N1MM udp packets. So far just RadioInfo, contactinfo, contactreplace and contactdelete.</p>
+<p>Work has started on N1MM udp packets. So far RadioInfo, contactinfo, contactreplace, contactdelete and score (a <code>dynamicresults</code> packet, the same score XML the RTC/online-score poster uses, sent after every QSO and once a minute).</p>
 
 <p>When entering IP and Ports, enter them with a colon &#39;:&#39; between them. You can enter multiple pairs on the same line if separated by a space &#39; &#39;.</p>
 

--- a/not1mm/lib/n1mm.py
+++ b/not1mm/lib/n1mm.py
@@ -102,21 +102,6 @@ class N1MM:
         "ID": "",
     }
 
-    score_report = {  # noqa: RUF012
-        "app": "NOT1MM",
-        "contest": "",
-        "call": "",
-        "class": {
-            "ops": "SINGLE-OP",
-            "mode": "MIXED",
-            "power": "LOW",
-            "bands": "ALL",
-            "transmitter": "ONE",
-        },
-        "score": 0,
-        "timestamp": "",
-    }
-
     def __init__(
         self,
         radioport="127.0.0.1:12060",
@@ -174,13 +159,44 @@ class N1MM:
         """Send lookup request"""
         self._send(self.lookup_port, self.contact_info, "lookupinfo")
 
-    def send_score(self):
-        """Send score"""
-        self._send(self.score_port, self.score_report, "scoreinfo")
+    def send_score(self, score_xml):
+        """Send a contest score report.
 
-    def send_realtime_score(self):
-        """Send score"""
-        self._send(self.score_port, self.score_report, "dynamicresults")
+        Unlike the other senders the payload is already-serialized XML - the
+        active contest plugin's online_score_xml() builds the <dynamicresults>
+        document - so it goes out verbatim rather than through dicttoxml().
+        """
+        self._send_raw(self.score_port, score_xml)
+
+    def _send_raw(self, port_list, payload):
+        """UDP-send an already-serialized payload to every ip:port in a
+        space-separated list."""
+        bytes_to_send = payload.encode() if isinstance(payload, str) else payload
+        logger.debug("********* %s", f"score {port_list}")
+        for connection in port_list.split():
+            try:
+                ip_address, port = connection.split(":")
+                port = int(port)
+            except ValueError as returned_error:
+                logger.debug(
+                    "%s", f"Bad IP:Port combination {connection} {returned_error}"
+                )
+                continue
+            try:
+                score_socket = socket.socket(
+                    family=socket.AF_INET, type=socket.SOCK_DGRAM
+                )
+                logger.debug(
+                    "********* %s", f"{ip_address} {int(port)} {bytes_to_send}"
+                )
+                score_socket.sendto(
+                    bytes_to_send,
+                    (ip_address, int(port)),
+                )
+            except PermissionError as exception:
+                logger.critical("%s", f"{exception}")
+            except socket.gaierror as exception:
+                logger.critical("%s", f"{exception}")
 
     def _send(self, port_list, payload, package_name):
         """Send XML data"""

--- a/not1mm/lib/preferences.py
+++ b/not1mm/lib/preferences.py
@@ -47,7 +47,7 @@ class Preferences:
         "n1mm_radioport": "127.0.0.1:12060",
         "n1mm_contactport": "127.0.0.1:12060",
         "n1mm_lookupport": "127.0.0.1:12060",
-        "n1mm_scoreport": "127.0.0.1:12060",
+        "n1mm_scoreport": "127.0.0.1:12062",
         "usehamdb": False,
         "usehamqth": False,
         "cloudlog": False,

--- a/not1mm/logwindow.py
+++ b/not1mm/logwindow.py
@@ -239,7 +239,7 @@ class LogWindow(QDockWidget):
                 self.pref.get("n1mm_radioport", "127.0.0.1:12060"),
                 self.pref.get("n1mm_contactport", "127.0.0.1:12061"),
                 self.pref.get("n1mm_lookupport", "127.0.0.1:12060"),
-                self.pref.get("n1mm_scoreport", "127.0.0.1:12060"),
+                self.pref.get("n1mm_scoreport", "127.0.0.1:12062"),
             )
         except ValueError:
             logger.warning("%s", f"{ValueError}")

--- a/test/n1mm_tests.py
+++ b/test/n1mm_tests.py
@@ -1,0 +1,56 @@
+"""Tests for not1mm.lib.n1mm.N1MM score sending."""
+
+import socket
+
+from not1mm.lib.n1mm import N1MM
+
+SCORE_XML = (
+    '<?xml version="1.0"?><dynamicresults><contest>CQ-WPX-CW</contest>'
+    "<call>WT2P</call><score>12345</score>"
+    '<breakdown><qso band="total" mode="ALL">42</qso>'
+    '<point band="total" mode="ALL">120</point></breakdown></dynamicresults>'
+)
+
+
+def _bound_udp_socket():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.settimeout(1.0)
+    return sock, sock.getsockname()[1]
+
+
+def test_send_score_transmits_xml_verbatim():
+    sock, port = _bound_udp_socket()
+    try:
+        n1mm = N1MM(scoreport=f"127.0.0.1:{port}")
+        n1mm.send_score(SCORE_XML)
+        received = sock.recv(65535)
+    finally:
+        sock.close()
+    assert received.decode() == SCORE_XML
+
+
+def test_send_score_accepts_bytes():
+    sock, port = _bound_udp_socket()
+    try:
+        n1mm = N1MM(scoreport=f"127.0.0.1:{port}")
+        n1mm.send_score(SCORE_XML.encode())
+        received = sock.recv(65535)
+    finally:
+        sock.close()
+    assert received.decode() == SCORE_XML
+
+
+def test_send_score_fans_out_and_skips_malformed_targets():
+    sock_a, port_a = _bound_udp_socket()
+    sock_b, port_b = _bound_udp_socket()
+    try:
+        n1mm = N1MM(
+            scoreport=f"127.0.0.1:{port_a} not-a-valid-target 127.0.0.1:{port_b}"
+        )
+        n1mm.send_score(SCORE_XML)
+        assert sock_a.recv(65535).decode() == SCORE_XML
+        assert sock_b.recv(65535).decode() == SCORE_XML
+    finally:
+        sock_a.close()
+        sock_b.close()


### PR DESCRIPTION

## What

`send_n1mm_score` in the N1MM Packets settings currently has no effect:
`N1MM.send_score()` / `send_realtime_score()` were never called from
anywhere, and the `score_report` dict they serialised carried no
`<breakdown>`, so a nodered / scoreboard collector listening on the score
port never received a usable score.

This wires it up by reusing the score XML the RTC poster already builds.

## How

The active contest plugin's `online_score_xml()` already produces a complete
`<dynamicresults>` document (class attrs, qth, a `band="total" mode="ALL"`
qso/point breakdown, `<score>`, `<timestamp>`). `update_rtc_xml()` now builds
that XML once and hands it to whichever reporters are enabled: the RTC HTTP
poster and/or an N1MM-style UDP datagram to `n1mm_scoreport`.

- **`lib/n1mm.py`** — `send_score(score_xml)` now takes the pre-rendered XML
  and sends it verbatim via a new `_send_raw()` helper (same `ip:port`
  fan-out and error handling as `_send`). Dropped the dead `score_report`
  dict and `send_realtime_score()`.
- **`__main__.py`** — `update_rtc_xml()` feeds RTC and/or UDP; a 60 s
  `QTimer` re-sends so the score keeps updating during a lull and a
  collector that restarts mid-contest re-syncs without waiting for the next
  QSO. Added `n1mm = None` to the class attrs.
- **`lib/preferences.py`, `logwindow.py`** — default `n1mm_scoreport` to
  `127.0.0.1:12062` (was `:12060`, the radio port).
- **`test/n1mm_tests.py`** — new; covers the sender (verbatim XML, bytes
  input, multi-target fan-out, skipping malformed targets).
- **Docs** (`not1mm.html`, `not1mm.tex`) — note score is now among the
  implemented N1MM packets.

## Testing

- `black not1mm test` — clean
- `pytest test/` — 389 passed (incl. 3 new). Two pre-existing failures on a
  clean `master` checkout (`cat_tci_tests.py::test_sendcw_sends_text`,
  `plugin_euhfc_tests.py::test_module_metadata`) are unrelated to this
  change.
- Verified end to end against a live CWT contest: the packet reaches a UDP
  collector on `:12062` on contest load, after each logged QSO, and on the
  60 s timer, and parses as a normal `dynamicresults` score.

## Note

`send_score()` changes signature (was no-arg, sending the static
`score_report` dict). It had no callers in the tree, so nothing else breaks.