### PR TITLE
contactinfo: fix the key so CQ zone actually reaches the packet

### DIFF
--- a/not1mm/__main__.py
+++ b/not1mm/__main__.py
@@ -3205,7 +3205,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.n1mm.contact_info["section"] = self.contact["Sect"]
                 self.n1mm.contact_info["prec"] = self.contact["Prec"]
                 self.n1mm.contact_info["ck"] = self.contact["CK"]
-                self.n1mm.contact_info["zn"] = self.contact["ZN"]
+                self.n1mm.contact_info["zone"] = self.contact["ZN"]
                 self.n1mm.contact_info["power"] = self.contact["Power"]
                 self.n1mm.contact_info["band"] = self.contact["Band"]
                 logger.debug("%s", f"{self.n1mm.contact_info}")


### PR DESCRIPTION
## What

`send_contact_info()`'s ADD path sets `contact_info["zn"]` — not a key
`contact_info` (in `lib/n1mm.py`) actually has, so `dicttoxml` just
serializes it as a second, unused `<zn>` element nobody downstream reads.
The real `"zone"` key that becomes the packet's `<zone>` element is never
touched by the ADD path, so it stays frozen at its class-level default
(`"5"`) for every single QSO logged this way — regardless of who was
actually worked.

`logwindow.py`'s two `send_contactreplace()` call sites already have this
right (`contact_info["zone"] = db_record["ZN"]`); the ADD path just used
the wrong key name.

## Fix

One character: `"zn"` → `"zone"`.

```diff
-                self.n1mm.contact_info["zn"] = self.contact["ZN"]
+                self.n1mm.contact_info["zone"] = self.contact["ZN"]
```

## Impact

Any downstream consumer that groups QSOs by the worked station's CQ zone
saw every single QSO as zone 5, no matter how far-flung the actual DX —
e.g. working stations in Japan, Russia, Australia and Zimbabwe in one
session all showed up under the same zone. Same bug class as #686
(continent/countryprefix never reaching the ADD-path packet either), just
a plain typo this time instead of a missing assignment.

## Testing

- `black --check not1mm/__main__.py` — clean
- `pytest test/` — 386 passed. Two pre-existing failures on a clean
  `master` checkout (`cat_tci_tests.py::test_sendcw_sends_text`,
  `plugin_euhfc_tests.py::test_module_metadata`) are unrelated.

Independent of #685 and #686 — this one's just the zone-key typo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKgMeTqe5zjcJeNmbLZ4FG